### PR TITLE
[fl::Tensor][1/N] Compute: sync and eval

### DIFF
--- a/docs/source/autograd.rst
+++ b/docs/source/autograd.rst
@@ -135,7 +135,7 @@ ArrayFire uses a JIT compiler to combine many small function calls into a single
   auto B = 2.0 * A; // 'B' is not allocated, Total Memory : 4 MB
   auto C = 1.0 + B; // 'C' is not allocated, Total Memory :  4 MB
   auto D = log(C); // 'D' is not allocated (yet), Total Memory :  4 MB
-  D.eval(); // only 'D' is allocated, Total Memory : 8 MB
+  fl::eval(D); // only 'D' is allocated, Total Memory : 8 MB
 
 
 The JIT both improves performance and reduces memory usage. For further documentation, see docs for the `ArrayFire JIT <https://arrayfire.com/performance-improvements-to-jit-in-arrayfire-v3-4/>`_.

--- a/flashlight/app/asr/Train.cpp
+++ b/flashlight/app/asr/Train.cpp
@@ -1025,7 +1025,7 @@ int main(int argc, char** argv) {
       FL_LOG_MASTER(INFO) << "Shuffling trainset";
       auto curTrainset = loadPrefetchDataset(
           trainset, FLAGS_nthread, true /* shuffle */, curEpoch /* seed */);
-      af::sync();
+      fl::sync();
       meters.sampletimer.resume();
       meters.runtime.resume();
       meters.timer.resume();
@@ -1047,7 +1047,7 @@ int main(int argc, char** argv) {
         critopt->setLr(
             initcritlr * lrDecayScale * lrScheduleScale *
             std::min(curBatch / double(FLAGS_warmup), 1.0));
-        af::sync();
+        fl::sync();
         meters.timer.incUnit();
         meters.sampletimer.stopAndIncUnit();
         meters.stats.add(batch[kDurationIdx], batch[kTargetSizeIdx]);
@@ -1082,7 +1082,7 @@ int main(int argc, char** argv) {
             output = fl::ext::forwardSequentialModuleWithPadMask(
                 input, ntwrk, batch[kDurationIdx]);
           }
-          af::sync();
+          fl::sync();
           meters.critfwdtimer.resume();
           std::vector<fl::Variable> critArgs = {
               output, fl::Variable(batch[kTargetIdx], false)};
@@ -1091,7 +1091,7 @@ int main(int argc, char** argv) {
             critArgs.push_back(fl::Variable(batch[kTargetSizeIdx], false));
           }
           auto loss = crit->forward(critArgs).front();
-          af::sync();
+          fl::sync();
           meters.fwdtimer.stopAndIncUnit();
           meters.critfwdtimer.stopAndIncUnit();
 
@@ -1123,7 +1123,7 @@ int main(int argc, char** argv) {
           if (reducer) {
             reducer->finalize();
           }
-          af::sync();
+          fl::sync();
           meters.bwdtimer.stopAndIncUnit();
 
           // optimizer
@@ -1183,7 +1183,7 @@ int main(int argc, char** argv) {
         // update weights
         critopt->step();
         netopt->step();
-        af::sync();
+        fl::sync();
         meters.optimtimer.stopAndIncUnit();
 
         // update scale factor
@@ -1219,7 +1219,7 @@ int main(int argc, char** argv) {
           break;
         }
       }
-      af::sync();
+      fl::sync();
       if (FLAGS_reportiters == 0) {
         runValAndSaveModel(
             curEpoch, curBatch, netopt->getLr(), critopt->getLr(), scaleFactor);

--- a/flashlight/app/asr/criterion/ConnectionistTemporalClassificationCriterion.cpp
+++ b/flashlight/app/asr/criterion/ConnectionistTemporalClassificationCriterion.cpp
@@ -32,7 +32,7 @@ af::array logSoftmax(const af::array& input, const int dim) {
   auto result = input -
       tile(log(sum(exp(input - tile(maxvals, tiledims)), dim)) + maxvals,
            tiledims);
-  result.eval();
+  fl::eval(result);
   return result;
 };
 

--- a/flashlight/app/asr/test/criterion/BenchmarkASG.cpp
+++ b/flashlight/app/asr/test/criterion/BenchmarkASG.cpp
@@ -39,13 +39,13 @@ int main() {
     b = asg.forward({input, target}).front();
     b.backward();
   }
-  af::sync();
+  fl::sync();
   auto s = af::timer::start();
   for (int i = 0; i < ntimes; ++i) {
     b = asg.forward({input, target}).front();
     b.backward(gradoutput);
   }
-  af::sync();
+  fl::sync();
   auto e = af::timer::stop(s);
   std::cout << "Total time (fwd+bwd pass) " << std::setprecision(5)
             << e * 1000.0 / ntimes << " msec" << std::endl;

--- a/flashlight/app/asr/test/criterion/BenchmarkCTC.cpp
+++ b/flashlight/app/asr/test/criterion/BenchmarkCTC.cpp
@@ -45,13 +45,13 @@ int main() {
     b = ctc.forward({input, target}).front();
     b.backward();
   }
-  af::sync();
+  fl::sync();
   auto s = af::timer::start();
   for (int i = 0; i < ntimes; ++i) {
     b = ctc.forward({input, target}).front();
     b.backward(gradoutput);
   }
-  af::sync();
+  fl::sync();
   auto e = af::timer::stop(s);
   std::cout << "Total time (fwd+bwd pass) " << std::setprecision(5)
             << e * 1000.0 / ntimes << " msec" << std::endl;

--- a/flashlight/app/asr/test/criterion/BenchmarkSeq2Seq.cpp
+++ b/flashlight/app/asr/test/criterion/BenchmarkSeq2Seq.cpp
@@ -43,7 +43,7 @@ void timeBeamSearch() {
     for (int i = 0; i < iters; ++i) {
       seq2seq.beamPath(input, af::array(), b);
     }
-    af::sync();
+    fl::sync();
     auto e = af::timer::stop(s);
     std::cout << "Total time (beam size: " << b << ") " << std::setprecision(5)
               << e * 1000.0 / iters << " msec" << std::endl;
@@ -69,7 +69,7 @@ void timeForwardBackward() {
     auto loss = seq2seq({input, target}).front();
     loss.backward();
   }
-  af::sync();
+  fl::sync();
 
   int iters = 100;
   auto s = af::timer::start();
@@ -77,7 +77,7 @@ void timeForwardBackward() {
     auto loss = seq2seq({input, target}).front();
     loss.backward();
   }
-  af::sync();
+  fl::sync();
   auto e = af::timer::stop(s);
   std::cout << "Total time (fwd+bwd pass) " << std::setprecision(5)
             << e * 1000.0 / iters << " msec" << std::endl;

--- a/flashlight/app/asr/tutorial/FinetuneCTC.cpp
+++ b/flashlight/app/asr/tutorial/FinetuneCTC.cpp
@@ -540,7 +540,7 @@ int main(int argc, char** argv) {
       FL_LOG_MASTER(INFO) << "Shuffling trainset";
       auto curTrainset = loadPrefetchDataset(
           trainset, FLAGS_nthread, true /* shuffle */, curEpoch /* seed */);
-      af::sync();
+      fl::sync();
       meters.sampletimer.resume();
       meters.runtime.resume();
       meters.timer.resume();
@@ -559,7 +559,7 @@ int main(int argc, char** argv) {
         netopt->setLr(
             initlr * lrDecayScale * lrScheduleScale *
             std::min(curBatch / double(FLAGS_warmup), 1.0));
-        af::sync();
+        fl::sync();
         meters.timer.incUnit();
         meters.sampletimer.stopAndIncUnit();
         meters.stats.add(batch[kDurationIdx], batch[kTargetSizeIdx]);
@@ -588,11 +588,11 @@ int main(int argc, char** argv) {
           }
           auto output = fl::ext::forwardSequentialModuleWithPadMask(
               input, ntwrk, batch[kDurationIdx]);
-          af::sync();
+          fl::sync();
           meters.critfwdtimer.resume();
           auto loss =
               crit->forward({output, fl::noGrad(batch[kTargetIdx])}).front();
-          af::sync();
+          fl::sync();
           meters.fwdtimer.stopAndIncUnit();
           meters.critfwdtimer.stopAndIncUnit();
 
@@ -629,7 +629,7 @@ int main(int argc, char** argv) {
           if (reducer) {
             reducer->finalize();
           }
-          af::sync();
+          fl::sync();
           meters.bwdtimer.stopAndIncUnit();
 
           // optimizer
@@ -673,7 +673,7 @@ int main(int argc, char** argv) {
 
         // update weights
         netopt->step();
-        af::sync();
+        fl::sync();
         meters.optimtimer.stopAndIncUnit();
 
         // update scale factor
@@ -703,7 +703,7 @@ int main(int argc, char** argv) {
           break;
         }
       }
-      af::sync();
+      fl::sync();
       if (FLAGS_reportiters == 0) {
         runValAndSaveModel(curEpoch, curBatch, netopt->getLr());
       }

--- a/flashlight/app/imgclass/examples/ImageNetResnet34.cpp
+++ b/flashlight/app/imgclass/examples/ImageNetResnet34.cpp
@@ -292,19 +292,19 @@ int main(int argc, char** argv) {
         inputs = inputs.as(f16);
       }
       auto target = noGrad(example[kImagenetTargetIdx]);
-      af::sync();
+      fl::sync();
       sampleTimerMeter.stopAndIncUnit();
 
       // Get the activations from the model.
       fwdTimeMeter.resume();
       auto output = model->forward(inputs);
-      af::sync();
+      fl::sync();
       fwdTimeMeter.stopAndIncUnit();
 
       // Compute and record the loss.
       critFwdTimeMeter.resume();
       auto loss = criterion(output, target);
-      af::sync();
+      fl::sync();
       critFwdTimeMeter.stopAndIncUnit();
 
       if (FLAGS_fl_amp_use_mixed_precision) {
@@ -336,7 +336,7 @@ int main(int argc, char** argv) {
       if (FLAGS_distributed_enable) {
         reducer->finalize();
       }
-      af::sync();
+      fl::sync();
       bwdTimeMeter.stopAndIncUnit();
 
       optimTimeMeter.resume();
@@ -373,7 +373,7 @@ int main(int argc, char** argv) {
       }
 
       opt.step();
-      af::sync();
+      fl::sync();
       optimTimeMeter.stopAndIncUnit();
       timeMeter.stopAndIncUnit();
 

--- a/flashlight/app/imgclass/examples/ImageNetTransformer.cpp
+++ b/flashlight/app/imgclass/examples/ImageNetTransformer.cpp
@@ -428,7 +428,7 @@ int main(int argc, char** argv) {
         input = input.as(f16);
       }
 
-      af::sync();
+      fl::sync();
       sampleTimerMeter.stopAndIncUnit();
 
       Variable loss;
@@ -462,7 +462,7 @@ int main(int argc, char** argv) {
             continue;
           }
         }
-        af::sync();
+        fl::sync();
         fwdTimeMeter.stopAndIncUnit();
         critFwdTimeMeter.stopAndIncUnit();
 
@@ -501,7 +501,7 @@ int main(int argc, char** argv) {
             }
           }
         }
-        af::sync();
+        fl::sync();
         bwdTimeMeter.stopAndIncUnit();
         if (retrySample) {
           continue;

--- a/flashlight/app/lm/Trainer.cpp
+++ b/flashlight/app/lm/Trainer.cpp
@@ -335,7 +335,7 @@ void Trainer::trainStep() {
   // 2. Forward
   fwdTimeMeter_.resume();
   auto output = network_->forward({input, fl::noGrad(inputSizes)}).front();
-  af::sync();
+  fl::sync();
   critFwdTimeMeter_.resume();
   auto loss = criterion_->forward({output, target}).front();
 
@@ -356,7 +356,7 @@ void Trainer::trainStep() {
       skipBatch = true;
     }
   }
-  af::sync();
+  fl::sync();
   fwdTimeMeter_.stopAndIncUnit();
   critFwdTimeMeter_.stopAndIncUnit();
   if (skipBatch) {
@@ -407,7 +407,7 @@ void Trainer::trainStep() {
       }
     }
   }
-  af::sync();
+  fl::sync();
   bwdTimeMeter_.stopAndIncUnit();
   if (skipBatch) {
     return;
@@ -417,7 +417,7 @@ void Trainer::trainStep() {
   optimTimeMeter_.resume();
   fl::clipGradNorm(parameters_, FLAGS_train_max_grad_norm);
   optimizer_->step();
-  af::sync();
+  fl::sync();
   optimTimeMeter_.stopAndIncUnit();
 
   if (FLAGS_fl_amp_use_mixed_precision &&

--- a/flashlight/app/objdet/examples/CocoDetr.cpp
+++ b/flashlight/app/objdet/examples/CocoDetr.cpp
@@ -472,7 +472,7 @@ int main(int argc, char** argv) {
           [&dataType](const af::array& in) {
             return fl::Variable(in.as(dataType), false);
           });
-      af::sync();
+      fl::sync();
       sampleTimerMeter.stopAndIncUnit();
 
       /////////////////////////
@@ -480,12 +480,12 @@ int main(int argc, char** argv) {
       /////////////////////////
       fwdBackboneTimeMeter.resume();
       input = detr->forwardBackbone(input);
-      af::sync();
+      fl::sync();
       fwdBackboneTimeMeter.stopAndIncUnit();
 
       fwdTimeMeter.resume();
       auto output = detr->forward({input, mask});
-      af::sync();
+      fl::sync();
       fwdTimeMeter.stopAndIncUnit();
 
       /////////////////////////
@@ -520,7 +520,7 @@ int main(int argc, char** argv) {
           continue;
         }
       }
-      af::sync();
+      fl::sync();
       critFwdTimeMeter.stopAndIncUnit();
 
       /////////////////////////
@@ -569,7 +569,7 @@ int main(int argc, char** argv) {
       if (skipBatch) {
         continue;
       }
-      af::sync();
+      fl::sync();
       bwdTimeMeter.stopAndIncUnit();
 
       optimTimeMeter.resume();

--- a/flashlight/fl/CMakeLists.txt
+++ b/flashlight/fl/CMakeLists.txt
@@ -69,6 +69,9 @@ include(${FL_CORE_COMPONENT_SRC_DIR}/nn/CMakeLists.txt)
 # Optim
 include(${FL_CORE_COMPONENT_SRC_DIR}/optim/CMakeLists.txt)
 
+# Tensor
+include(${FL_CORE_COMPONENT_SRC_DIR}/tensor/CMakeLists.txt)
+
 # --------------------------- Configure Examples/Tests ---------------------------
 
 # Build tests

--- a/flashlight/fl/autograd/Functions.cpp
+++ b/flashlight/fl/autograd/Functions.cpp
@@ -21,6 +21,7 @@
 
 #include "flashlight/fl/autograd/Functions.h"
 #include "flashlight/fl/autograd/Variable.h"
+#include "flashlight/fl/tensor/Compute.h"
 
 namespace fl {
 namespace detail {
@@ -678,7 +679,7 @@ norm(const Variable& input, const std::vector<int>& axes, double p /* = 2 */) {
   }
   af::array sumap = result;
   result = af::pow(result, 1 / p);
-  result.eval();
+  fl::eval(result);
 
   auto gradFunc =
       [sumap, p](std::vector<Variable>& inputs, const Variable& gradOutput) {
@@ -853,7 +854,7 @@ Variable softmax(const Variable& input, const int dim) {
   auto expInput = af::exp(inputArr - af::tile(maxvals, tiledims));
   auto result = expInput / af::tile(af::sum(expInput, dim), tiledims);
 
-  result.eval();
+  fl::eval(result);
   auto gradFunc = [dim, tiledims, result](
                       std::vector<Variable>& inputs,
                       const Variable& gradOutput) {
@@ -875,7 +876,7 @@ Variable logSoftmax(const Variable& input, const int dim) {
                    maxvals,
                tiledims);
 
-  result.eval();
+  fl::eval(result);
   auto gradFunc = [dim, tiledims, result](
                       std::vector<Variable>& inputs,
                       const Variable& gradOutput) {

--- a/flashlight/fl/autograd/Variable.cpp
+++ b/flashlight/fl/autograd/Variable.cpp
@@ -26,6 +26,7 @@
 
 #include "flashlight/fl/autograd/Functions.h"
 #include "flashlight/fl/common/Utils.h"
+#include "flashlight/fl/tensor/Compute.h"
 
 namespace fl {
 
@@ -67,7 +68,7 @@ Variable Variable::operator()(
   // Extract af::index variable information,
   // it can either be af::span, af::seq or af::array
   auto idxFunc = [&idxStart, &idxEnd, &idxArr, &advancedIndex, unique, inDims](
-      const af::index& index, int pos) {
+                     const af::index& index, int pos) {
     if (index.isspan()) {
       idxStart[pos] = 0;
       idxEnd[pos] = inDims[pos];
@@ -125,8 +126,8 @@ af::array& Variable::array() const {
 
 Variable Variable::as(af::dtype newType) const {
   auto output = array().as(newType);
-  auto gradFunc = [](
-      std::vector<Variable>& inputs, const Variable& gradOutput) {
+  auto gradFunc = [](std::vector<Variable>& inputs,
+                     const Variable& gradOutput) {
     auto& input = inputs[0];
     // Cast the grad output to match the type of the input's grad
     input.addGrad(Variable(gradOutput.array().as(input.type()), false));
@@ -203,7 +204,7 @@ dim_t Variable::dims(unsigned dim) const {
 }
 
 void Variable::eval() const {
-  return array().eval();
+  fl::eval(array());
 }
 
 void Variable::zeroGrad() {
@@ -300,7 +301,8 @@ Variable Variable::col(int index) const {
   auto inDims = dims();
   auto inType = type();
   auto gradFunc = [index, inDims, inType](
-      std::vector<Variable>& inputs, const Variable& gradOutput) {
+                      std::vector<Variable>& inputs,
+                      const Variable& gradOutput) {
     auto grad = Variable(af::constant(0, inDims, inType), false);
     grad.array().col(index) = gradOutput.array();
     inputs[0].addGrad(grad);
@@ -313,7 +315,8 @@ Variable Variable::cols(int first, int last) const {
   auto inDims = dims();
   auto inType = type();
   auto gradFunc = [first, last, inDims, inType](
-      std::vector<Variable>& inputs, const Variable& gradOutput) {
+                      std::vector<Variable>& inputs,
+                      const Variable& gradOutput) {
     auto grad = Variable(af::constant(0, inDims, inType), false);
     grad.array().cols(first, last) = gradOutput.array();
     inputs[0].addGrad(grad);
@@ -326,7 +329,8 @@ Variable Variable::row(int index) const {
   auto inDims = dims();
   auto inType = type();
   auto gradFunc = [index, inDims, inType](
-      std::vector<Variable>& inputs, const Variable& gradOutput) {
+                      std::vector<Variable>& inputs,
+                      const Variable& gradOutput) {
     auto grad = Variable(af::constant(0, inDims, inType), false);
     grad.array().row(index) = gradOutput.array();
     inputs[0].addGrad(grad);
@@ -339,7 +343,8 @@ Variable Variable::rows(int first, int last) const {
   auto inDims = dims();
   auto inType = type();
   auto gradFunc = [first, last, inDims, inType](
-      std::vector<Variable>& inputs, const Variable& gradOutput) {
+                      std::vector<Variable>& inputs,
+                      const Variable& gradOutput) {
     auto grad = Variable(af::constant(0, inDims, inType), false);
     grad.array().rows(first, last) = gradOutput.array();
     inputs[0].addGrad(grad);
@@ -352,7 +357,8 @@ Variable Variable::slice(int index) const {
   auto inDims = dims();
   auto inType = type();
   auto gradFunc = [index, inDims, inType](
-      std::vector<Variable>& inputs, const Variable& gradOutput) {
+                      std::vector<Variable>& inputs,
+                      const Variable& gradOutput) {
     auto grad = Variable(af::constant(0, inDims, inType), false);
     grad.array().slice(index) = gradOutput.array();
     inputs[0].addGrad(grad);
@@ -365,7 +371,8 @@ Variable Variable::slices(int first, int last) const {
   auto inDims = dims();
   auto inType = type();
   auto gradFunc = [first, last, inDims, inType](
-      std::vector<Variable>& inputs, const Variable& gradOutput) {
+                      std::vector<Variable>& inputs,
+                      const Variable& gradOutput) {
     auto grad = Variable(af::constant(0, inDims, inType), false);
     grad.array().slices(first, last) = gradOutput.array();
     inputs[0].addGrad(grad);

--- a/flashlight/fl/autograd/backend/cpu/DnnlUtils.cpp
+++ b/flashlight/fl/autograd/backend/cpu/DnnlUtils.cpp
@@ -14,6 +14,7 @@
 
 #include "flashlight/fl/autograd/backend/cpu/DnnlUtils.h"
 #include "flashlight/fl/common/Defines.h"
+#include "flashlight/fl/tensor/Compute.h"
 
 #if FL_BACKEND_OPENCL
 #include "flashlight/fl/common/OpenClUtils.h"

--- a/flashlight/fl/autograd/backend/cpu/DnnlUtils.cpp
+++ b/flashlight/fl/autograd/backend/cpu/DnnlUtils.cpp
@@ -130,7 +130,7 @@ void executeNetwork(
   // enforcing that inputs to computation are ready; we're required to wait
   // until all AF operations are done
   if (cpuBackend) {
-    af::sync();
+    fl::sync();
   }
   for (size_t i = 0; i < net.size(); ++i) {
     net.at(i).execute(DnnlStream::getInstance().getStream(), netArgs.at(i));

--- a/flashlight/fl/common/DynamicBenchmark.cpp
+++ b/flashlight/fl/common/DynamicBenchmark.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "flashlight/fl/common/DynamicBenchmark.h"
+#include "flashlight/fl/tensor/Compute.h"
 
 namespace fl {
 
@@ -29,12 +30,12 @@ void DynamicBenchmark::audit(
 }
 
 void DynamicBenchmark::start() {
-  af::sync();
+  fl::sync();
   currentTimer_ = af::timer::start();
 }
 
 void DynamicBenchmark::stop(bool incrementCount) {
-  af::sync();
+  fl::sync();
   auto elapsedTime = af::timer::stop(currentTimer_);
   options_->accumulateTimeToCurrentOption(elapsedTime, incrementCount);
 }

--- a/flashlight/fl/common/DynamicBenchmark.h
+++ b/flashlight/fl/common/DynamicBenchmark.h
@@ -209,7 +209,7 @@ class DynamicBenchmark {
    * DynamicBenchmark's options' currently-active option.
    *
    * If the timings are complete for the benchmark options, simply executes the
-   passed function. Calls `af::sync()` before and after function execution to
+   passed function. Calls `fl::sync()` before and after function execution to
    get an accurate count.
    *
    * @param[in] function the function to benchmark

--- a/flashlight/fl/distributed/reducers/CoalescingReducer.cpp
+++ b/flashlight/fl/distributed/reducers/CoalescingReducer.cpp
@@ -7,6 +7,7 @@
 
 #include "flashlight/fl/distributed/reducers/CoalescingReducer.h"
 #include "flashlight/fl/distributed/DistributedApi.h"
+#include "flashlight/fl/tensor/Compute.h"
 
 namespace fl {
 

--- a/flashlight/fl/examples/Benchmark.cpp
+++ b/flashlight/fl/examples/Benchmark.cpp
@@ -10,6 +10,7 @@
 
 #include "flashlight/fl/common/Init.h"
 #include "flashlight/fl/nn/nn.h"
+#include "flashlight/fl/tensor/tensor.h"
 
 using namespace fl;
 
@@ -22,15 +23,15 @@ double timeit(std::function<void()> fn) {
   for (int i = 0; i < 10; ++i) {
     fn();
   }
-  af::sync();
+  fl::sync();
 
   int num_iters = 100;
-  af::sync();
+  fl::sync();
   auto start = af::timer::start();
   for (int i = 0; i < num_iters; i++) {
     fn();
   }
-  af::sync();
+  fl::sync();
   return af::timer::stop(start) / num_iters;
 }
 

--- a/flashlight/fl/examples/RnnLm.cpp
+++ b/flashlight/fl/examples/RnnLm.cpp
@@ -199,7 +199,7 @@ int main(int argc, char** argv) {
       clipGradNorm(model.params(), max_grad_norm);
       opt.step();
 
-      af::sync();
+      fl::sync();
       timer.incUnit();
     }
 

--- a/flashlight/fl/flashlight.h
+++ b/flashlight/fl/flashlight.h
@@ -16,3 +16,4 @@
 #include "flashlight/fl/meter/meters.h"
 #include "flashlight/fl/nn/nn.h"
 #include "flashlight/fl/optim/optim.h"
+#include "flashlight/fl/tensor/tensor.h"

--- a/flashlight/fl/optim/AMSgradOptimizer.cpp
+++ b/flashlight/fl/optim/AMSgradOptimizer.cpp
@@ -17,6 +17,8 @@
 
 #include <cmath>
 
+#include "flashlight/fl/tensor/Compute.h"
+
 using std::vector;
 
 namespace fl {
@@ -48,9 +50,9 @@ AMSgradOptimizer::AMSgradOptimizer(
     maxExpAvgSq_.emplace_back(
         af::constant(0, parameter.dims(), parameter.type()));
 
-    biasedFirst_.back().eval();
-    biasedSecond_.back().eval();
-    maxExpAvgSq_.back().eval();
+    fl::eval(biasedFirst_.back());
+    fl::eval(biasedSecond_.back());
+    fl::eval(maxExpAvgSq_.back());
   }
 }
 
@@ -74,13 +76,13 @@ void AMSgradOptimizer::step() {
     biasedFirst = beta1_ * biasedFirst + (1 - beta1_) * grad;
     biasedSecond = beta2_ * biasedSecond + (1 - beta2_) * grad * grad;
     maxExpAvgSq = af::max(maxExpAvgSq, biasedSecond);
-    af::eval(biasedFirst);
-    af::eval(biasedSecond);
-    af::eval(maxExpAvgSq);
+    fl::eval(biasedFirst);
+    fl::eval(biasedSecond);
+    fl::eval(maxExpAvgSq);
 
     data = data - (lr_ * biasedFirst) / (af::sqrt(maxExpAvgSq) + eps_);
 
-    af::eval(data);
+    fl::eval(data);
   }
 }
 

--- a/flashlight/fl/optim/AdadeltaOptimizer.cpp
+++ b/flashlight/fl/optim/AdadeltaOptimizer.cpp
@@ -17,6 +17,8 @@
 
 #include <cmath>
 
+#include "flashlight/fl/tensor/Compute.h"
+
 namespace fl {
 
 AdadeltaOptimizer::AdadeltaOptimizer(
@@ -38,8 +40,8 @@ AdadeltaOptimizer::AdadeltaOptimizer(
     accGrad_.emplace_back(af::constant(0, parameter.dims(), parameter.type()));
     accDelta_.emplace_back(af::constant(0, parameter.dims(), parameter.type()));
 
-    accGrad_.back().eval();
-    accDelta_.back().eval();
+    fl::eval(accGrad_.back());
+    fl::eval(accDelta_.back());
   }
 }
 
@@ -61,15 +63,15 @@ void AdadeltaOptimizer::step() {
     af::array& accDelta = accDelta_[i];
 
     accGrad = rho_ * accGrad + (1 - rho_) * grad * grad;
-    af::eval(accGrad);
+    fl::eval(accGrad);
 
     auto delta = af::sqrt(accDelta + eps_) / af::sqrt(accGrad + eps_) * grad;
 
     data = data - lr_ * delta;
-    af::eval(data);
+    fl::eval(data);
 
     accDelta = rho_ * accDelta + (1 - rho_) * delta * delta;
-    af::eval(accDelta);
+    fl::eval(accDelta);
   }
 }
 

--- a/flashlight/fl/optim/AdagradOptimizer.cpp
+++ b/flashlight/fl/optim/AdagradOptimizer.cpp
@@ -17,6 +17,8 @@
 
 #include <cmath>
 
+#include "flashlight/fl/tensor/Compute.h"
+
 namespace fl {
 
 AdagradOptimizer::AdagradOptimizer(
@@ -30,7 +32,7 @@ AdagradOptimizer::AdagradOptimizer(
   variance_.reserve(parameters.size());
   for (const auto& param : parameters_) {
     variance_.push_back(af::constant(0, param.dims(), param.type()));
-    variance_.back().eval();
+    fl::eval(variance_.back());
   }
 }
 
@@ -50,9 +52,9 @@ void AdagradOptimizer::step() {
     }
 
     variance = variance + grad * grad;
-    af::eval(variance);
+    fl::eval(variance);
     data = data - lr_ * grad / (af::sqrt(variance) + eps_);
-    af::eval(data);
+    fl::eval(data);
   }
 }
 

--- a/flashlight/fl/optim/AdamOptimizer.cpp
+++ b/flashlight/fl/optim/AdamOptimizer.cpp
@@ -17,6 +17,8 @@
 
 #include <cmath>
 
+#include "flashlight/fl/tensor/Compute.h"
+
 using std::vector;
 
 namespace fl {
@@ -45,8 +47,8 @@ AdamOptimizer::AdamOptimizer(
     biasedSecond_.emplace_back(
         af::constant(0, parameter.dims(), parameter.type()));
 
-    biasedFirst_.back().eval();
-    biasedSecond_.back().eval();
+    fl::eval(biasedFirst_.back());
+    fl::eval(biasedSecond_.back());
   }
 }
 
@@ -75,12 +77,12 @@ void AdamOptimizer::step() {
     biasedFirst = beta1_ * biasedFirst + (1 - beta1_) * grad;
     biasedSecond = beta2_ * biasedSecond + (1 - beta2_) * grad * grad;
 
-    af::eval(biasedFirst);
-    af::eval(biasedSecond);
+    fl::eval(biasedFirst);
+    fl::eval(biasedSecond);
 
     data = data - (correctedLr * biasedFirst) / (af::sqrt(biasedSecond) + eps_);
 
-    af::eval(data);
+    fl::eval(data);
   }
 }
 

--- a/flashlight/fl/optim/NAGOptimizer.cpp
+++ b/flashlight/fl/optim/NAGOptimizer.cpp
@@ -9,6 +9,8 @@
 
 #include <cmath>
 
+#include "flashlight/fl/tensor/Compute.h"
+
 using std::vector;
 
 namespace fl {
@@ -31,7 +33,7 @@ NAGOptimizer::NAGOptimizer(
   for (const auto& parameter : parameters_) {
     velocities_.emplace_back(
         af::constant(0, parameter.dims(), parameter.type()));
-    velocities_.back().eval();
+    fl::eval(velocities_.back());
   }
 }
 
@@ -53,10 +55,10 @@ void NAGOptimizer::step() {
     af::array& velocity = velocities_[i];
     // this velocity corresponds to fairseq velocity * -1
     velocity = mu_ * velocity * correctedLr + lr_ * grad;
-    af::eval(velocity);
+    fl::eval(velocity);
     grad = grad * lr_ + velocity * mu_;
     data = data - grad;
-    af::eval(data);
+    fl::eval(data);
   }
   oldLr_ = lr_;
 }

--- a/flashlight/fl/optim/NovogradOptimizer.cpp
+++ b/flashlight/fl/optim/NovogradOptimizer.cpp
@@ -17,6 +17,8 @@
 
 #include <cmath>
 
+#include "flashlight/fl/tensor/Compute.h"
+
 using std::vector;
 
 namespace fl {
@@ -42,7 +44,7 @@ NovogradOptimizer::NovogradOptimizer(
     accGradNorm_.emplace_back(0.0);
     accGrad_.emplace_back(af::constant(0, parameter.dims(), parameter.type()));
 
-    accGrad_.back().eval();
+    fl::eval(accGrad_.back());
   }
 }
 
@@ -63,11 +65,11 @@ void NovogradOptimizer::step() {
         (1 - beta1_) *
             (grad / (static_cast<float>(std::sqrt(accGradNorm_[i]) + eps_)) +
              wd_ * data);
-    af::eval(accGrad);
+    fl::eval(accGrad);
 
     data = data - (lr_ * accGrad);
 
-    af::eval(data);
+    fl::eval(data);
   }
 }
 

--- a/flashlight/fl/optim/RMSPropOptimizer.cpp
+++ b/flashlight/fl/optim/RMSPropOptimizer.cpp
@@ -17,6 +17,8 @@
 
 #include <cmath>
 
+#include "flashlight/fl/tensor/Compute.h"
+
 using std::vector;
 
 namespace fl {
@@ -43,11 +45,11 @@ RMSPropOptimizer::RMSPropOptimizer(
   for (const auto& parameter : parameters_) {
     if (useFirst_) {
       first_.emplace_back(af::constant(0, parameter.dims(), parameter.type()));
-      first_.back().eval();
+      fl::eval(first_.back());
     }
 
     second_.emplace_back(af::constant(0, parameter.dims(), parameter.type()));
-    second_.back().eval();
+    fl::eval(second_.back());
   }
 }
 
@@ -67,7 +69,7 @@ void RMSPropOptimizer::step() {
 
     af::array& second = second_[i];
     second = rho_ * second + (1 - rho_) * grad * grad;
-    af::eval(second);
+    fl::eval(second);
 
     // Create shallow copy of second so that we don't update
     // "second" below
@@ -76,12 +78,12 @@ void RMSPropOptimizer::step() {
       af::array& first = first_[i];
       first = rho_ * first + (1 - rho_) * grad;
       moments = moments - first * first;
-      af::eval(first);
+      fl::eval(first);
     }
 
     data = data - (lr_ * grad) / (af::sqrt(moments) + eps_);
 
-    af::eval(data);
+    fl::eval(data);
   }
 }
 

--- a/flashlight/fl/optim/SGDOptimizer.cpp
+++ b/flashlight/fl/optim/SGDOptimizer.cpp
@@ -17,6 +17,8 @@
 
 #include <cmath>
 
+#include "flashlight/fl/tensor/Compute.h"
+
 using std::vector;
 
 namespace fl {
@@ -37,7 +39,7 @@ SGDOptimizer::SGDOptimizer(
     for (const auto& parameter : parameters_) {
       velocities_.emplace_back(
           af::constant(0, parameter.dims(), parameter.type()));
-      velocities_.back().eval();
+      fl::eval(velocities_.back());
     }
   }
 }
@@ -61,7 +63,7 @@ void SGDOptimizer::step() {
 
       // Regular momentum
       velocity = mu_ * velocity + grad;
-      af::eval(velocity);
+      fl::eval(velocity);
       if (useNesterov_) {
         // Update for nesterov momentum
         grad += velocity * mu_;
@@ -70,7 +72,7 @@ void SGDOptimizer::step() {
       }
     }
     data = data - lr_ * grad;
-    af::eval(data);
+    fl::eval(data);
   }
 }
 

--- a/flashlight/fl/tensor/CMakeLists.txt
+++ b/flashlight/fl/tensor/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.10)
+
+target_sources(
+  flashlight
+  PRIVATE
+  ${CMAKE_CURRENT_LIST_DIR}/Compute.cpp
+  )

--- a/flashlight/fl/tensor/Compute.cpp
+++ b/flashlight/fl/tensor/Compute.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "flashlight/fl/tensor/Compute.h"
+
+#include <af/array.h>
+#include <af/device.h>
+
+namespace fl {
+
+// TODO:fl::Tensor {move,build}  move this and other files into
+// `flashlight/fl/tensor/backend/af` or a directory with a similar structure.
+// For now, keep everything flat to make life easier.
+
+void sync() {
+  af::sync();
+}
+
+void eval(af::array& tensor) {
+  tensor.eval();
+}
+
+} // namespace fl

--- a/flashlight/fl/tensor/Compute.h
+++ b/flashlight/fl/tensor/Compute.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace af {
+class array;
+}
+
+namespace fl {
+
+/**
+ * Block the calling host thread until all outstanding computation has
+ * completed.
+ *
+ * The implementation of this ffunction should synchronize any outstanding
+ * computation abstractions, blocking accordingly.
+ */
+void sync();
+
+// TODO:fl::Tensor {signature}
+/**
+ * Launches computation, [usually] asynchronously, on operations needed to make
+ * a particular value for a tensor available.
+ *
+ * There is no implementation requirement for this function (it can be a noop),
+ * but it may be called by the user in areas with empirically high memory
+ * pressure or where computation might be prudent to perform as per the user's
+ * discretion.
+ *
+ * @param[in] tensor the tensor on which to launch computation.
+ */
+void eval(af::array& tensor);
+
+} // namespace fl

--- a/flashlight/fl/tensor/tensor.h
+++ b/flashlight/fl/tensor/tensor.h
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "flashlight/fl/tensor/Compute.h"

--- a/flashlight/fl/test/common/DynamicBenchmarkTest.cpp
+++ b/flashlight/fl/test/common/DynamicBenchmarkTest.cpp
@@ -14,6 +14,7 @@
 
 #include "flashlight/fl/common/DynamicBenchmark.h"
 #include "flashlight/fl/common/Init.h"
+#include "flashlight/fl/tensor/Compute.h"
 
 namespace {
 
@@ -137,7 +138,7 @@ TEST_F(DynamicBenchmark, DynamicBenchmarkMatmul) {
       auto a = af::randu({size, size});
       auto b = af::randu({size, size});
       auto c = af::matmul(a, b);
-      c.eval();
+      fl::eval(c);
     });
   }
   auto ops = dynamicBench->getOptions<fl::DynamicBenchmarkOptions<int>>();

--- a/flashlight/fl/test/contrib/modules/ContribModuleTest.cpp
+++ b/flashlight/fl/test/contrib/modules/ContribModuleTest.cpp
@@ -194,8 +194,7 @@ void transformerFwd(bool isfp16) {
 
   auto tr =
       Transformer(c, c / nheads, c, nheads, timesteps, 0.2, 0.1, true, false);
-  auto input =
-      Variable(af::randu(c, timesteps, batchsize, 1, dtype), false);
+  auto input = Variable(af::randu(c, timesteps, batchsize, 1, dtype), false);
 
   fl::Variable padMask;
   auto output = tr.forward({input, padMask});
@@ -229,8 +228,7 @@ void conformerFwd(bool isfp16) {
   auto dtype = isfp16 ? af::dtype::f16 : af::dtype::f32;
 
   auto tr = Conformer(c, c / nheads, c, nheads, timesteps, 33, 0.2, 0.1);
-  auto input =
-      Variable(af::randu(c, timesteps, batchsize, 1, dtype), false);
+  auto input = Variable(af::randu(c, timesteps, batchsize, 1, dtype), false);
 
   auto output = tr.forward({input, Variable()});
   if (OptimMode::get().getOptimLevel() == OptimLevel::O3) {
@@ -262,8 +260,7 @@ void positionEmbeddingFwd(bool isfp16) {
   auto dtype = isfp16 ? af::dtype::f16 : af::dtype::f32;
 
   auto posemb = PositionEmbedding(csz, timesteps, 0.5);
-  auto input =
-      Variable(af::randu(csz, timesteps, batchsize, 1, dtype), false);
+  auto input = Variable(af::randu(csz, timesteps, batchsize, 1, dtype), false);
 
   auto output = posemb.forward({input});
 
@@ -293,8 +290,7 @@ void sinusoidalPositionEmbeddingFwd(bool isfp16) {
 
   auto posemb = SinusoidalPositionEmbedding(csz, 2.);
   auto input =
-      Variable(af::randu(csz, timesteps, batchsize, 1, dtype), false) -
-      0.5;
+      Variable(af::randu(csz, timesteps, batchsize, 1, dtype), false) - 0.5;
 
   auto output = posemb.forward({input});
 

--- a/flashlight/fl/test/distributed/AllReduceBenchmark.cpp
+++ b/flashlight/fl/test/distributed/AllReduceBenchmark.cpp
@@ -39,11 +39,11 @@ int main() {
     for (auto& size : sizes) {
       for (size_t i = 0; i < kNumIters; ++i) {
         af::array in = af::randu(size);
-        in.eval();
-        af::sync();
+        fl::eval(in);
+        fl::sync();
         auto start = af::timer::start();
         allReduce(in);
-        af::sync();
+        fl::sync();
         times[i] = af::timer::stop(start);
       }
       auto timesAf = af::array(kNumIters, times.data());

--- a/flashlight/fl/test/distributed/AllReduceBenchmark.cpp
+++ b/flashlight/fl/test/distributed/AllReduceBenchmark.cpp
@@ -12,6 +12,7 @@
 
 #include "flashlight/fl/common/Init.h"
 #include "flashlight/fl/distributed/distributed.h"
+#include "flashlight/fl/tensor/Compute.h"
 
 using namespace fl;
 

--- a/flashlight/fl/test/optim/OptimBenchmark.cpp
+++ b/flashlight/fl/test/optim/OptimBenchmark.cpp
@@ -25,15 +25,15 @@ double timeit(std::function<void()> fn) {
   for (int i = 0; i < 10; ++i) {
     fn();
   }
-  af::sync();
+  fl::sync();
 
   int num_iters = 100;
-  af::sync();
+  fl::sync();
   auto start = af::timer::start();
   for (int i = 0; i < num_iters; i++) {
     fn();
   }
-  af::sync();
+  fl::sync();
   return af::timer::stop(start) / num_iters;
 }
 

--- a/flashlight/fl/test/optim/OptimBenchmark.cpp
+++ b/flashlight/fl/test/optim/OptimBenchmark.cpp
@@ -11,7 +11,7 @@
 #include "flashlight/fl/autograd/autograd.h"
 #include "flashlight/fl/common/common.h"
 #include "flashlight/fl/optim/optim.h"
-
+#include "flashlight/fl/tensor/Compute.h"
 #include "flashlight/lib/common/System.h"
 
 using namespace fl;


### PR DESCRIPTION
Adds `flashlight/fl/tensor`.

For now, add `fl::sync()` and `fl::eval(af::array&)` to begin abstracting away ArrayFire-specific semantics into a general API. Changes all callsites throughout all Flashlight components.

For now, the ArrayFire implementations of these functions will live in `flashlight/fl/tensor/*.cpp`. These will be moved into `flashlight/fl/tensor/backend/af/*` (or some similar path) once the interface is complete.

Test plan:
Rebuild + `make test` + CI