### PR TITLE
Tile operator

### DIFF
--- a/flashlight/fl/tensor/TensorBackend.h
+++ b/flashlight/fl/tensor/TensorBackend.h
@@ -33,6 +33,7 @@ class TensorBackend {
    */
   /************************ Shaping and Indexing *************************/
   virtual Tensor reshape(const Tensor& tensor, const Shape& shape) = 0;
+  virtual Tensor tile(const Tensor& tensor, const Shape& shape) = 0;
 
   /************************** Unary Operators ***************************/
   virtual Tensor exp(const Tensor& tensor) = 0;

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -129,6 +129,10 @@ Tensor reshape(const Tensor& tensor, const Shape& shape) {
   return tensor.backend().reshape(tensor, shape);
 }
 
+Tensor tile(const Tensor& tensor, const Shape& shape) {
+  return tensor.backend().tile(tensor, shape);
+}
+
 /************************** Unary Operators ***************************/
 Tensor exp(const Tensor& tensor) {
   return tensor.backend().exp(tensor);

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -196,6 +196,17 @@ Tensor identity(const Dim dim, const dtype type = dtype::f32);
  */
 Tensor reshape(const Tensor& tensor, const Shape& shape);
 
+/**
+ * Repeat the contents of a tensor a given number of times along specified
+ * dimensions.
+ *
+ * @param[in] tensor the tensor to tile
+ * @param[in] shape the number of times, along each dimension, which to tile the
+ * tensor
+ * @return the tiled tensor
+ */
+Tensor tile(const Tensor& tensor, const Shape& shape);
+
 /************************** Unary Operators ***************************/
 /**
  * Element-wise negation of a tensor.

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
@@ -68,6 +68,11 @@ Tensor ArrayFireBackend::reshape(const Tensor& tensor, const Shape& shape) {
       af::moddims(toArray(tensor), detail::flToAfDims(shape)));
 }
 
+Tensor ArrayFireBackend::tile(const Tensor& tensor, const Shape& shape) {
+  return toTensor<ArrayFireTensor>(
+      af::tile(toArray(tensor), detail::flToAfDims(shape)));
+}
+
 /************************** Unary Operators ***************************/
 
 Tensor ArrayFireBackend::exp(const Tensor& tensor) {

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
@@ -30,6 +30,7 @@ class ArrayFireBackend : public TensorBackend {
 
   /************************ Shaping and Indexing *************************/
   Tensor reshape(const Tensor& tensor, const Shape& shape) override;
+  Tensor tile(const Tensor& tensor, const Shape& shape) override;
 
   /************************** Unary Operators ***************************/
   Tensor exp(const Tensor& tensor) override;

--- a/flashlight/fl/test/tensor/ArrayFireTensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/ArrayFireTensorBaseTest.cpp
@@ -57,7 +57,7 @@ TEST(ArrayFireTensorBaseTest, AfRefCountBasic) {
   ASSERT_EQ(refCount, 2);
 }
 
-TEST(TensorBaseTest, ArrayFireAssignmentOperators) {
+TEST(ArrayFireTensorBaseTest, ArrayFireAssignmentOperators) {
   int refCount = 0;
 
   fl::Tensor a = fl::full({3, 3}, 1.);
@@ -86,7 +86,7 @@ TEST(ArrayFireTensorBaseTest, BinaryOperators) {
   ASSERT_TRUE(allClose((a + b), add(a, b)));
 }
 
-TEST(TensorBaseTest, full) {
+TEST(ArrayFireTensorBaseTest, full) {
   // TODO: expand with fixtures for each type
   auto a = fl::full({3, 4}, 3.);
   ASSERT_EQ(a.shape(), Shape({3, 4}));
@@ -99,7 +99,7 @@ TEST(TensorBaseTest, full) {
   ASSERT_TRUE(allClose(toArray(b), af::constant(4.5, {1, 1, 5, 4})));
 }
 
-TEST(TensorBaseTest, identity) {
+TEST(ArrayFireTensorBaseTest, identity) {
   auto a = fl::identity(6);
   ASSERT_EQ(a.shape(), Shape({6, 6}));
   ASSERT_EQ(a.type(), fl::dtype::f32);
@@ -108,7 +108,7 @@ TEST(TensorBaseTest, identity) {
   ASSERT_EQ(fl::identity(6, fl::dtype::f64).type(), fl::dtype::f64);
 }
 
-TEST(TensorBaseTest, randn) {
+TEST(ArrayFireTensorBaseTest, randn) {
   int s = 30;
   auto a = fl::randn({s, s});
   ASSERT_EQ(a.shape(), Shape({s, s}));
@@ -119,7 +119,7 @@ TEST(TensorBaseTest, randn) {
   ASSERT_EQ(fl::randn({1}, fl::dtype::f64).type(), fl::dtype::f64);
 }
 
-TEST(TensorBaseTest, rand) {
+TEST(ArrayFireTensorBaseTest, rand) {
   int s = 30;
   auto a = fl::rand({s, s});
   ASSERT_EQ(a.shape(), Shape({s, s}));
@@ -130,71 +130,71 @@ TEST(TensorBaseTest, rand) {
   ASSERT_EQ(fl::rand({1}, fl::dtype::f64).type(), fl::dtype::f64);
 }
 
-TEST(TensorBaseTest, amin) {
+TEST(ArrayFireTensorBaseTest, amin) {
   auto a = fl::rand({3, 3});
   ASSERT_EQ(fl::amin<float>(a), af::min<float>(toArray(a)));
   ASSERT_TRUE(allClose(toArray(fl::amin(a, {0})), af::min(toArray(a), 0)));
 }
 
-TEST(TensorBaseTest, amax) {
+TEST(ArrayFireTensorBaseTest, amax) {
   auto a = fl::rand({3, 3});
   ASSERT_EQ(fl::amax<float>(a), af::max<float>(toArray(a)));
   ASSERT_TRUE(allClose(toArray(fl::amax(a, {0})), af::max(toArray(a), 0)));
 }
 
-TEST(TensorBaseTest, sum) {
+TEST(ArrayFireTensorBaseTest, sum) {
   auto a = fl::rand({3, 3});
   ASSERT_EQ(fl::sum<float>(a), af::sum<float>(toArray(a)));
   ASSERT_TRUE(allClose(toArray(fl::sum(a, {0})), af::sum(toArray(a), 0)));
 }
 
-TEST(TensorBaseTest, exp) {
+TEST(ArrayFireTensorBaseTest, exp) {
   auto in = fl::full({3, 3}, 4.f);
   ASSERT_TRUE(allClose(toArray(fl::exp(in)), af::exp(toArray(in))));
 }
 
-TEST(TensorBaseTest, log) {
+TEST(ArrayFireTensorBaseTest, log) {
   auto in = fl::full({3, 3}, 2.f);
   ASSERT_TRUE(allClose(toArray(fl::log(in)), af::log(toArray(in))));
 }
 
-TEST(TensorBaseTest, log1p) {
+TEST(ArrayFireTensorBaseTest, log1p) {
   auto in = fl::rand({3, 3});
   ASSERT_TRUE(allClose(fl::log1p(in), fl::log(1 + in)));
 }
 
-TEST(TensorBaseTest, sin) {
+TEST(ArrayFireTensorBaseTest, sin) {
   auto in = fl::rand({3, 3});
   ASSERT_TRUE(allClose(toArray(fl::sin(in)), af::sin(toArray(in))));
 }
 
-TEST(TensorBaseTest, cos) {
+TEST(ArrayFireTensorBaseTest, cos) {
   auto in = fl::rand({3, 3});
   ASSERT_TRUE(allClose(toArray(fl::cos(in)), af::cos(toArray(in))));
 }
 
-TEST(TensorBaseTest, sqrt) {
+TEST(ArrayFireTensorBaseTest, sqrt) {
   auto in = fl::full({3, 3}, 4.f);
   ASSERT_TRUE(allClose(fl::sqrt(in), in / 2));
 }
 
-TEST(TensorBaseTest, tanh) {
+TEST(ArrayFireTensorBaseTest, tanh) {
   auto in = fl::rand({3, 3});
   ASSERT_TRUE(allClose(toArray(fl::tanh(in)), af::tanh(toArray(in))));
 }
 
-TEST(TensorBaseTest, absolute) {
+TEST(ArrayFireTensorBaseTest, absolute) {
   float val = -3.1;
   ASSERT_TRUE(allClose(fl::abs(fl::full({3, 3}, val)), fl::full({3, 3}, -val)));
 }
 
-TEST(TensorBaseTest, mean) {
+TEST(ArrayFireTensorBaseTest, mean) {
   auto a = fl::rand({3, 50});
   ASSERT_EQ(fl::mean<float>(a), af::mean<float>(toArray(a)));
   ASSERT_TRUE(allClose(toArray(fl::mean(a, {0})), af::mean(toArray(a), 0)));
 }
 
-TEST(TensorBaseTest, var) {
+TEST(ArrayFireTensorBaseTest, var) {
   auto a = fl::rand({3, 3});
   ASSERT_EQ(fl::var<float>(a), af::var<float>(toArray(a)));
   ASSERT_TRUE(allClose(toArray(fl::var(a, {0})), af::var(toArray(a), 0)));
@@ -209,7 +209,13 @@ TEST(TensorBaseTest, var) {
       af::var<float>(toArray(a), true));
 }
 
-TEST(TensorBaseTest, norm) {
+TEST(ArrayFireTensorBaseTest, norm) {
   auto a = fl::rand({3, 3});
   ASSERT_EQ(fl::norm(a), af::norm(toArray(a)));
+}
+
+TEST(ArrayFireTensorBaseTest, tile) {
+  auto a = fl::rand({3, 3});
+  ASSERT_TRUE(allClose(
+      toArray(fl::tile(a, {4, 5, 6})), af::tile(toArray(a), {4, 5, 6})));
 }

--- a/flashlight/fl/test/tensor/TensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/TensorBaseTest.cpp
@@ -58,6 +58,13 @@ TEST(TensorBaseTest, reshape) {
   ASSERT_TRUE(allClose(a, fl::reshape(b, {4, 4})));
 }
 
+TEST(TensorBaseTest, tile) {
+  auto a = fl::full({4, 4}, 3.);
+  auto tiled = fl::tile(a, {2, 2});
+  ASSERT_EQ(tiled.shape(), Shape({8, 8}));
+  ASSERT_TRUE(allClose(tiled, fl::full({8, 8}, 3.)));
+}
+
 TEST(TensorBaseTest, flatten) {
   unsigned s = 6;
   auto a = fl::full({s, s, s}, 2.);


### PR DESCRIPTION
Summary: `tile` operator (see [equiv](https://numpy.org/doc/stable/reference/generated/numpy.tile.html)). Takes `Shape`s only, not dimension literals like numpy.

Differential Revision: D29267635

