### PR TITLE
Assignment operators, generics reorg

### DIFF
--- a/flashlight/fl/tensor/TensorAdapter.h
+++ b/flashlight/fl/tensor/TensorAdapter.h
@@ -87,6 +87,32 @@ class TensorAdapterBase {
    * @return an indexed tensor
    */
   virtual Tensor index(const std::vector<Index>& indices) const = 0;
+
+  /******************** Assignment Operators ********************/
+#define ASSIGN_OP_TYPE(OP, TYPE) virtual void OP(const TYPE& val) = 0;
+#define ASSIGN_OP(OP)                 \
+  ASSIGN_OP_TYPE(OP, Tensor);         \
+  ASSIGN_OP_TYPE(OP, double);         \
+  ASSIGN_OP_TYPE(OP, float);          \
+  ASSIGN_OP_TYPE(OP, int);            \
+  ASSIGN_OP_TYPE(OP, unsigned);       \
+  ASSIGN_OP_TYPE(OP, bool);           \
+  ASSIGN_OP_TYPE(OP, char);           \
+  ASSIGN_OP_TYPE(OP, unsigned char);  \
+  ASSIGN_OP_TYPE(OP, short);          \
+  ASSIGN_OP_TYPE(OP, unsigned short); \
+  ASSIGN_OP_TYPE(OP, long);           \
+  ASSIGN_OP_TYPE(OP, unsigned long);  \
+  ASSIGN_OP_TYPE(OP, long long);      \
+  ASSIGN_OP_TYPE(OP, unsigned long long);
+
+  ASSIGN_OP(assign); // =
+  ASSIGN_OP(inPlaceAdd); // +=
+  ASSIGN_OP(inPlaceSubtract); // -=
+  ASSIGN_OP(inPlaceMultiply); // *=
+  ASSIGN_OP(inPlaceDivide); // /=
+#undef ASSIGN_OP_TYPE
+#undef ASSIGN_OP
 };
 
 namespace detail {

--- a/flashlight/fl/tensor/TensorBackend.h
+++ b/flashlight/fl/tensor/TensorBackend.h
@@ -53,11 +53,18 @@ class TensorBackend {
 
   /************************** Reductions ***************************/
   virtual Tensor amin(const Tensor& input, const std::vector<int>& axes) = 0;
+  virtual double amin(const Tensor& input) = 0; // TODO: consoildate w/ above
   virtual Tensor amax(const Tensor& input, const std::vector<int>& axes) = 0;
+  virtual double amax(const Tensor& input) = 0; // TODO: consoildate w/ above
   virtual Tensor sum(const Tensor& input, const std::vector<int>& axes) = 0;
+  virtual double sum(const Tensor& input) = 0; // TODO: consolidate w/ above
   virtual Tensor mean(const Tensor& input, const std::vector<int>& axes) = 0;
+  virtual double mean(const Tensor& input) = 0; // TODO: consolidate w/ above
   virtual Tensor
   var(const Tensor& input, const std::vector<int>& axes, bool bias) = 0;
+  virtual double var(
+      const Tensor& input,
+      bool bias) = 0; // TODO: consolidate w/ above
   virtual double norm(const Tensor& input) = 0;
 };
 

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -128,7 +128,47 @@ class Tensor {
    * @return a TensorBackend.
    */
   TensorBackend& backend() const;
+
+  /******************** Assignment Operators ********************/
+#define ASSIGN_OP(OP)                    \
+  Tensor& OP(const Tensor& val);         \
+  Tensor& OP(const double& val);         \
+  Tensor& OP(const float& val);          \
+  Tensor& OP(const int& val);            \
+  Tensor& OP(const unsigned& val);       \
+  Tensor& OP(const bool& val);           \
+  Tensor& OP(const char& val);           \
+  Tensor& OP(const unsigned char& val);  \
+  Tensor& OP(const short& val);          \
+  Tensor& OP(const unsigned short& val); \
+  Tensor& OP(const long& val);           \
+  Tensor& OP(const unsigned long& val);  \
+  Tensor& OP(const long long& val);      \
+  Tensor& OP(const unsigned long long& val);
+
+  ASSIGN_OP(operator=);
+  ASSIGN_OP(operator+=);
+  ASSIGN_OP(operator-=);
+  ASSIGN_OP(operator*=);
+  ASSIGN_OP(operator/=);
+#undef ASSIGN_OP
 };
+
+/**
+ * Returns of two tensors are close. Checks:
+ * - Tensor data types
+ * - Tensor shapes
+ * - Emptiness
+ * - Absolute distance between elements
+ *
+ * @param[in] a lhs tensor
+ * @param[in] b rhs tensor
+ * @param[in] absTolerance the maximum-allowable distance between the tensors
+ */
+bool allClose(
+    const fl::Tensor& a,
+    const fl::Tensor& b,
+    const double absTolerance = 1e-5);
 
 /******************** Tensor Creation Functions ********************/
 /**
@@ -368,6 +408,16 @@ Tensor power(const Tensor& lhs, const Tensor& rhs);
 Tensor amin(const Tensor& input, const std::vector<int>& axes);
 
 /**
+ * Compute the minimum value across all axes.
+ * TODO: consolidate with amin above.
+ *
+ * @param[in] input the input along which to operate
+ * @return a scalar T containing the mim
+ */
+template <typename T>
+T amin(const Tensor& input);
+
+/**
  * Compute the maximum value along multiple axes.
  *
  * @param[in] input the input along which to operate
@@ -376,6 +426,16 @@ Tensor amin(const Tensor& input, const std::vector<int>& axes);
  *
  */
 Tensor amax(const Tensor& input, const std::vector<int>& axes);
+
+/**
+ * Compute the minimum value across all axes.
+ * TODO: consolidate with amax above.
+ *
+ * @param[in] input the input along which to operate
+ * @return a scalar T containing the mim
+ */
+template <typename T>
+T amax(const Tensor& input);
 
 /**
  * Sum of array over given axes.
@@ -387,6 +447,16 @@ Tensor amax(const Tensor& input, const std::vector<int>& axes);
 Tensor sum(const Tensor& input, const std::vector<int>& axes);
 
 /**
+ * Sum of array over all axes.
+ * TODO: consolidate with sum above.
+ *
+ * @param[in] input the input along which to operate
+ * @return a scalar T containing the sum
+ */
+template <typename T>
+T sum(const Tensor& input);
+
+/**
  * Mean of array over given axes.
  *
  * @param[in] input the input along which to operate
@@ -394,6 +464,15 @@ Tensor sum(const Tensor& input, const std::vector<int>& axes);
  * @return a tensor containing the mean across given axes
  */
 Tensor mean(const Tensor& input, const std::vector<int>& axes);
+
+/**
+ * Mean of array over all axes.
+ *
+ * @param[in] input the input along which to operate
+ * @return a scalar T containing the mean
+ */
+template <typename T>
+T mean(const Tensor& input);
 
 /**
  * var of array over given axes.
@@ -404,6 +483,15 @@ Tensor mean(const Tensor& input, const std::vector<int>& axes);
  */
 Tensor
 var(const Tensor& input, const std::vector<int>& axes, bool bias = false);
+
+/**
+ * var of array over all axes.
+ *
+ * @param[in] input the input along which to operate
+ * @return a scalar T containing the var
+ */
+template <typename T>
+T var(const Tensor& input, bool bias = false);
 
 /**
  * norm of array over all axes.

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
@@ -137,16 +137,31 @@ Tensor ArrayFireBackend::amin(
   return toTensor<ArrayFireTensor>(afReduceAxes(toArray(input), axes, af::min));
 }
 
+// TODO: consolidate with above
+double ArrayFireBackend::amin(const Tensor& input) {
+  return af::min<double>(toArray(input));
+}
+
 Tensor ArrayFireBackend::amax(
     const Tensor& input,
     const std::vector<int>& axes) {
   return toTensor<ArrayFireTensor>(afReduceAxes(toArray(input), axes, af::max));
 }
 
+// TODO: consolidate with above
+double ArrayFireBackend::amax(const Tensor& input) {
+  return af::max<double>(toArray(input));
+}
+
 Tensor ArrayFireBackend::sum(
     const Tensor& input,
     const std::vector<int>& axes) {
   return toTensor<ArrayFireTensor>(afReduceAxes(toArray(input), axes, af::sum));
+}
+
+// TODO: consolidate with above
+double ArrayFireBackend::sum(const Tensor& input) {
+  return af::sum<double>(toArray(input));
 }
 
 Tensor ArrayFireBackend::mean(
@@ -158,6 +173,11 @@ Tensor ArrayFireBackend::mean(
     arr = af::mean(arr, dim);
   }
   return toTensor<ArrayFireTensor>(std::move(arr));
+}
+
+// TODO: consolidate with above
+double ArrayFireBackend::mean(const Tensor& input) {
+  return af::mean<double>(toArray(input));
 }
 
 Tensor ArrayFireBackend::var(
@@ -186,6 +206,11 @@ Tensor ArrayFireBackend::var(
 
   x = x / denominator;
   return toTensor<ArrayFireTensor>(std::move(x));
+}
+
+// TODO: consolidate with above
+double ArrayFireBackend::var(const Tensor& input, bool bias) {
+  return af::var<double>(toArray(input), bias);
 }
 
 double ArrayFireBackend::norm(const Tensor& input) {

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
@@ -50,11 +50,17 @@ class ArrayFireBackend : public TensorBackend {
 
   /************************** Reductions ***************************/
   Tensor amin(const Tensor& input, const std::vector<int>& axes) override;
+  double amin(const Tensor& input) override; // TODO: consolidate w/ above
   Tensor amax(const Tensor& input, const std::vector<int>& axes) override;
+  double amax(const Tensor& input) override; // TODO: consolidate w/ above
   Tensor sum(const Tensor& input, const std::vector<int>& axes) override;
+  double sum(const Tensor& input) override; // TODO: consolidate w/ above
   Tensor mean(const Tensor& input, const std::vector<int>& axes) override;
+  double mean(const Tensor& input) override; // TODO: consolidate w/ above
   Tensor var(const Tensor& input, const std::vector<int>& axes, bool bias)
       override;
+  double var(const Tensor& input, bool bias)
+      override; // TODO: consolidate w/ above
   double norm(const Tensor& input) override;
 };
 

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
@@ -68,6 +68,33 @@ class ArrayFireTensor : public TensorAdapterBase {
   dtype type() const override;
   Tensor astype(const dtype type) override;
   Tensor index(const std::vector<Index>& indices) const override;
+
+  /******************** Assignment Operators ********************/
+#define ASSIGN_OP_TYPE(OP, TYPE) void OP(const TYPE& val) override;
+
+#define ASSIGN_OP(OP)                 \
+  ASSIGN_OP_TYPE(OP, Tensor);         \
+  ASSIGN_OP_TYPE(OP, double);         \
+  ASSIGN_OP_TYPE(OP, float);          \
+  ASSIGN_OP_TYPE(OP, int);            \
+  ASSIGN_OP_TYPE(OP, unsigned);       \
+  ASSIGN_OP_TYPE(OP, bool);           \
+  ASSIGN_OP_TYPE(OP, char);           \
+  ASSIGN_OP_TYPE(OP, unsigned char);  \
+  ASSIGN_OP_TYPE(OP, short);          \
+  ASSIGN_OP_TYPE(OP, unsigned short); \
+  ASSIGN_OP_TYPE(OP, long);           \
+  ASSIGN_OP_TYPE(OP, unsigned long);  \
+  ASSIGN_OP_TYPE(OP, long long);      \
+  ASSIGN_OP_TYPE(OP, unsigned long long);
+
+  ASSIGN_OP(assign); // =
+  ASSIGN_OP(inPlaceAdd); // +=
+  ASSIGN_OP(inPlaceSubtract); // -=
+  ASSIGN_OP(inPlaceMultiply); // *=
+  ASSIGN_OP(inPlaceDivide); // /=
+#undef ASSIGN_OP_TYPE
+#undef ASSIGN_OP
 };
 
 /**
@@ -78,68 +105,5 @@ class ArrayFireTensor : public TensorAdapterBase {
  * @return the array underying the Tensor
  */
 af::array& toArray(const Tensor& tensor);
