### PR TITLE
Update Docker build config

### DIFF
--- a/.github/workflows/docker_image_build.yml
+++ b/.github/workflows/docker_image_build.yml
@@ -10,18 +10,18 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Build the CUDA Docker image
-      run: docker build . --file Dockerfile-CUDA --tag flml/flashlight:cuda-latest
+      run: docker build . --file Dockerfile-CUDA --tag flml/flashlight:cuda-consolidation-latest
     - name: Docker login
       env:
           USER: ${{ secrets.DOCKER_USERNAME }}
           PASSWORD: ${{ secrets.DOCKER_PASSWORD }}  
       run: docker login -u=$USER -p=$PASSWORD
     - name: Push image with the latest tag
-      run: docker push flml/flashlight:cuda-latest
+      run: docker push flml/flashlight:cuda-consolidation-latest
     - name: Tag revision
-      run: docker tag flml/flashlight:cuda-latest flml/flashlight:cuda-`git rev-parse --short HEAD`
+      run: docker tag flml/flashlight:cuda-consolidation-latest flml/flashlight:cuda-consolidation-`git rev-parse --short HEAD`
     - name: Push image with the revision tag
-      run: docker push flml/flashlight:cuda-`git rev-parse --short HEAD` 
+      run: docker push flml/flashlight:cuda-consolidation-`git rev-parse --short HEAD` 
     - name: Docker logout
       run: docker logout
   cpu_image_build:
@@ -30,17 +30,17 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Build the CPU Docker image
-      run: docker build . --file Dockerfile-CPU --tag flml/flashlight:cpu-latest
+      run: docker build . --file Dockerfile-CPU --tag flml/flashlight:cpu-consolidation-latest
     - name: Docker login
       env:
           USER: ${{ secrets.DOCKER_USERNAME }}
           PASSWORD: ${{ secrets.DOCKER_PASSWORD }}  
       run: docker login -u=$USER -p=$PASSWORD
     - name: Push image with the latest tag
-      run: docker push flml/flashlight:cpu-latest
+      run: docker push flml/flashlight:cpu-consolidation-latest
     - name: Tag revision
-      run: docker tag flml/flashlight:cpu-latest flml/flashlight:cpu-`git rev-parse --short HEAD`
+      run: docker tag flml/flashlight:cpu-consolidation-latest flml/flashlight:cpu-consolidation-`git rev-parse --short HEAD`
     - name: Push image with the revision tag
-      run: docker push flml/flashlight:cpu-`git rev-parse --short HEAD` 
+      run: docker push flml/flashlight:cpu-consolidation-`git rev-parse --short HEAD` 
     - name: Docker logout
       run: docker logout


### PR DESCRIPTION
Summary:
Fix Docker build config -- was reverted in https://github.com/facebookresearch/flashlight/commit/73a4c821feb8f15f1f49a20821390caeac70860a as a stopgap to make sure repo states are consistent so that we could re-enable ShipIt.

This will inaugural run of the new ShipIt setup with the new repo layout.

Reviewed By: padentomasello

Differential Revision: D23277322

