### PR TITLE
CI: Use GCC 10 for building the Docker images

### DIFF
--- a/.github/workflows/docker_image_build.yml
+++ b/.github/workflows/docker_image_build.yml
@@ -3,11 +3,16 @@ on:
   push:
     branches:
       - master
+
 jobs:
   cuda_image_build:
     if: github.repository_owner == 'flashlight'
     name: CUDA image build
     runs-on: ubuntu-latest
+    env:
+       CC: gcc-10
+       CXX: g++-10
+
     steps:
     - uses: actions/checkout@master
     - name: Build the CUDA Docker image
@@ -25,10 +30,15 @@ jobs:
       run: docker push flml/flashlight:cuda-`git rev-parse --short HEAD`
     - name: Docker logout
       run: docker logout
+
   cpu_image_build:
     if: github.repository_owner == 'flashlight'
     name: CPU image build
     runs-on: ubuntu-latest
+    env:
+       CC: gcc-10
+       CXX: g++-10
+ 
     steps:
     - uses: actions/checkout@master
     - name: Build the CPU Docker image


### PR DESCRIPTION
Use GCC 10 for building the Docker images instead of the GitHub default GCC 9. GitHub environments are not super stable so also makes sure the major compiler version isn't changed on accident.

Also adds a few white lines for readability.

**Original Issue**: None yet, discussion can take place in this PR since the change is quite small and specific.

**Test Plan (required)**
As far as I understand Circle CI tests the docker images. More tests can be done if needed.