-
-/************************** Generic Reductions ***************************/
-/*
- * TODO: move me to a singleton backend abstraction interface once available so
- * generics can be properly handled.
- */
-
-/**
- * Compute the minimum value across all axes.
- *
- * @param[in] input the input along which to operate
- * @return a scalar T containing the mim
- *
- */
-template <typename T>
-T amin(const Tensor& input) {
-  return af::min<T>(toArray(input));
-}
-
-/**
- * Compute the maximum value across all axes.
- *
- * @param[in] input the input along which to operate
- * @return a scalar T containing the max value
- *
- */
-template <typename T>
-T amax(const Tensor& input) {
-  return af::max<T>(toArray(input));
-}
-
-/**
- * Sum of array over all axes.
- *
- * @param[in] input the input along which to operate
- * @return a scalar T containing the sum
- */
-template <typename T>
-T sum(const Tensor& input) {
-  return af::sum<T>(toArray(input));
-}
-
-/**
- * Mean of array over all axes.
- *
- * @param[in] input the input along which to operate
- * @return a scalar T containing the mean
- */
-template <typename T>
-T mean(const Tensor& input) {
-  return af::mean<T>(toArray(input));
-}
-
-/**
- * var of array over all axes.
- *
- * @param[in] input the input along which to operate
- * @return a scalar T containing the var
- */
-template <typename T>
-T var(const Tensor& input, bool bias = false) {
-  return af::var<T>(toArray(input), bias);
-}
 
 } // namespace fl

