### PR TITLE
Fix Detr batchsize 1  - Explicitly reshape target classes

### DIFF
--- a/flashlight/app/objdet/criterion/SetCriterion.cpp
+++ b/flashlight/app/objdet/criterion/SetCriterion.cpp
@@ -256,8 +256,11 @@ SetCriterion::LossDict SetCriterion::lossLabels(
   for (auto idx : indices) {
     auto targetIdxs = idx.first;
     auto srcIdxs = idx.second;
-    auto reordered = targetClasses[i](targetIdxs);
-    target_classes_full(srcIdxs, i) = targetClasses[i].array()(targetIdxs);
+    if (!srcIdxs.isempty()) {
+      af::array t = targetClasses[i].array()(targetIdxs);
+      t =  af::moddims(t, {t.dims(1)});
+      target_classes_full(srcIdxs, i) = t;
+    }
     i += 1;
   }
 

--- a/flashlight/app/objdet/test/criterion/SetCriterionTest.cpp
+++ b/flashlight/app/objdet/test/criterion/SetCriterionTest.cpp
@@ -52,7 +52,7 @@ TEST(SetCriterion, PytorchRepro) {
       af::array(4, NUM_TARGETS, NUM_BATCHES, targetBoxesVec.data()), false)};
 
   std::vector<fl::Variable> targetClasses = {fl::Variable(
-      af::array(NUM_TARGETS, NUM_BATCHES, targetClassVec.data()), false)};
+      af::array(1, NUM_TARGETS, NUM_BATCHES, targetClassVec.data()), false)};
   auto matcher = HungarianMatcher(1, 1, 1);
   auto crit = SetCriterion(80, matcher, getLossWeights(), 0.0);
   auto loss = crit.forward(predBoxes, predLogits, targetBoxes, targetClasses);
@@ -123,7 +123,7 @@ TEST(SetCriterion, PytorchReproMultipleTargets) {
       af::array(4, NUM_TARGETS, NUM_BATCHES, targetBoxesVec.data()), false)};
 
   std::vector<fl::Variable> targetClasses = {fl::Variable(
-      af::array(NUM_TARGETS, NUM_BATCHES, targetClassVec.data()), false)};
+      af::array(1, NUM_TARGETS, NUM_BATCHES, targetClassVec.data()), false)};
   auto matcher = HungarianMatcher(1, 1, 1);
   auto crit = SetCriterion(80, matcher, getLossWeights(), 0.0);
   auto loss = crit.forward(predBoxes, predLogits, targetBoxes, targetClasses);
@@ -156,7 +156,7 @@ TEST(SetCriterion, PytorchReproNoPerfectMatch) {
       af::array(4, NUM_TARGETS, NUM_BATCHES, targetBoxesVec.data()), false)};
 
   std::vector<fl::Variable> targetClasses = {fl::Variable(
-      af::array(NUM_TARGETS, NUM_BATCHES, targetClassVec.data()), false)};
+      af::array(1, NUM_TARGETS, NUM_BATCHES, targetClassVec.data()), false)};
   auto matcher = HungarianMatcher(1, 1, 1);
   auto crit = SetCriterion(80, matcher, getLossWeights(), 0.0);
   auto loss = crit.forward(predBoxes, predLogits, targetBoxes, targetClasses);
@@ -298,9 +298,9 @@ TEST(SetCriterion, PytorchReproBatching) {
 
   std::vector<fl::Variable> targetClasses = {
       fl::Variable(
-          af::array(NUM_TARGETS, NUM_PREDS, 1, targetClassVec.data()), false),
+          af::array(1, NUM_TARGETS, NUM_PREDS, 1, targetClassVec.data()), false),
       fl::Variable(
-          af::array(NUM_TARGETS, NUM_PREDS, 1, targetClassVec.data()), false)};
+          af::array(1, NUM_TARGETS, NUM_PREDS, 1, targetClassVec.data()), false)};
   auto matcher = HungarianMatcher(1, 1, 1);
   auto crit = SetCriterion(80, matcher, getLossWeights(), 0.0);
   auto loss = crit.forward(predBoxes, predLogits, targetBoxes, targetClasses);
@@ -349,8 +349,8 @@ TEST(SetCriterion, DifferentNumberOfLabels) {
       fl::Variable(af::array(4, 1, 1, targetBoxesVec2.data()), false)};
 
   std::vector<fl::Variable> targetClasses = {
-      fl::Variable(af::constant(1, {2, 1, 1}), false),
-      fl::Variable(af::constant(1, {1, 1, 1}), false)};
+      fl::Variable(af::constant(1, {1, 2, 1, 1}), false),
+      fl::Variable(af::constant(1, {1, 1, 1, 1}), false)};
   auto matcher = HungarianMatcher(1, 1, 1);
   auto crit = SetCriterion(80, matcher, getLossWeights(), 0.0);
   auto loss = crit.forward(predBoxes, predLogits, targetBoxes, targetClasses);
@@ -387,8 +387,10 @@ TEST(SetCriterion, DifferentNumberOfLabelsClass) {
       fl::Variable(af::array(4, 2, 1, targetBoxesVec1.data()), false),
       fl::Variable(af::array(4, 1, 1, targetBoxesVec2.data()), false)};
 
+  auto iota = af::iota({2});
+  iota = af::moddims(iota, { 1, iota.dims(0) });
   std::vector<fl::Variable> targetClasses = {
-      fl::Variable(af::iota({2}), false),
+      fl::Variable(iota, false),
       fl::Variable(af::constant(9, {1, 1, 1}), false)};
   auto matcher = HungarianMatcher(1, 1, 1);
   auto crit = SetCriterion(80, matcher, getLossWeights(), 0.0);


### PR DESCRIPTION
Some weird arrayfire behavior allows you to assign arrays of different dimensions but only if the dimensions are * not * singlular for the other dimensions. 

For example, below, with batch_size 2, and num boxes 3, target_classes_full is { 100, 3 } and targetClasses[i](targetIdxs) is { 1, 3 }. srcIdxs = { 3,  1 } . target_classes_full(srcIdxs, i) = targetClasses[i](targetIdxs) is fine. (Arrayfire can assign to  { 3, 1} from { 1, 3}. 

For whatever reason, with batch_size 1, and num boxes 3, target_classes_full is now { 100, 1 } and like before targetClasses[i](targetIdxs) is { 1, 3 }. srcIdxs = { 3,  1 } . target_classes_full(srcIdxs, i) = targetClasses[i](targetIdxs) now fails. (Arrayfire cannot assign to { 3, 1} from { 1, 3 }. 

Anyway, probably better to be explicit. 

