### PR TITLE
Supporting AMP training in ResNet example

### DIFF
--- a/flashlight/app/imgclass/examples/ImageNetResnet34.cpp
+++ b/flashlight/app/imgclass/examples/ImageNetResnet34.cpp
@@ -11,6 +11,7 @@
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 
+#include "flashlight/app/common/Runtime.h"
 #include "flashlight/app/imgclass/dataset/Imagenet.h"
 #include "flashlight/app/imgclass/examples/Defines.h"
 #include "flashlight/ext/common/DistributedUtils.h"
@@ -20,6 +21,7 @@
 #include "flashlight/fl/dataset/datasets.h"
 #include "flashlight/fl/meter/meters.h"
 #include "flashlight/fl/optim/optim.h"
+#include "flashlight/lib/common/String.h"
 #include "flashlight/lib/common/System.h"
 
 DEFINE_string(data_dir, "", "Directory of imagenet data");
@@ -49,6 +51,32 @@ DEFINE_string(
 DEFINE_uint64(data_batch_size, 256, "Total batch size across all gpus");
 DEFINE_string(exp_checkpoint_path, "/tmp/model", "Checkpointing prefix path");
 DEFINE_int64(exp_checkpoint_epoch, -1, "Checkpoint epoch to load from");
+
+DEFINE_bool(
+    fl_amp_use_mixed_precision,
+    false,
+    "[train] Use mixed precision for training - scale loss and gradients up and down "
+    "by a scale factor that changes over time. If no fl optim mode is "
+    "specified with --fl_optim_mode when passing this flag, automatically "
+    "sets the optim mode to O1.");
+DEFINE_double(
+    fl_amp_scale_factor,
+    65536.,
+    "[train] Starting scale factor to use for loss scaling "
+    " with mixed precision training");
+DEFINE_uint64(
+    fl_amp_scale_factor_update_interval,
+    2000,
+    "[train] Update interval for adjusting loss scaling in mixed precision training");
+DEFINE_double(
+    fl_amp_max_scale_factor,
+    65536.,
+    "[train] Maximum value for the loss scale factor in mixed precision training");
+DEFINE_string(
+    fl_optim_mode,
+    "",
+    "[train] Sets the flashlight optimization mode. "
+    "Optim modes can be O1, O2, or O3.");
 
 using namespace fl;
 using fl::ext::image::compose;
@@ -119,9 +147,25 @@ int main(int argc, char** argv) {
 
   af::setDevice(worldRank);
   af::setSeed(worldSize);
+  fl::DynamicBenchmark::setBenchmarkMode(true);
 
   auto reducer =
       std::make_shared<fl::CoalescingReducer>(1.0 / worldSize, true, true);
+
+  if (FLAGS_fl_amp_use_mixed_precision) {
+    // Only set the optim mode to O1 if it was left empty
+    LOG(INFO) << "Mixed precision training enabled. Will perform loss scaling.";
+    auto flOptimLevel = FLAGS_fl_optim_mode.empty()
+        ? fl::OptimLevel::DEFAULT
+        : fl::OptimMode::toOptimLevel(FLAGS_fl_optim_mode);
+    fl::OptimMode::get().setOptimLevel(flOptimLevel);
+  }
+  unsigned short scaleCounter = 1;
+  double scaleFactor =
+      FLAGS_fl_amp_use_mixed_precision ? FLAGS_fl_amp_scale_factor : 1.;
+  unsigned int kScaleFactorUpdateInterval =
+      FLAGS_fl_amp_scale_factor_update_interval;
+  double kMaxScaleFactor = FLAGS_fl_amp_max_scale_factor;
 
   //////////////////////////
   //  Create datasets
@@ -217,43 +261,121 @@ int main(int argc, char** argv) {
   }
 
   // The main training loop
-  TimeMeter timeMeter;
   TopKMeter top5Acc(5);
   TopKMeter top1Acc(1);
   AverageValueMeter trainLossMeter;
+
+  fl::TimeMeter sampleTimerMeter{true};
+  fl::TimeMeter fwdTimeMeter{true};
+  fl::TimeMeter critFwdTimeMeter{true};
+  fl::TimeMeter bwdTimeMeter{true};
+  fl::TimeMeter optimTimeMeter{true};
+  fl::TimeMeter timeMeter{true};
+
   for (int epoch = (FLAGS_exp_checkpoint_epoch + 1); epoch < FLAGS_train_epochs;
        epoch++) {
     trainDataset.resample(epoch);
     lrScheduler(epoch);
 
     // Get an iterator over the data
-    timeMeter.resume();
     int idx = 0;
     for (auto& example : trainDataset) {
+      timeMeter.resume();
       opt.zeroGrad();
-      // Make a Variable from the input array.
+
+      // Make Variables from the input arrays.
+      sampleTimerMeter.resume();
       auto inputs = noGrad(example[kImagenetInputIdx]);
+      if (FLAGS_fl_amp_use_mixed_precision && FLAGS_fl_optim_mode.empty()) {
+        // In case AMP is activated with DEFAULT mode,
+        // we manually cast input to fp16.
+        inputs = inputs.as(f16);
+      }
+      auto target = noGrad(example[kImagenetTargetIdx]);
+      af::sync();
+      sampleTimerMeter.stopAndIncUnit();
 
       // Get the activations from the model.
+      fwdTimeMeter.resume();
       auto output = model->forward(inputs);
-
-      // Make a Variable from the target array.
-      auto target = noGrad(example[kImagenetTargetIdx]);
+      af::sync();
+      fwdTimeMeter.stopAndIncUnit();
 
       // Compute and record the loss.
+      critFwdTimeMeter.resume();
       auto loss = criterion(output, target);
+      af::sync();
+      critFwdTimeMeter.stopAndIncUnit();
+
+      if (FLAGS_fl_amp_use_mixed_precision) {
+        ++scaleCounter;
+        loss = loss * scaleFactor;
+
+        auto scaledLoss = loss.array() / worldSize;
+        if (FLAGS_distributed_enable) {
+          fl::allReduce(scaledLoss);
+        }
+        if (fl::app::isInvalidArray(scaledLoss)) {
+          FL_LOG(INFO) << "Loss has NaN values in 2, in proc: "
+                       << fl::getWorldRank();
+          scaleFactor = scaleFactor / 2.0f;
+          FL_LOG(INFO) << "AMP: Scale factor decreased (loss). New value :\t "
+                       << scaleFactor;
+          continue;
+        }
+      }
 
       trainLossMeter.add(loss.array());
       top5Acc.add(output.array(), target.array());
       top1Acc.add(output.array(), target.array());
 
       // Backprop, update the weights and then zero the gradients.
+      bwdTimeMeter.resume();
       loss.backward();
 
       if (FLAGS_distributed_enable) {
         reducer->finalize();
       }
+      af::sync();
+      bwdTimeMeter.stopAndIncUnit();
+
+      optimTimeMeter.resume();
+      auto retrySample = false;
+      if (FLAGS_fl_amp_use_mixed_precision) {
+        for (auto& p : model->params()) {
+          p.grad() = p.grad() / scaleFactor;
+          if (fl::app::isInvalidArray(p.grad().array())) {
+            FL_LOG(INFO) << "Grad has NaN values in 3, in proc: "
+                         << fl::getWorldRank();
+            if (scaleFactor >= fl::kAmpMinimumScaleFactorValue) {
+              scaleFactor = scaleFactor / 2.0f;
+              FL_LOG(INFO) << "AMP: Scale factor decreased (grad). New value:\t"
+                           << scaleFactor;
+              retrySample = true;
+            } else {
+              FL_LOG(FATAL)
+                  << "Minimum loss scale reached: "
+                  << fl::kAmpMinimumScaleFactorValue
+                  << " with over/underflowing gradients. Lowering the "
+                  << "learning rate, using gradient clipping, or "
+                  << "increasing the batch size can help resolve "
+                  << "loss explosion.";
+            }
+            scaleCounter = 1;
+            break;
+          }
+        }
+      }
+      if (retrySample) {
+        timeMeter.stopAndIncUnit();
+        optimTimeMeter.stopAndIncUnit();
+        continue;
+      }
+
       opt.step();
+      af::sync();
+      optimTimeMeter.stopAndIncUnit();
+      timeMeter.stopAndIncUnit();
 
       // Compute and record the prediction error.
       double trainLoss = trainLossMeter.value()[0];
@@ -263,16 +385,45 @@ int main(int argc, char** argv) {
         fl::ext::syncMeter(top5Acc);
         fl::ext::syncMeter(top1Acc);
         double time = timeMeter.value();
-        double samplePerSecond = (idx * FLAGS_data_batch_size) / time;
+        double samplePerSecond = FLAGS_data_batch_size * worldSize / time;
         FL_LOG_MASTER(INFO)
             << "Epoch " << epoch << std::setprecision(5) << " Batch: " << idx
             << " Samples per second " << samplePerSecond
+            << " : Total Time(ms): " << fl::lib::format("%.2f", time * 1000)
+            << " : Sample Time(ms): "
+            << fl::lib::format("%.2f", sampleTimerMeter.value() * 1000)
+            << " : Forward Time(ms): "
+            << fl::lib::format("%.2f", fwdTimeMeter.value() * 1000)
+            << " : Criterion Forward Time(ms): "
+            << fl::lib::format("%.2f", critFwdTimeMeter.value() * 1000)
+            << " : Backward Time(ms): "
+            << fl::lib::format("%.2f", bwdTimeMeter.value() * 1000)
+            << " : Optim Time(ms): "
+            << fl::lib::format("%.2f", optimTimeMeter.value() * 1000)
             << ": Avg Train Loss: " << trainLoss
             << ": Train Top5 Accuracy( %): " << top5Acc.value()
             << ": Train Top1 Accuracy( %): " << top1Acc.value();
         top5Acc.reset();
         top1Acc.reset();
         trainLossMeter.reset();
+        timeMeter.reset();
+        sampleTimerMeter.reset();
+        fwdTimeMeter.reset();
+        critFwdTimeMeter.reset();
+        bwdTimeMeter.reset();
+        optimTimeMeter.reset();
+      }
+
+      if (FLAGS_fl_amp_use_mixed_precision && scaleFactor < kMaxScaleFactor) {
+        if (scaleCounter % kScaleFactorUpdateInterval == 0) {
+          scaleFactor *= 2;
+          FL_VLOG(2) << "AMP: Scale factor doubled. New value:\t"
+                     << scaleFactor;
+        } else {
+          scaleFactor += 2;
+          FL_VLOG(3) << "AMP: Scale factor incremented. New value\t"
+                     << scaleFactor;
+        }
       }
     }
     timeMeter.reset();

--- a/flashlight/ext/image/fl/models/ViT.cpp
+++ b/flashlight/ext/image/fl/models/ViT.cpp
@@ -62,19 +62,8 @@ ViT::ViT(
 
 std::vector<fl::Variable> ViT::forward(
     const std::vector<fl::Variable>& inputs) {
-  return forward(inputs, false);
-}
-
-std::vector<fl::Variable> ViT::forward(
-    const std::vector<fl::Variable>& inputs,
-    bool useFp16) {
   // Patching
   auto output = patchEmbedding_->forward(inputs[0]); // H x W x C x B
-  if (useFp16) {
-    // Avoid running conv2D in fp16 in this case.
-    // All the other part of the network can be run in fp16 if compatible.
-    output = output.as(f16);
-  }
   output = moddims(output, af::dim4(-1, 1, 0, 0)); // T x 1 x C x B
   output = reorder(output, 2, 0, 3, 1); // C x T x B
   auto B = output.dims(2);

--- a/flashlight/ext/image/fl/models/ViT.h
+++ b/flashlight/ext/image/fl/models/ViT.h
@@ -61,13 +61,6 @@ class ViT : public fl::Container {
   std::vector<fl::Variable> forward(
       const std::vector<fl::Variable>& inputs) override;
 
-  // TODO: to be removed after
-  //  1. comprehensive benchmarking
-  //  2. AMP config updated accordingly
-  std::vector<fl::Variable> forward(
-      const std::vector<fl::Variable>& inputs,
-      bool useFp16);
-
   std::string prettyString() const override;
 };
 


### PR DESCRIPTION
Summary:
Supporting AMP training in ResNet example. Made sure Conv2D works well in AMP.

It is still optimal to use Default fl_optim_mode + manually casting input.

Differential Revision: D27848909

