### PR TITLE
Move most operators to fl::TensorBackend

### DIFF
--- a/flashlight/fl/tensor/CMakeLists.txt
+++ b/flashlight/fl/tensor/CMakeLists.txt
@@ -16,7 +16,8 @@ target_sources(
   flashlight
   PRIVATE
   ${CMAKE_CURRENT_LIST_DIR}/Shape.cpp
-  ${CMAKE_CURRENT_LIST_DIR}/TensorBase.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/TensorBackend.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/TensorBase.cpp  
   ${CMAKE_CURRENT_LIST_DIR}/TensorAdapter.cpp
   ${CMAKE_CURRENT_LIST_DIR}/Types.cpp
 )

--- a/flashlight/fl/tensor/TensorAdapter.cpp
+++ b/flashlight/fl/tensor/TensorAdapter.cpp
@@ -10,6 +10,9 @@
 #include <memory>
 #include <stdexcept>
 
+#include "flashlight/fl/tensor/TensorBackend.h"
+#include "flashlight/fl/tensor/TensorBase.h"
+
 #if FL_USE_ARRAYFIRE
 #include "flashlight/fl/tensor/backend/af/ArrayFireTensor.h"
 #endif

--- a/flashlight/fl/tensor/TensorAdapter.h
+++ b/flashlight/fl/tensor/TensorAdapter.h
@@ -41,9 +41,16 @@ class TensorAdapterBase {
   /**
    * Gets the tensor's associated backend.
    *
-   * @return TensorBackend enum associated with the backend
+   * @return TensorBackendType enum associated with the backend
    */
-  virtual TensorBackend backend() const = 0;
+  virtual TensorBackendType backendType() const = 0;
+
+  /**
+   * Gets the backend for a tensor with this adapter implementation.
+   *
+   * @return the TensorBackend instance backing this particular tensor.
+   */
+  virtual TensorBackend& backend() const = 0;
 
   /**
    * Get the shape of a tensor.

--- a/flashlight/fl/tensor/TensorBackend.cpp
+++ b/flashlight/fl/tensor/TensorBackend.cpp
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "flashlight/fl/tensor/TensorBackend.h"
+
+namespace fl {
+namespace detail {
+bool areBackendsEqual(const Tensor& a, const Tensor& b) {
+  return a.backendType() == b.backendType();
+}
+
+} // namespace detail
+} // namespace fl

--- a/flashlight/fl/tensor/TensorBackend.h
+++ b/flashlight/fl/tensor/TensorBackend.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "flashlight/fl/tensor/TensorBase.h"
+
+namespace fl {
+
+/**
+ * A Tensor backend that can be used to store global state associated with a
+ * particular tensor implementation.
+ *
+ * This abstraction facilitates adherence to the implementation requirements for
+ * global operators that operate on tensors (e.g. those functions that are not
+ * members of `fl::Tensor`). The interface defines here implicitly defines the
+ * required functionality.
+ *
+ * Flashlight Tensors dispatch to their corresponding backends using
+ * typeToBackend (see below) to grab the correct singleton.
+ */
+class TensorBackend {
+ public:
+  TensorBackend() = default;
+  virtual ~TensorBackend() = default;
+
+  /* --------------------------- Tensor Operators ---------------------------
+   * For operator documentation and expected behavior, see TensorBase.h.
+   */
+
+  /************************** Unary Operators ***************************/
+  virtual Tensor exp(const Tensor& tensor) = 0;
+  virtual Tensor log(const Tensor& tensor) = 0;
+};
+
+} // namespace fl

--- a/flashlight/fl/tensor/TensorBackend.h
+++ b/flashlight/fl/tensor/TensorBackend.h
@@ -17,11 +17,11 @@ namespace fl {
  *
  * This abstraction facilitates adherence to the implementation requirements for
  * global operators that operate on tensors (e.g. those functions that are not
- * members of `fl::Tensor`). The interface defines here implicitly defines the
- * required functionality.
+ * members of `fl::Tensor`).
  *
  * Flashlight Tensors dispatch to their corresponding backends using
