### PR TITLE
Exclude tools/plugin dirs from installed paths to avoid empty dirs

### DIFF
--- a/cmake/InternalUtils.cmake
+++ b/cmake/InternalUtils.cmake
@@ -63,6 +63,8 @@ function(setup_install_headers HEADER_DIR DEST_DIR)
     PATTERN "*.cuh" # TODO: make this conditional, e.g. $<IF:FLASHLIGHT_USE_CUDA,"*.cuh","a^">
     PATTERN "test*" EXCLUDE
     PATTERN "tests" EXCLUDE
+    PATTERN "tools" EXCLUDE
+    PATTERN "plugins" EXCLUDE
     PATTERN "backend" EXCLUDE
     PATTERN "examples" EXCLUDE
     PATTERN "tutorial" EXCLUDE


### PR DESCRIPTION
See title. No `tools` dirs include headers that we care about being in the public API, so don't install headers in them.

We can change this policy down the line/figure out a better way to exclude empty directories from headers later.

Test plan:
CI + local test