### PR TITLE
[build] Use Kenlm imported targets

### DIFF
--- a/flashlight/lib/text/decoder/lm/CMakeLists.txt
+++ b/flashlight/lib/text/decoder/lm/CMakeLists.txt
@@ -12,16 +12,18 @@ target_sources(
 # ------------------------- KenLM-specific -------------------------
 
 if (FL_LIBRARIES_USE_KENLM)
-  find_package(kenlm)
+  # Try to find the CMake config first
+  find_package(kenlm CONFIG)
   if (NOT kenlm_FOUND)
-    if (FL_BUILD_STANDALONE)
-      message(STATUS "KenLM not found - will download and build from source")
-      include(${CMAKE_MODULE_PATH}/BuildKenlm.cmake)
-      add_dependencies(fl-libraries kenlm) # ExternalProject target
+    # No luck - use Findkenlm.cmake
+    find_package(kenlm MODULE)
+    if (NOT kenlm_FOUND)
+      if (FL_BUILD_STANDALONE)
+        message(STATUS "KenLM not found - will download and build from source")
+        include(${CMAKE_MODULE_PATH}/BuildKenlm.cmake)
+        add_dependencies(fl-libraries kenlm) # ExternalProject target
+      endif()
     endif()
-  endif()
-  if (FL_BUILD_STANDALONE)
-    setup_install_find_module(${CMAKE_MODULE_PATH}/Findkenlm.cmake)
   endif()
 
   target_sources(
@@ -30,22 +32,32 @@ if (FL_LIBRARIES_USE_KENLM)
     ${CMAKE_CURRENT_LIST_DIR}/KenLM.cpp
     )
 
-  target_link_libraries(
-    fl-libraries
-    PRIVATE
-    ${KENLM_LIBRARIES}
-    )
-
-  target_include_directories(
-    fl-libraries
-    PUBLIC
-    $<BUILD_INTERFACE:${KENLM_INCLUDE_DIRS}>
-    $<BUILD_INTERFACE:${KENLM_INCLUDE_DIRS_LM}>
-    )
-
   target_compile_definitions(
     fl-libraries
     PUBLIC
     KENLM_MAX_ORDER=${KENLM_MAX_ORDER}
     )
-endif ()
+
+  # Link imported kenlm target if we have it
+  if (TARGET kenlm::kenlm AND TARGET kenlm::kenlm_util)
+    target_link_libraries(
+      fl-libraries
+      PRIVATE
+      kenlm::kenlm
+      kenlm::kenlm_util
+      )
+  else()
+    target_link_libraries(
+      fl-libraries
+      PRIVATE
+      ${KENLM_LIBRARIES}
+      )
+
+    target_include_directories(
+      fl-libraries
+      PUBLIC
+      $<BUILD_INTERFACE:${KENLM_INCLUDE_DIRS}>
+      $<BUILD_INTERFACE:${KENLM_INCLUDE_DIRS_LM}>
+      )
+  endif()
+endif()


### PR DESCRIPTION
Awaiting https://github.com/kpu/kenlm/pull/342, which fixes include directories and makes using imported targets for KenLM in flashlight possible. Removes some unfortunate silliness with having to append `include/kenlm` to include paths to capture internal transitively-included kenlm headers, since these are now specified on the `INSTALL_INTERFACE` of exported KenLM targets in https://github.com/kpu/kenlm/pull/342 and the correct directory appears in the `INTERFACE_INCLUDE_DIRECTORIES` of `IMPORTED` targets.

Will require updating Docker images to a more recent KenLM commit to make CI pass.

### Test Plan
Local build with Kenlm:
```
cmake .. -DCMAKE_INSTALL_PREFIX=/tmp/kenlm_test -DCOMPILE_TESTS=OFF
make install -j80
```
from FL build:
```
cmake .. -DFL_BACKEND=CUDA -DFL_BUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Debug -DFL_BUILD_LIBRARIES=ON -Dkenlm_DIR=/tmp/kenlm_test/share/kenlm/cmake/
make -j80
```