- * typeToBackend (see below) to grab the correct singleton.
+ * fl::Tensor::backend() --> typeToBackend (see below) to grab the correct
+ * singleton.
  */
 class TensorBackend {
  public:
@@ -31,10 +31,55 @@ class TensorBackend {
   /* --------------------------- Tensor Operators ---------------------------
    * For operator documentation and expected behavior, see TensorBase.h.
    */
-
   /************************** Unary Operators ***************************/
   virtual Tensor exp(const Tensor& tensor) = 0;
   virtual Tensor log(const Tensor& tensor) = 0;
+  virtual Tensor negative(const Tensor& tensor) = 0;
+  virtual Tensor logicalNot(const Tensor& tensor) = 0;
+  virtual Tensor log1p(const Tensor& tensor) = 0;
+  virtual Tensor sin(const Tensor& tensor) = 0;
+  virtual Tensor cos(const Tensor& tensor) = 0;
+  virtual Tensor sqrt(const Tensor& tensor) = 0;
+  virtual Tensor tanh(const Tensor& tensor) = 0;
+  virtual Tensor absolute(const Tensor& tensor) = 0;
+  virtual Tensor
+  clip(const Tensor& tensor, const Tensor& low, const Tensor& high) = 0;
+  virtual Tensor isnan(const Tensor& tensor) = 0;
+
+  /************************** Binary Operators ***************************/
+  virtual Tensor minimum(const Tensor& lhs, const Tensor& rhs) = 0;
+  virtual Tensor maximum(const Tensor& lhs, const Tensor& rhs) = 0;
+  virtual Tensor power(const Tensor& lhs, const Tensor& rhs) = 0;
+
+  /************************** Reductions ***************************/
+  virtual Tensor amin(const Tensor& input, const std::vector<int>& axes) = 0;
+  virtual Tensor amax(const Tensor& input, const std::vector<int>& axes) = 0;
+  virtual Tensor sum(const Tensor& input, const std::vector<int>& axes) = 0;
+  virtual Tensor mean(const Tensor& input, const std::vector<int>& axes) = 0;
+  virtual Tensor
+  var(const Tensor& input, const std::vector<int>& axes, bool bias) = 0;
+  virtual double norm(const Tensor& input) = 0;
 };
 
+namespace detail {
+
+/**
+ * Compare the backends of two tensors.
+ *
+ * @return true if the backends of both tensors are the same, else false.
+ */
+bool areBackendsEqual(const Tensor& a, const Tensor& b);
+
+/**
+ * Compare the backends of multiple tensors.
+ *
+ * @return true if all tensors' backends are the same, false otherwise.
+ */
+template <typename... Args>
+bool areBackendsEqual(const Tensor& a, const Tensor& b, const Args&... args) {
+  return areBackendsEqual(a, b) && areBackendsEqual(a, args...) &&
+      areBackendsEqual(b, args...);
+}
+
+} // namespace detail
 } // namespace fl

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -10,6 +10,7 @@
 #include <utility>
 
 #include "flashlight/fl/tensor/TensorAdapter.h"
