### PR TITLE
Rework Tensor - add TensorAdapterBase and ArrayFireTensor (#38)

### DIFF
--- a/flashlight/fl/tensor/CMakeLists.txt
+++ b/flashlight/fl/tensor/CMakeLists.txt
@@ -1,15 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-set(FL_TENSOR_BACKEND "AF" CACHE STRING "Tensor backend with which to build flashlight")
-# Select from exactly one tensor backend
-set_property(CACHE FL_TENSOR_BACKEND PROPERTY STRINGS AF)
-# Map to flags
-set(FL_USE_ARRAYFIRE OFF)
-if (FL_TENSOR_BACKEND STREQUAL "AF")
-  set(FL_USE_ARRAYFIRE ON)
-else()
-  message(FATAL_ERROR "Invalid FL_TENSOR_BACKEND specified")
-endif()
+option(FL_USE_ARRAYFIRE "Build ArrayFire tensor backend" ON)
 
 if (FL_USE_ARRAYFIRE)
   include(${CMAKE_CURRENT_LIST_DIR}/backend/af/CMakeLists.txt)
@@ -18,5 +9,6 @@ endif()
 target_sources(
   flashlight
   PRIVATE
+  ${CMAKE_CURRENT_LIST_DIR}/TensorBase.cpp
   ${CMAKE_CURRENT_LIST_DIR}/Types.cpp
 )

--- a/flashlight/fl/tensor/TensorAdapter.h
+++ b/flashlight/fl/tensor/TensorAdapter.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "flashlight/fl/tensor/TensorBase.h"
+
+namespace fl {
+
+/**
+ * Convert a Tensor from an adapter or via arguments for an adapter.
+ *
+ * @param[in] t the thing to convert
+ * @return a Tensor containing the ArrayFire array
+ */
+template <typename Impl, typename... T>
+Tensor toTensor(T&&... t) {
+  return Tensor(std::make_unique<Impl>(std::forward<T>(t)...));
+}
+
+/**
+ * The implementation interface for Flashlight Tensor backends.
+ *
+ * Defines the implementation requirements and behaviors for a particular tensor
+ * backend. These implementations can be tested against default
+ * backend/reference implementations.
+ *
+ * Derived types from TensorAdapterBase should not be constructed or operated on
+ * literally. Calls to their member implementations are dispatched via visiting
+ * Tensor or other interfaces.
+ */
+class TensorAdapterBase {
+ public:
+  TensorAdapterBase() = default;
+  virtual ~TensorAdapterBase() = default;
+
+  /**
+   * Gets the tensor's associated backend.
+   *
+   * @return TensorBackend enum associated with the backend
+   */
+  virtual TensorBackend backend() const = 0;
+
+  /**
+   * Get the shape of a tensor.
+   *
+   * @return the shape of the tensor
+   */
+  virtual Shape shape() const = 0;
+
+  /**
+   * Get the data type of tensor.
+   *
+   * @return the dtype of the tensor
+   */
+  virtual dtype type() const = 0;
+
+  /**
+   * Returns a tensor with elements cast as a particular type
+   *
+   * @param[in] the type to which to cast the tensor
+   * @return a tensor with element-wise cast to the new type
+   */
+  virtual Tensor astype(const dtype type) = 0;
+};
+
+} // namespace fl

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "flashlight/fl/tensor/TensorBase.h"
+
+#include <utility>
+
+#include "flashlight/fl/tensor/TensorAdapter.h"
+
+namespace fl {
+
+Tensor::Tensor(std::unique_ptr<TensorAdapterBase> adapter)
+    : impl_(std::move(adapter)) {}
+
+Tensor::~Tensor() {}
+
+Shape Tensor::shape() const {
+  return impl_->shape();
+}
+
+dtype Tensor::type() const {
+  return impl_->type();
+}
+
+Tensor Tensor::astype(const dtype type) {
+  return impl_->astype(type);
+}
+
+TensorBackend Tensor::backend() const {
+  return impl_->backend();
+}
+
+} // namespace fl

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <af/algorithm.h>
+#include <af/array.h>
+#include <af/statistics.h>
+
+#include "flashlight/fl/tensor/TensorAdapter.h"
+
+namespace fl {
+
+/**
+ * Tensor adapter for the ArrayFire tensor library. Maps operations expressed in
+ * Flashlight Tensors to ArrayFire
+ */
+class ArrayFireTensor : public TensorAdapterBase {
+  // The internal ArrayFire array handle
+  af::array array_;
+
+ public:
+  /**
+   * Constructs an ArrayFireTensor.
+   *
+   * Since af::arrays are refcounted, an instance of this class
+   * can only be created using arrays that are moved therein.
+   *
+   * Tensor operations occurring directly on this tensor's underlying af::array
+   * should not copy the array else take a performance penalty (via an internal
+   * copy if refcount is > 1 in some cases).
+   *
+   * @param[in] array&& construct a tensor from an ArrayFire array rvalue
+   * reference.
+   */
+  explicit ArrayFireTensor(af::array&& array);
+  ~ArrayFireTensor() override = default;
+
+  TensorBackend backend() const override {
+    return TensorBackend::ArrayFire;
+  }
+
+  Shape shape() const override;
+  dtype type() const override;
+  Tensor astype(const dtype type) override;
+
+  af::array& getHandle() {
+    return array_;
+  }
+
+  const af::array& getHandle() const {
+    return array_;
+  }
+};
+
+/**
+ * Gets an af::array from a Tensor. If the Tensor is not ArrayFire-backed,
+ * throws an exception
+ *
+ * @param[in] tensor the input tensor
+ * @return the array underying the Tensor
+ */
+af::array& toArray(const Tensor& tensor);
+
+/************************** Generic Reductions ***************************/
+/*
+ * TODO: move me to a singleton backend abstraction interface once available so
+ * generics can be properly handled.
+ */
+
+/**
+ * Compute the minimum value across all axes.
+ *
+ * @param[in] input the input along which to operate
+ * @return a scalar T containing the mim
+ *
+ */
+template <typename T>
+T amin(const Tensor& input) {
+  return af::min<T>(toArray(input));
+}
+
+/**
+ * Compute the maximum value across all axes.
+ *
+ * @param[in] input the input along which to operate
+ * @return a scalar T containing the max value
+ *
+ */
+template <typename T>
+T amax(const Tensor& input) {
+  return af::max<T>(toArray(input));
+}
+
+/**
+ * Sum of array over all axes.
+ *
+ * @param[in] input the input along which to operate
+ * @return a scalar T containing the sum
+ */
+template <typename T>
+T sum(const Tensor& input) {
+  return af::sum<T>(toArray(input));
+}
+
+/**
+ * Mean of array over all axes.
+ *
+ * @param[in] input the input along which to operate
+ * @return a scalar T containing the mean
+ */
+template <typename T>
+T mean(const Tensor& input) {
+  return af::mean<T>(toArray(input));
+}
+
+/**
+ * var of array over all axes.
+ *
+ * @param[in] input the input along which to operate
+ * @return a scalar T containing the var
+ */
+template <typename T>
+T var(const Tensor& input, bool bias = false) {
+  return af::var<T>(toArray(input), bias);
+}
+
+} // namespace fl

--- a/flashlight/fl/tensor/backend/af/CMakeLists.txt
+++ b/flashlight/fl/tensor/backend/af/CMakeLists.txt
@@ -41,10 +41,9 @@ target_link_libraries(flashlight PUBLIC ArrayFire::${FL_AF_BACKEND})
 target_sources(
   flashlight
   PRIVATE
+  ${CMAKE_CURRENT_LIST_DIR}/ArrayFireTensor.cpp
   ${CMAKE_CURRENT_LIST_DIR}/Compute.cpp
   ${CMAKE_CURRENT_LIST_DIR}/Random.cpp
   ${CMAKE_CURRENT_LIST_DIR}/ShapeBase.cpp
-  ${CMAKE_CURRENT_LIST_DIR}/TensorBase.cpp
   ${CMAKE_CURRENT_LIST_DIR}/Utils.cpp
-
   )

--- a/flashlight/fl/tensor/backend/af/Random.cpp
+++ b/flashlight/fl/tensor/backend/af/Random.cpp
@@ -7,6 +7,7 @@
 
 #include "flashlight/fl/tensor/Random.h"
 
+#include "flashlight/fl/tensor/backend/af/ArrayFireTensor.h"
 #include "flashlight/fl/tensor/backend/af/Utils.h"
 
 #include <af/random.h>
@@ -18,11 +19,13 @@ void setSeed(int seed) {
 }
 
 Tensor randn(const Shape& shape, dtype type) {
-  return Tensor(af::randn(detail::flToAfDims(shape), detail::flToAfType(type)));
+  return toTensor<ArrayFireTensor>(
+      af::randn(detail::flToAfDims(shape), detail::flToAfType(type)));
 }
 
 Tensor rand(const Shape& shape, dtype type) {
-  return Tensor(af::randu(detail::flToAfDims(shape), detail::flToAfType(type)));
+  return toTensor<ArrayFireTensor>(
+      af::randu(detail::flToAfDims(shape), detail::flToAfType(type)));
 }
 
 } // namespace fl


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/fairinternal/flashlight/pull/38

Change `Tensor` to follow a [pimpl](https://en.cppreference.com/w/cpp/language/pimpl) where implementations visit `Tensor`. The base is `Tensor`, and the implementations inherit from `TensorAdapterBase`. More concretely:

```
// forward decl
class TensorAdapterBase;

class Tensor {
  std::unique_ptr<TensorAdapterBase> impl_; // the backend implementation
 public:
  // public methods in tensors, e.g.
  const Shape& shape() const;
  // ...
};

```

`TensorAdapterBase` contains the implementation details for a particular backend, e.g. backends implement the following interface:

```
class TensorAdapterBase {
 public:
  // ...
  const Shape& shape() const = 0;
};
```

The implementations in `Tensor` are dispatched accordingly:

```
const Shape& Tensor::shape() const {
  // reminder: impl_ is stored on the tensor
  return impl_->shape();
}
```

To implement specific backends, users simply derive from `TensorAdapterBase` and define their methods as needed, for example:

```
class ArrayFireTensor: public TensorAdapterBase {
  af::array array_; // handle to implementation-specific data
 public:
  // ...
  fl::dtype type() const {
    return afToFlType(array_.type());
  }
};
```

Differential Revision: D28458027

