### PR TITLE
Introduce TensorBackend

### DIFF
--- a/flashlight/fl/tensor/TensorAdapter.cpp
+++ b/flashlight/fl/tensor/TensorAdapter.cpp
@@ -10,6 +10,9 @@
 #include <memory>
 #include <stdexcept>
 
+#include "flashlight/fl/tensor/TensorBackend.h"
+#include "flashlight/fl/tensor/TensorBase.h"
+
 #if FL_USE_ARRAYFIRE
 #include "flashlight/fl/tensor/backend/af/ArrayFireTensor.h"
 #endif

--- a/flashlight/fl/tensor/TensorAdapter.h
+++ b/flashlight/fl/tensor/TensorAdapter.h
@@ -41,9 +41,16 @@ class TensorAdapterBase {
   /**
    * Gets the tensor's associated backend.
    *
-   * @return TensorBackend enum associated with the backend
+   * @return TensorBackendType enum associated with the backend
    */
-  virtual TensorBackend backend() const = 0;
+  virtual TensorBackendType backendType() const = 0;
+
+  /**
+   * Gets the backend for a tensor with this adapter implementation.
+   *
+   * @return the TensorBackend instance backing this particular tensor.
+   */
+  virtual TensorBackend& backend() const = 0;
 
   /**
    * Get the shape of a tensor.

--- a/flashlight/fl/tensor/TensorBackend.h
+++ b/flashlight/fl/tensor/TensorBackend.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "flashlight/fl/tensor/TensorBase.h"
+
+namespace fl {
+
+/**
+ * A Tensor backend that can be used to store global state associated with a
+ * particular tensor implementation.
+ *
+ * This abstraction facilitates adherence to the implementation requirements for
+ * global operators that operate on tensors (e.g. those functions that are not
+ * members of `fl::Tensor`). The interface defines here implicitly defines the
+ * required functionality.
+ *
+ * Flashlight Tensors dispatch to their corresponding backends using
+ * typeToBackend (see below) to grab the correct singleton.
+ */
+class TensorBackend {
+ public:
+  TensorBackend() = default;
+  virtual ~TensorBackend() = default;
+
+  /* --------------------------- Tensor Operators ---------------------------
+   * For operator documentation and expected behavior, see TensorBase.h.
+   */
+
+  /************************** Unary Operators ***************************/
+  virtual Tensor exp(const Tensor& tensor) = 0;
+  virtual Tensor log(const Tensor& tensor) = 0;
+};
+
+} // namespace fl

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -10,6 +10,7 @@
 #include <utility>
 
 #include "flashlight/fl/tensor/TensorAdapter.h"