+#include "flashlight/fl/tensor/TensorBackend.h"
 
 namespace fl {
 
@@ -32,8 +33,23 @@ Tensor Tensor::astype(const dtype type) {
   return impl_->astype(type);
 }
 
-TensorBackend Tensor::backend() const {
+TensorBackendType Tensor::backendType() const {
+  return impl_->backendType();
+}
+
+TensorBackend& Tensor::backend() const {
   return impl_->backend();
+}
+
+/* --------------------------- Tensor Operators --------------------------- */
+
+/************************** Unary Operators ***************************/
+Tensor exp(const Tensor& tensor) {
+  return tensor.backend().exp(tensor);
+}
+
+Tensor log(const Tensor& tensor) {
+  return tensor.backend().log(tensor);
 }
 
 } // namespace fl

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -7,10 +7,18 @@
 
 #include "flashlight/fl/tensor/TensorBase.h"
 
+#include <stdexcept>
 #include <utility>
 
 #include "flashlight/fl/tensor/TensorAdapter.h"
 #include "flashlight/fl/tensor/TensorBackend.h"
+
+#define FL_TENSOR_BACKENDS_MATCH_CHECK(...)             \
+  if (!detail::areBackendsEqual(__VA_ARGS__)) {         \
+    throw std::invalid_argument(                        \
+        std::string(__func__) +                         \
+        " called with tensors of different backends."); \
+  }
 
 namespace fl {
 
@@ -50,6 +58,118 @@ Tensor exp(const Tensor& tensor) {
 
 Tensor log(const Tensor& tensor) {
   return tensor.backend().log(tensor);
+}
+
+Tensor negative(const Tensor& tensor) {
+  return tensor.backend().negative(tensor);
+}
+
+Tensor logicalNot(const Tensor& tensor) {
+  return tensor.backend().logicalNot(tensor);
+}
+
+Tensor log1p(const Tensor& tensor) {
+  return tensor.backend().log1p(tensor);
+}
+
+Tensor sin(const Tensor& tensor) {
+  return tensor.backend().sin(tensor);
+}
+
+Tensor cos(const Tensor& tensor) {
+  return tensor.backend().cos(tensor);
+}
+
+Tensor sqrt(const Tensor& tensor) {
+  return tensor.backend().sqrt(tensor);
+}
+
+Tensor tanh(const Tensor& tensor) {
+  return tensor.backend().tanh(tensor);
+}
+
+Tensor absolute(const Tensor& tensor) {
+  return tensor.backend().absolute(tensor);
+}
+
+Tensor clip(const Tensor& tensor, const Tensor& low, const Tensor& high) {
+  FL_TENSOR_BACKENDS_MATCH_CHECK(tensor, low, high);
+  return tensor.backend().clip(tensor, low, high);
+}
+
+Tensor clip(const Tensor& tensor, const Tensor& low, const double& high) {
+  return clip(tensor, low, full(tensor.shape(), high));
+}
+
+Tensor clip(const Tensor& tensor, const double& low, const Tensor& high) {
+  return clip(tensor, full(tensor.shape(), low), high);
+}
+
+Tensor clip(const Tensor& tensor, const double& low, const double& high) {
+  return clip(tensor, full(tensor.shape(), low), full(tensor.shape(), high));
+}
+
+Tensor isnan(const Tensor& tensor) {
+  return tensor.backend().isnan(tensor);
+}
+
+/************************** Binary Operators ***************************/
+
+Tensor minimum(const Tensor& lhs, const Tensor& rhs) {
+  FL_TENSOR_BACKENDS_MATCH_CHECK(lhs, rhs);
+  return lhs.backend().minimum(lhs, rhs);
+}
+
+Tensor maximum(const Tensor& lhs, const Tensor& rhs) {
+  FL_TENSOR_BACKENDS_MATCH_CHECK(lhs, rhs);
+  return lhs.backend().maximum(lhs, rhs);
+}
+
+Tensor minimum(const Tensor& lhs, const double& rhs) {
+  return minimum(lhs, full(lhs.shape(), rhs));
+}
+
+Tensor minimum(const double& lhs, const Tensor& rhs) {
+  return minimum(full(rhs.shape(), lhs), rhs);
+}
+
+Tensor maximum(const Tensor& lhs, const double& rhs) {
+  return maximum(lhs, full(lhs.shape(), rhs));
+}
+
+Tensor maximum(const double& lhs, const Tensor& rhs) {
+  return maximum(full(rhs.shape(), lhs), rhs);
+}
+
+Tensor power(const Tensor& lhs, const Tensor& rhs) {
+  FL_TENSOR_BACKENDS_MATCH_CHECK(lhs, rhs);
+  return lhs.backend().power(lhs, rhs);
+}
+
+/************************** Reductions ***************************/
+
+Tensor amin(const Tensor& input, const std::vector<int>& axes) {
+  return input.backend().amin(input, axes);
+}
+
+Tensor amax(const Tensor& input, const std::vector<int>& axes) {
+  return input.backend().amax(input, axes);
+}
+
+Tensor sum(const Tensor& input, const std::vector<int>& axes) {
+  return input.backend().sum(input, axes);
+}
+
+Tensor mean(const Tensor& input, const std::vector<int>& axes) {
+  return input.backend().mean(input, axes);
+}
+
+Tensor var(const Tensor& input, const std::vector<int>& axes, bool bias) {
+  return input.backend().var(input, axes, bias);
+}
+
+double norm(const Tensor& input) {
+  return input.backend().norm(input);
 }
 
 } // namespace fl

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -18,10 +18,13 @@ namespace fl {
 /**
  * Enum for various tensor backends.
  */
-enum class TensorBackend { ArrayFire };
+enum class TensorBackendType { ArrayFire };
 
 // Forward declaration - see TensorAdapter.h
 class TensorAdapterBase;
+
+// Forward declaration - see TensorBackend.h
+class TensorBackend;
 
 /**
  * A Tensor on which computation can be performed.
@@ -37,7 +40,7 @@ class TensorAdapterBase;
  * frequently and is not yet stable.
  */
 class Tensor {
-  // The backend adapter for the tensor
+  // The tensor adapter for the tensor
   std::unique_ptr<TensorAdapterBase> impl_;
 
  public:
@@ -76,7 +79,7 @@ class Tensor {
    *
    * @return the backend in question
    */
-  TensorBackend backend() const;
+  TensorBackendType backendType() const;
 
   /**
    * Gets the underlying tensor adapter implementation.
@@ -87,6 +90,13 @@ class Tensor {
   T& getAdapter() const {
     return *static_cast<T*>(impl_.get());
   }
+
+  /**
+   * Return the TensorBackend associated with this tensor.
+   *
+   * @return a TensorBackend.
+   */
+  TensorBackend& backend() const;
 };
 
 /******************** Tensor Creation Functions ********************/

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "flashlight/fl/tensor/backend/af/ArrayFireBackend.h"
+
+#include <af/arith.h>
+#include <af/device.h>
+#include <af/exception.h>
+
+#include "flashlight/fl/tensor/backend/af/ArrayFireTensor.h"
+
+/*
+ * TODO: this is duplicative - remove this from flashlight/fl/common/Utils.h
+ * once the rest of the proj depends on headers here.
+ */
+#define AF_CHECK(fn)                                                          \
+  do {                                                                        \
+    af_err __err = fn;                                                        \
+    if (__err == AF_SUCCESS) {                                                \
+      break;                                                                  \
+    }                                                                         \
+    throw af::exception(                                                      \
+        "ArrayFire error: ", __PRETTY_FUNCTION__, __FILE__, __LINE__, __err); \
+  } while (0)
+
+namespace fl {
+
+ArrayFireBackend::ArrayFireBackend() {
+  AF_CHECK(af_init());
+}
+
+ArrayFireBackend& ArrayFireBackend::getInstance() {
+  static ArrayFireBackend instance;
+  return instance;
+}
+
+Tensor ArrayFireBackend::exp(const Tensor& tensor) {
+  return toTensor<ArrayFireTensor>(af::exp(toArray(tensor)));
+}
+
+Tensor ArrayFireBackend::log(const Tensor& tensor) {
+  return toTensor<ArrayFireTensor>(af::log(toArray(tensor)));
+}
+
+} // namespace fl

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
@@ -7,9 +7,13 @@
 
 #include "flashlight/fl/tensor/backend/af/ArrayFireBackend.h"
 
+#include <af/algorithm.h>
 #include <af/arith.h>
+#include <af/data.h>
 #include <af/device.h>
 #include <af/exception.h>
+#include <af/gfor.h>
+#include <af/lapack.h>
 
 #include "flashlight/fl/tensor/backend/af/ArrayFireTensor.h"
 
@@ -27,6 +31,23 @@
         "ArrayFire error: ", __PRETTY_FUNCTION__, __FILE__, __LINE__, __err); \
   } while (0)
 
+namespace {
+
+typedef af::array (*reduceFunc_t)(const af::array&, const int);
+
+af::array afReduceAxes(
+    const af::array& input,
+    const std::vector<int>& axes,
+    reduceFunc_t func) {
+  auto arr = input;
+  for (int dim : axes) {
+    arr = func(arr, dim);
+  }
+  return arr;
+}
+
+} // namespace
+
 namespace fl {
 
 ArrayFireBackend::ArrayFireBackend() {
@@ -38,12 +59,137 @@ ArrayFireBackend& ArrayFireBackend::getInstance() {
   return instance;
 }
 
+/* --------------------------- Tensor Operators --------------------------- */
+
+/************************** Unary Operators ***************************/
+
 Tensor ArrayFireBackend::exp(const Tensor& tensor) {
   return toTensor<ArrayFireTensor>(af::exp(toArray(tensor)));
 }
 
 Tensor ArrayFireBackend::log(const Tensor& tensor) {
   return toTensor<ArrayFireTensor>(af::log(toArray(tensor)));
+}
+
+Tensor ArrayFireBackend::negative(const Tensor& tensor) {
+  return toTensor<ArrayFireTensor>(-toArray(tensor));
+}
+
+Tensor ArrayFireBackend::logicalNot(const Tensor& tensor) {
+  return toTensor<ArrayFireTensor>(!toArray(tensor));
+}
+
+Tensor ArrayFireBackend::log1p(const Tensor& tensor) {
+  return toTensor<ArrayFireTensor>(af::log1p(toArray(tensor)));
+}
+
+Tensor ArrayFireBackend::sin(const Tensor& tensor) {
+  return toTensor<ArrayFireTensor>(af::sin(toArray(tensor)));
+}
+
+Tensor ArrayFireBackend::cos(const Tensor& tensor) {
+  return toTensor<ArrayFireTensor>(af::cos(toArray(tensor)));
+}
+
+Tensor ArrayFireBackend::sqrt(const Tensor& tensor) {
+  return toTensor<ArrayFireTensor>(af::sqrt(toArray(tensor)));
+}
+
+Tensor ArrayFireBackend::tanh(const Tensor& tensor) {
+  return toTensor<ArrayFireTensor>(af::tanh(toArray(tensor)));
+}
+
+Tensor ArrayFireBackend::absolute(const Tensor& tensor) {
+  return toTensor<ArrayFireTensor>(af::abs(toArray(tensor)));
+}
+
+Tensor ArrayFireBackend::clip(
+    const Tensor& tensor,
+    const Tensor& low,
+    const Tensor& high) {
+  return toTensor<ArrayFireTensor>(
+      af::clamp(toArray(tensor), toArray(low), toArray(high)));
+}
+
+Tensor ArrayFireBackend::isnan(const Tensor& tensor) {
+  return toTensor<ArrayFireTensor>(af::isNaN(toArray(tensor)));
+}
+
+/************************** Binary Operators ***************************/
+
+Tensor ArrayFireBackend::minimum(const Tensor& lhs, const Tensor& rhs) {
+  return toTensor<ArrayFireTensor>(af::min(toArray(lhs), toArray(rhs)));
+}
+
+Tensor ArrayFireBackend::maximum(const Tensor& lhs, const Tensor& rhs) {
+  return toTensor<ArrayFireTensor>(af::max(toArray(lhs), toArray(rhs)));
+}
+
+Tensor ArrayFireBackend::power(const Tensor& lhs, const Tensor& rhs) {
+  return toTensor<ArrayFireTensor>(af::pow(toArray(lhs), toArray(rhs)));
+}
+
+/************************** Reductions ***************************/
+
+Tensor ArrayFireBackend::amin(
+    const Tensor& input,
+    const std::vector<int>& axes) {
+  return toTensor<ArrayFireTensor>(afReduceAxes(toArray(input), axes, af::min));
+}
+
+Tensor ArrayFireBackend::amax(
+    const Tensor& input,
+    const std::vector<int>& axes) {
+  return toTensor<ArrayFireTensor>(afReduceAxes(toArray(input), axes, af::max));
+}
+
+Tensor ArrayFireBackend::sum(
+    const Tensor& input,
+    const std::vector<int>& axes) {
+  return toTensor<ArrayFireTensor>(afReduceAxes(toArray(input), axes, af::sum));
+}
+
+Tensor ArrayFireBackend::mean(
+    const Tensor& input,
+    const std::vector<int>& axes) {
+  // Cannot use afReduceAxes because sum uses dim instead of int
+  auto arr = toArray(input);
+  for (int dim : axes) {
+    arr = af::mean(arr, dim);
+  }
+  return toTensor<ArrayFireTensor>(std::move(arr));
+}
+
+Tensor ArrayFireBackend::var(
+    const Tensor& input,
+    const std::vector<int>& axes,
+    bool bias) {
+  // Use arrayfire default for one dimension which may be optimized
+  auto& arr = toArray(input);
+  if (axes.size() == 1) {
+    return toTensor<ArrayFireTensor>(af::var(arr, bias, axes[0]));
+  }
+  auto meanArr = mean(input, axes);
+  // TODO Replace when we have batchFunc for fl::Tensor
+  auto x = af::batchFunc(arr, toArray(meanArr), af::operator-);
+  x = af::pow(x, 2);
+  x = afReduceAxes(x, axes, af::sum);
+
+  int denominator = 1;
+  auto dims = toArray(input).dims();
+  for (auto dim : axes) {
+    denominator *= dims[dim];
+  }
+  if (bias) {
+    denominator--;
+  }
+
+  x = x / denominator;
+  return toTensor<ArrayFireTensor>(std::move(x));
+}
+
+double ArrayFireBackend::norm(const Tensor& input) {
+  return af::norm(toArray(input));
 }
 
 } // namespace fl

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "flashlight/fl/tensor/TensorBackend.h"
+
+namespace fl {
+
+/**
+ * A tensor backend implementation of the ArrayFire tensor library.
+ *
+ * Given that ArrayFire has an internal DeviceManager singleton to manage its
+ * global state, nothing is stored here as those internals are opaquely handled.
+ * This class simply dispatches operations on global tensor functions to their
+ * ArrayFire counterparts.
+ */
+class ArrayFireBackend : public TensorBackend {
+  // TODO: consolidate the ArrayFire memory manager here so its global state can
+  // be stored/we can reduce the number of singletons.
+ public:
+  ArrayFireBackend();
+  ~ArrayFireBackend() override = default;
+
+  static ArrayFireBackend& getInstance();
+
+  Tensor exp(const Tensor& tensor) override;
+  Tensor log(const Tensor& tensor) override;
+};
+
+} // namespace fl

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
@@ -26,8 +26,36 @@ class ArrayFireBackend : public TensorBackend {
 
   static ArrayFireBackend& getInstance();
 
+  /* --------------------------- Tensor Operators --------------------------- */
+
+  /************************** Unary Operators ***************************/
   Tensor exp(const Tensor& tensor) override;
   Tensor log(const Tensor& tensor) override;
+  Tensor negative(const Tensor& tensor) override;
+  Tensor logicalNot(const Tensor& tensor) override;
+  Tensor log1p(const Tensor& tensor) override;
+  Tensor sin(const Tensor& tensor) override;
+  Tensor cos(const Tensor& tensor) override;
+  Tensor sqrt(const Tensor& tensor) override;
+  Tensor tanh(const Tensor& tensor) override;
+  Tensor absolute(const Tensor& tensor) override;
+  Tensor clip(const Tensor& tensor, const Tensor& low, const Tensor& high)
+      override;
+  Tensor isnan(const Tensor& tensor) override;
+
+  /************************** Binary Operators ***************************/
+  Tensor minimum(const Tensor& lhs, const Tensor& rhs) override;
+  Tensor maximum(const Tensor& lhs, const Tensor& rhs) override;
+  Tensor power(const Tensor& lhs, const Tensor& rhs) override;
+
+  /************************** Reductions ***************************/
+  Tensor amin(const Tensor& input, const std::vector<int>& axes) override;
+  Tensor amax(const Tensor& input, const std::vector<int>& axes) override;
+  Tensor sum(const Tensor& input, const std::vector<int>& axes) override;
+  Tensor mean(const Tensor& input, const std::vector<int>& axes) override;
+  Tensor var(const Tensor& input, const std::vector<int>& axes, bool bias)
+      override;
+  double norm(const Tensor& input) override;
 };
 
 } // namespace fl

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
@@ -12,6 +12,7 @@
 #include <utility>
 
 #include "flashlight/fl/tensor/TensorBase.h"
+#include "flashlight/fl/tensor/backend/af/ArrayFireBackend.h"
 #include "flashlight/fl/tensor/backend/af/Utils.h"
 
 #include <af/algorithm.h>
@@ -44,8 +45,13 @@ ArrayFireTensor::ArrayFireTensor(af::array&& array)
 
 ArrayFireTensor::ArrayFireTensor() {}
 
-TensorBackend ArrayFireTensor::backend() const {
-  return TensorBackend::ArrayFire;
+TensorBackendType ArrayFireTensor::backendType() const {
+  return TensorBackendType::ArrayFire;
+}
+
+TensorBackend& ArrayFireTensor::backend() const {
+  // The ArrayFire backend has a single ArrayFireBackend instance per process.
+  return ::fl::ArrayFireBackend::getInstance();
 }
 
 const Shape& ArrayFireTensor::shape() {
@@ -72,7 +78,7 @@ const af::array& ArrayFireTensor::getHandle() const {
 }
 
 af::array& toArray(const Tensor& tensor) {
-  if (tensor.backend() != TensorBackend::ArrayFire) {
+  if (tensor.backendType() != TensorBackendType::ArrayFire) {
     throw std::invalid_argument("toArray: tensor is not ArrayFire-backed");
   }
   return tensor.getAdapter<ArrayFireTensor>().getHandle();
@@ -111,14 +117,6 @@ Tensor negative(const Tensor& tensor) {
 
 Tensor logicalNot(const Tensor& tensor) {
   return toTensor<ArrayFireTensor>(!toArray(tensor));
-}
-
-Tensor exp(const Tensor& tensor) {
-  return toTensor<ArrayFireTensor>(af::exp(toArray(tensor)));
-}
-
-Tensor log(const Tensor& tensor) {
-  return toTensor<ArrayFireTensor>(af::log(toArray(tensor)));
 }
 
 Tensor log1p(const Tensor& tensor) {

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
@@ -61,7 +61,8 @@ class ArrayFireTensor : public TensorAdapterBase {
   const af::array& getHandle() const;
 
   ~ArrayFireTensor() override = default;
-  TensorBackend backend() const override;
+  TensorBackendType backendType() const override;
+  TensorBackend& backend() const override;
   const Shape& shape() override;
   dtype type() const override;
   Tensor astype(const dtype type) override;

--- a/flashlight/fl/tensor/backend/af/CMakeLists.txt
+++ b/flashlight/fl/tensor/backend/af/CMakeLists.txt
@@ -41,6 +41,7 @@ target_link_libraries(flashlight PUBLIC ArrayFire::${FL_AF_BACKEND})
 target_sources(
   flashlight
   PRIVATE
+  ${CMAKE_CURRENT_LIST_DIR}/ArrayFireBackend.cpp
   ${CMAKE_CURRENT_LIST_DIR}/ArrayFireTensor.cpp
   ${CMAKE_CURRENT_LIST_DIR}/Compute.cpp
   ${CMAKE_CURRENT_LIST_DIR}/Random.cpp

--- a/flashlight/fl/tensor/tensor.h
+++ b/flashlight/fl/tensor/tensor.h
@@ -9,3 +9,6 @@
 
 #include "flashlight/fl/tensor/Compute.h"
 #include "flashlight/fl/tensor/Random.h"
+#include "flashlight/fl/tensor/Shape.h"
+#include "flashlight/fl/tensor/TensorBase.h"
+#include "flashlight/fl/tensor/Types.h"

--- a/flashlight/fl/test/tensor/TensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/TensorBaseTest.cpp
@@ -53,7 +53,7 @@ bool allClose(
 
 TEST(TensorBaseTest, DefaultBackend) {
   Tensor t;
-  ASSERT_EQ(t.backend(), TensorBackend::ArrayFire);
+  ASSERT_EQ(t.backendType(), TensorBackendType::ArrayFire);
 }
 
 TEST(TensorBaseTest, AfRefCountBasic) {


### PR DESCRIPTION
Summary:
Move most unary, binary, and reduction operators to the `fl::TensorBackend` interface.

ill move type-specific operators in a later diff/avoid macro bloat as much as possible.

Differential Revision: D28806617