--- a/flashlight/fl/test/tensor/TensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/TensorBaseTest.cpp
@@ -43,12 +43,6 @@ bool allClose(
   return af::max<double>(af::abs(a - b)) < absTolerance;
 }
 
-bool allClose(
-    const fl::Tensor& a,
-    const fl::Tensor& b,
-    double absTolerance = 1e-5) {
-  return allClose(toArray(a), toArray(b), absTolerance);
-}
 } // namespace
 
 TEST(TensorBaseTest, DefaultBackend) {
@@ -85,6 +79,43 @@ TEST(TensorBaseTest, BinaryOperators) {
   ASSERT_TRUE(allClose((a == b), eq(a, b)));
   ASSERT_TRUE(allClose((a + b), c));
   ASSERT_TRUE(allClose((a + b), add(a, b)));
+}
+
+TEST(TensorBaseTest, AssignmentOperators) {
+  auto a = fl::full({3, 3}, 1.);
+  a += 2;
+  ASSERT_TRUE(allClose(a, fl::full({3, 3}, 3.)));
+  a -= 1;
+  ASSERT_TRUE(allClose(a, fl::full({3, 3}, 2.)));
+  a *= 8;
+  ASSERT_TRUE(allClose(a, fl::full({3, 3}, 16.)));
+  a /= 4;
+  ASSERT_TRUE(allClose(a, fl::full({3, 3}, 4.)));
+
+  a = fl::full({4, 4}, 7.);
+  ASSERT_TRUE(allClose(a, fl::full({4, 4}, 7.)));
+  auto b = a;
+  ASSERT_TRUE(allClose(b, fl::full({4, 4}, 7.)));
+  a = 6.;
+  ASSERT_TRUE(allClose(a, fl::full({4, 4}, 6.)));
+}
+
+TEST(TensorBaseTest, ArrayFireAssignmentOperators) {
+  int refCount = 0;
+
+  fl::Tensor a = fl::full({3, 3}, 1.);
+  af::array& aArr = toArray(a);
+  af_get_data_ref_count(&refCount, aArr.get());
+  ASSERT_EQ(refCount, 1);
+
+  auto b = a;
+  af_get_data_ref_count(&refCount, aArr.get());
+  ASSERT_EQ(refCount, 2);
+
+  af::array& bArr = toArray(b);
+  b = fl::full({4, 4}, 2.);
+  af_get_data_ref_count(&refCount, bArr.get());
+  ASSERT_EQ(refCount, 1);
 }
 
 TEST(TensorBaseTest, full) {


### PR DESCRIPTION
Summary:
Add assignment operators for tensors and in-place arithmetic operations.

These are implemented as functions (e.g. `inPlaceAdd`) on `TensorBackend` and operators (`operator+=`) on `Tensor` for clarity and to make the `TensorBackend` API easier to derive from.

Also move templated reductions from `ArrayFireTensor` into `TensorBase` and manually define specializations in `TensorBase`. For now, these specializations simply cast the result of the reduction defined on `TensorBase` to the relevant type — the functions on `TensorBase` return `double` as needed.
- Eventually, we should remove/reimplement these specializations in terms of the reductions that return tensors then let the user decide how to cast the tensor into some type on host memory.

Also define a generic version of `allClose` that operates on `fl::Tensor`/use it in tests.

Differential Revision: D29118744