+#include "flashlight/fl/tensor/TensorBackend.h"
 
 namespace fl {
 
@@ -32,8 +33,23 @@ Tensor Tensor::astype(const dtype type) {
   return impl_->astype(type);
 }
 
-TensorBackend Tensor::backend() const {
+TensorBackendType Tensor::backendType() const {
+  return impl_->backendType();
+}
+
+TensorBackend& Tensor::backend() const {
   return impl_->backend();
+}
+
+/* --------------------------- Tensor Operators --------------------------- */
+
+/************************** Unary Operators ***************************/
+Tensor exp(const Tensor& tensor) {
+  return tensor.backend().exp(tensor);
+}
+
+Tensor log(const Tensor& tensor) {
+  return tensor.backend().log(tensor);
 }
 
 } // namespace fl

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -18,10 +18,13 @@ namespace fl {
 /**
  * Enum for various tensor backends.
  */
-enum class TensorBackend { ArrayFire };
+enum class TensorBackendType { ArrayFire };
 
 // Forward declaration - see TensorAdapter.h
 class TensorAdapterBase;
+
+// Forward declaration - see TensorBackend.h
+class TensorBackend;
 
 /**
  * A Tensor on which computation can be performed.
@@ -37,7 +40,7 @@ class TensorAdapterBase;
  * frequently and is not yet stable.
  */
 class Tensor {
-  // The backend adapter for the tensor
+  // The tensor adapter for the tensor
   std::unique_ptr<TensorAdapterBase> impl_;
 
  public:
@@ -76,7 +79,7 @@ class Tensor {
    *
    * @return the backend in question
    */
-  TensorBackend backend() const;
+  TensorBackendType backendType() const;
 
   /**
    * Gets the underlying tensor adapter implementation.
@@ -87,6 +90,13 @@ class Tensor {
   T& getAdapter() const {
     return *static_cast<T*>(impl_.get());
   }
+
+  /**
+   * Return the TensorBackend associated with this tensor.
+   *
+   * @return a TensorBackend.
+   */
+  TensorBackend& backend() const;
 };
 
 /******************** Tensor Creation Functions ********************/

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "flashlight/fl/tensor/backend/af/ArrayFireBackend.h"
+
+#include <af/arith.h>
+#include <af/device.h>
+#include <af/exception.h>
+
+#include "flashlight/fl/tensor/backend/af/ArrayFireTensor.h"
+
+/*
+ * TODO: this is duplicative - remove this from flashlight/fl/common/Utils.h
+ * once the rest of the proj depends on headers here.
+ */
+#define AF_CHECK(fn)                                                          \
+  do {                                                                        \
+    af_err __err = fn;                                                        \
+    if (__err == AF_SUCCESS) {                                                \
+      break;                                                                  \
+    }                                                                         \
+    throw af::exception(                                                      \
+        "ArrayFire error: ", __PRETTY_FUNCTION__, __FILE__, __LINE__, __err); \
+  } while (0)
+
+namespace fl {
+
+ArrayFireBackend::ArrayFireBackend() {
+  AF_CHECK(af_init());
+}
+
+ArrayFireBackend& ArrayFireBackend::getInstance() {
+  static ArrayFireBackend instance;
+  return instance;
+}
+
+Tensor ArrayFireBackend::exp(const Tensor& tensor) {
+  return toTensor<ArrayFireTensor>(af::exp(toArray(tensor)));
+}
+
+Tensor ArrayFireBackend::log(const Tensor& tensor) {
+  return toTensor<ArrayFireTensor>(af::log(toArray(tensor)));
+}
+
+} // namespace fl

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "flashlight/fl/tensor/TensorBackend.h"
+
+namespace fl {
+
+/**
+ * A tensor backend implementation of the ArrayFire tensor library.
+ *
+ * Given that ArrayFire has an internal DeviceManager singleton to manage its
+ * global state, nothing is stored here as those internals are opaquely handled.
+ * This class simply dispatches operations on global tensor functions to their
+ * ArrayFire counterparts.
+ */
+class ArrayFireBackend : public TensorBackend {
+  // TODO: consolidate the ArrayFire memory manager here so its global state can
+  // be stored/we can reduce the number of singletons.
+ public:
+  ArrayFireBackend();
+  ~ArrayFireBackend() override = default;
+
+  static ArrayFireBackend& getInstance();
+
+  Tensor exp(const Tensor& tensor) override;
+  Tensor log(const Tensor& tensor) override;
+};
+
+} // namespace fl

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
@@ -12,6 +12,7 @@
 #include <utility>
 
 #include "flashlight/fl/tensor/TensorBase.h"
+#include "flashlight/fl/tensor/backend/af/ArrayFireBackend.h"
 #include "flashlight/fl/tensor/backend/af/Utils.h"
 
 #include <af/algorithm.h>
@@ -44,8 +45,13 @@ ArrayFireTensor::ArrayFireTensor(af::array&& array)
 
 ArrayFireTensor::ArrayFireTensor() {}
 
-TensorBackend ArrayFireTensor::backend() const {
-  return TensorBackend::ArrayFire;
+TensorBackendType ArrayFireTensor::backendType() const {
+  return TensorBackendType::ArrayFire;
+}
+
+TensorBackend& ArrayFireTensor::backend() const {
+  // The ArrayFire backend has a single ArrayFireBackend instance per process.
+  return ::fl::ArrayFireBackend::getInstance();
 }
 
 const Shape& ArrayFireTensor::shape() {
@@ -72,7 +78,7 @@ const af::array& ArrayFireTensor::getHandle() const {
 }
 
 af::array& toArray(const Tensor& tensor) {
-  if (tensor.backend() != TensorBackend::ArrayFire) {
+  if (tensor.backendType() != TensorBackendType::ArrayFire) {
     throw std::invalid_argument("toArray: tensor is not ArrayFire-backed");
   }
   return tensor.getAdapter<ArrayFireTensor>().getHandle();
@@ -111,14 +117,6 @@ Tensor negative(const Tensor& tensor) {
 
 Tensor logicalNot(const Tensor& tensor) {
   return toTensor<ArrayFireTensor>(!toArray(tensor));
-}
-
-Tensor exp(const Tensor& tensor) {
-  return toTensor<ArrayFireTensor>(af::exp(toArray(tensor)));
-}
-
-Tensor log(const Tensor& tensor) {
-  return toTensor<ArrayFireTensor>(af::log(toArray(tensor)));
 }
 
 Tensor log1p(const Tensor& tensor) {

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
@@ -61,7 +61,8 @@ class ArrayFireTensor : public TensorAdapterBase {
   const af::array& getHandle() const;
 
   ~ArrayFireTensor() override = default;
-  TensorBackend backend() const override;
+  TensorBackendType backendType() const override;
+  TensorBackend& backend() const override;
   const Shape& shape() override;
   dtype type() const override;
   Tensor astype(const dtype type) override;

--- a/flashlight/fl/tensor/backend/af/CMakeLists.txt
+++ b/flashlight/fl/tensor/backend/af/CMakeLists.txt
@@ -41,6 +41,7 @@ target_link_libraries(flashlight PUBLIC ArrayFire::${FL_AF_BACKEND})
 target_sources(
   flashlight
   PRIVATE
+  ${CMAKE_CURRENT_LIST_DIR}/ArrayFireBackend.cpp
   ${CMAKE_CURRENT_LIST_DIR}/ArrayFireTensor.cpp
   ${CMAKE_CURRENT_LIST_DIR}/Compute.cpp
   ${CMAKE_CURRENT_LIST_DIR}/Random.cpp

--- a/flashlight/fl/tensor/tensor.h
+++ b/flashlight/fl/tensor/tensor.h
@@ -9,3 +9,6 @@
 
 #include "flashlight/fl/tensor/Compute.h"
 #include "flashlight/fl/tensor/Random.h"
+#include "flashlight/fl/tensor/Shape.h"
+#include "flashlight/fl/tensor/TensorBase.h"
+#include "flashlight/fl/tensor/Types.h"

--- a/flashlight/fl/test/tensor/TensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/TensorBaseTest.cpp
@@ -53,7 +53,7 @@ bool allClose(
 
 TEST(TensorBaseTest, DefaultBackend) {
   Tensor t;
-  ASSERT_EQ(t.backend(), TensorBackend::ArrayFire);
+  ASSERT_EQ(t.backendType(), TensorBackendType::ArrayFire);
 }
 
 TEST(TensorBaseTest, AfRefCountBasic) {


### PR DESCRIPTION
Summary:
Adds a `TensorBackend` abstraction. This allows the following:
- Global functions that operate on tensors (and aren't members of `fl::Tensor`) need to call into corresponding implementations based on the backend of the tensor operands.
- Tensor backends need to standardize their implementations and implement certain operators. Enforcing this with missing symbols in a global function API isn't really feasible; using pure virtual functions accomplishes this more easily
- Facilitates storing global state associated with a particular tensor backend (e.g. a )

The dispatch pattern for global tensor operations is as follows:
1. A global function operating on a tensor is called, e.g. `fl::log(tensor)`.
2. `fl::Tensor::backend()` is used to ascertain the `TensorBackend` instance for that given tensor based on its `TensorBackendType`
3. the `fl::TensorBackend::log()` function is dispatched to for the tensor's backing `TensorBackend`.

While this adds an additional layer of runtime polymorphism, the overhead is minimal; a single `switch` is required to find the `TensorBackend` per tensor (branch prediction should be solid for 99% of cases) and one virtual function call is required to dispatch to the correct function implementation.

`s/TensorBackend/TensorBackendType/g`

I've moved `log` and `exp` as sample operators so far; will move other operators in a future change — this is to get input on the design.

Differential Revision: D28659887

