### PR TITLE
Fix nvtx profiling telemetry

### DIFF
--- a/flashlight/fl/common/Profile.h
+++ b/flashlight/fl/common/Profile.h
@@ -49,7 +49,7 @@ class ProfileTracer {
   fl::detail::ProfileTracer _FL_PROFILE_CAT(profileTracer, __LINE__)(name);
 
 #define FL_SCOPED_PROFILE() \
-  fl::detail::ScopedProfiler _FL_PROFILE_CAT(scopedProfile, __LINE__)();
+  fl::detail::ScopedProfiler _FL_PROFILE_CAT(scopedProfile, __LINE__);
 
 #else
 #define FL_PROFILE_TRACE(_)

--- a/flashlight/fl/common/backend/cuda/Profile.cpp
+++ b/flashlight/fl/common/backend/cuda/Profile.cpp
@@ -10,15 +10,17 @@
 #include <cuda_profiler_api.h>
 #include <nvToolsExt.h>
 
+#include "flashlight/fl/common/backend/cuda/CudaUtils.h"
+
 namespace fl {
 namespace detail {
 
 ScopedProfiler::ScopedProfiler() {
-  cudaProfilerStart();
+  FL_CUDA_CHECK(cudaProfilerStart());
 }
 
 ScopedProfiler::~ScopedProfiler() {
-  cudaProfilerStop();
+  FL_CUDA_CHECK(cudaProfilerStop());
 }
 
 ProfileTracer::ProfileTracer(const std::string& name) {


### PR DESCRIPTION
See title. Add CUDA check macros to catch failure and fix `ScopedProfiler` ctor

Test plan:
Build with `-DFL_BUILD_PROFILING=ON`

Local profile:
![Screen Shot 2021-04-23 at 12 30 20 PM](https://user-images.githubusercontent.com/7871817/115908435-c88c7b00-a42f-11eb-979f-0a08eb4f48eb.png)
