### PR TITLE
Exclude scripts dirs from installed header globbing

### DIFF
--- a/cmake/InternalUtils.cmake
+++ b/cmake/InternalUtils.cmake
@@ -64,6 +64,7 @@ function(setup_install_headers HEADER_DIR DEST_DIR)
     PATTERN "test*" EXCLUDE
     PATTERN "tests" EXCLUDE
     PATTERN "tools" EXCLUDE
+    PATTERN "scripts" EXCLUDE
     PATTERN "plugins" EXCLUDE
     PATTERN "backend" EXCLUDE
     PATTERN "examples" EXCLUDE


### PR DESCRIPTION
Summary: Kill `scripts` directories that contain no headers but are installed as empty dirs (e.g. `objdet/scripts`)

Differential Revision: D27887412

