### PR TITLE
Gate flashlightConfig finds behind standalone build

### DIFF
--- a/cmake/flashlightConfig.cmake.in
+++ b/cmake/flashlightConfig.cmake.in
@@ -71,7 +71,7 @@ if (@FL_BUILD_STANDALONE@)
   endif()
   # Remove this dir from module path
   list(REMOVE_AT CMAKE_MODULE_PATH -1)
-endif()
+endif() # FL_BUILD_STANDALONE
 
 ################################################################################
 

--- a/cmake/flashlightConfig.cmake.in
+++ b/cmake/flashlightConfig.cmake.in
@@ -20,54 +20,58 @@
 #
 
 # Dependencies
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
-include(CMakeFindDependencyMacro)
-if (@FL_BUILD_LIBRARIES@)
-  # Lib dependencies
-  find_dependency(OpenMP)
-  find_dependency(kenlm)
-  find_dependency(Threads)
-  find_dependency(FFTW3)
-  if (@FL_LIBRARIES_USE_MKL@)
-    find_dependency(MKL)
-  else()
-    find_dependency(CBLAS)
+# If not building standalone, don't try to find upstream deps,
+# as many of these find modules won't exist
+if (@FL_BUILD_STANDALONE@)
+  list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
+  include(CMakeFindDependencyMacro)
+  if (@FL_BUILD_LIBRARIES@)
+    # Lib dependencies
+    find_dependency(OpenMP)
+    find_dependency(kenlm)
+    find_dependency(Threads)
+    find_dependency(FFTW3)
+    if (@FL_LIBRARIES_USE_MKL@)
+      find_dependency(MKL)
+    else()
+      find_dependency(CBLAS)
+    endif()
   endif()
-endif()
-# Core dependencies
-if (@FL_BUILD_CORE@)
-  find_dependency(ArrayFire 3.7.1)
-endif()
-if (@FL_BUILD_DISTRIBUTED@)
-  find_dependency(MPI)
-endif()
-# Backend-specific dependencies
-if (@FL_USE_CPU@)
-  find_dependency(DNNL)
+  # Core dependencies
+  if (@FL_BUILD_CORE@)
+    find_dependency(ArrayFire 3.7.1)
+  endif()
   if (@FL_BUILD_DISTRIBUTED@)
-    find_dependency(Gloo)
+    find_dependency(MPI)
   endif()
-endif()
-if (@FL_USE_CUDA@)
-  find_dependency(CUDNN 7.1)
-  if (@FL_BUILD_DISTRIBUTED@)
-    find_dependency(NCCL)
+  # Backend-specific dependencies
+  if (@FL_USE_CPU@)
+    find_dependency(DNNL)
+    if (@FL_BUILD_DISTRIBUTED@)
+      find_dependency(Gloo)
+    endif()
   endif()
+  if (@FL_USE_CUDA@)
+    find_dependency(CUDNN 7.1)
+    if (@FL_BUILD_DISTRIBUTED@)
+      find_dependency(NCCL)
+    endif()
+  endif()
+  # App dependencies
+  if (@FL_BUILD_APP_ASR@ OR
+      @FL_BUILD_APP_IMGCLASS@ OR
+      @FL_BUILD_APP_OBJDET@ OR
+      @FL_BUILD_APP_LM@)
+    find_dependency(gflags)
+    find_dependency(GLOG)
+  endif()
+  # Additional app-specific dependencies
+  if (@FL_BUILD_APP_ASR@)
+    find_dependency(SndFile)
+  endif()
+  # Remove this dir from module path
+  list(REMOVE_AT CMAKE_MODULE_PATH -1)
 endif()
-# App dependencies
-if (@FL_BUILD_APP_ASR@ OR
-    @FL_BUILD_APP_IMGCLASS@ OR
-    @FL_BUILD_APP_OBJDET@ OR
-    @FL_BUILD_APP_LM@)
-  find_dependency(gflags)
-  find_dependency(GLOG)
-endif()
-# Additional app-specific dependencies
-if (@FL_BUILD_APP_ASR@)
-  find_dependency(SndFile)
-endif()
-# Remove this dir from module path
-list(REMOVE_AT CMAKE_MODULE_PATH -1)
 
 ################################################################################
 


### PR DESCRIPTION
In cases where `Find***` CMake modules can't be installed (i.e. vcpkg), finding deps in flashlightConfig breaks downstream projects because those find modules don't exist. Find modules are always installed when doing a standalone install, and they only aren't installed with `FL_BUILD_STANDALONE=OFF`, so gate calling into those modules based on the behavior of upstream dependencies.

This will fix longstanding issues including https://github.com/flashlight/flashlight/issues/574 once the vcpkg port is updated.

### Test Plan (required)
vcpkg independent test with patch.

