### PR TITLE
[easy] Some misc DeTR fixes

### DIFF
--- a/flashlight/app/objdet/CMakeLists.txt
+++ b/flashlight/app/objdet/CMakeLists.txt
@@ -36,14 +36,15 @@ include(${CMAKE_CURRENT_LIST_DIR}/nn/CMakeLists.txt)
 add_executable(
   fl_img_imagenet_resnet50_backbone
   ${CMAKE_CURRENT_LIST_DIR}/examples/ImageNetResnet50Backbone.cpp)
-
 target_link_libraries(
   fl_img_imagenet_resnet50_backbone
   flashlight-app-imgclass
   flashlight-app-objdet)
+set_executable_output_directory(fl_img_imagenet_resnet50_backbone ${FL_BUILD_BINARY_OUTPUT_DIR}/objdet)
 
 add_executable(fl_img_coco_detr ${CMAKE_CURRENT_LIST_DIR}/examples/CocoDetr.cpp)
 target_link_libraries(fl_img_coco_detr flashlight-app-objdet)
+set_executable_output_directory(fl_img_coco_detr ${FL_BUILD_BINARY_OUTPUT_DIR}/objdet)
 
 # Build tests
 if (FL_BUILD_TESTS)

--- a/flashlight/app/objdet/nn/Transformer.h
+++ b/flashlight/app/objdet/nn/Transformer.h
@@ -170,7 +170,6 @@ class TransformerDecoder : public Container {
   std::string prettyString() const override;
 
  private:
-
   TransformerDecoder() = default;
   FL_SAVE_LOAD_WITH_BASE(fl::Container)
 };

--- a/flashlight/app/objdet/scripts/requirements.txt
+++ b/flashlight/app/objdet/scripts/requirements.txt
@@ -1,4 +1,13 @@
-pycocotools==2.0
-arrayfire==3.6.20181017
-numpy==1.18.1
-Pillow=7.1.2
+certifi==2020.12.5
+cycler==0.10.0
+Cython==0.29.22
+kiwisolver==1.3.1
+matplotlib==3.4.1
+numpy==1.20.2
+Pillow==8.2.0
+pycocotools==2.0.2
+pyparsing==2.4.7
+python-dateutil==2.8.1
+six==1.15.0
+torch==1.8.1
+typing-extensions==3.7.4.3

--- a/flashlight/fl/autograd/Functions.cpp
+++ b/flashlight/fl/autograd/Functions.cpp
@@ -985,7 +985,7 @@ Variable weightedCategoricalCrossEntropy(
     throw std::invalid_argument(
         "dimension mismatch in categorical cross entropy");
   }
-  if(weight.dims(0) != input.dims(0)) {
+  if (weight.dims(0) != input.dims(0)) {
     throw std::invalid_argument(
         "dimension mismatch in categorical cross entropy");
   }


### PR DESCRIPTION
Some random fixes:
- Put objdet binaries in the `bin` build dir
- Fix the imagenet script `requirements.txt` (existing one is malformed)

Test plan:
Local test, i.e.
```
./bin/objdet/fl_img_coco_detr train --exp_rundir /tmp/detr --eval_dir /tmp/eval --eval_command /private/home/jacobkahn/flashlight-clone/flashlight/flashlight/app/objdet/scripts/eval_coco.py --data_dir ~/data/coco --nodistributed_enable --data_dir ~/data/coco/
```