### PR TITLE
Fix end idx obo

### DIFF
--- a/flashlight/fl/tensor/Index.cpp
+++ b/flashlight/fl/tensor/Index.cpp
@@ -9,12 +9,18 @@
 
 namespace fl {
 
-range::range(int idx) : range(0, idx) {}
+range::range(idx idx) : range(0, idx) {}
 
-range::range(int start, int end) : range(start, end, /* stride */ 1) {}
+range::range(idx start, idx end) : range(start, end, /* stride */ 1) {}
 
-range::range(int start, int end, int stride)
-    : start_(start), end_(end - 1), stride_(stride) {}
+range::range(idx start, idx end, int stride)
+    : // fl::end decays to int
+      start_(std::visit([](int idx) -> int { return idx; }, start)),
+      // fl::end --> -1, else idx as int
+      end_(
+          std::holds_alternative<fl::end_t>(end) ? std::get<fl::end_t>(end)
+                                                 : std::get<int>(end) - 1),
+      stride_(stride) {}
 
 int range::start() const {
   return start_;

--- a/flashlight/fl/tensor/Index.h
+++ b/flashlight/fl/tensor/Index.h
@@ -16,20 +16,42 @@ namespace fl {
 /**
  * Represents the last index along an axis of a tensor.
  */
-constexpr int end = -1;
+struct end_t {
+  operator int() const {
+    return -1;
+  }
+};
+
+// A static alias for end that can properly decay to an index type
+static const end_t end = end_t();
 
 /**
  * An entity representing a contiguous or strided sequence of indices.
  */
 class range {
+  using idx = std::variant<end_t, int>;
+
   int start_{0};
   int end_{fl::end};
   int stride_{1};
 
  public:
-  explicit range(int idx);
-  range(int start, int end);
-  range(int start, int end, int stride);
+  /**
+   * Construct a range with the indices [0, idx) (i.e. [0, idx - 1])
+   */
+  explicit range(idx idx);
+
+  /**
+   * Construct a range with the indices [start, end) (i.e. [start, end - 1])
+   */
+  range(idx start, idx end);
+
+  /**
+   * Construct a range with the indices [start, end) (i.e. [start, end - 1])
+   * with the given stride.
+   */
+  range(idx start, idx end, int stride);
+
   int start() const;
   int end() const;
   int stride() const;

--- a/flashlight/fl/tensor/Shape.h
+++ b/flashlight/fl/tensor/Shape.h
@@ -46,7 +46,7 @@ class Shape {
 
  public:
   Shape() = default;
-  virtual ~Shape() = default;
+  ~Shape() = default;
   /**
    * Gives the maximum number of dimensions a tensor of a particular shape can
    * have.
@@ -69,12 +69,12 @@ class Shape {
   /**
    * @return the number of elements in a tensor that has the given shape.
    */
-  virtual size_t elements() const;
+  size_t elements() const;
 
   /**
    * @return Number of dimensions in the shape.
    */
-  virtual size_t nDims() const;
+  size_t nDims() const;
 
   /**
    * Get the size of a given dimension. Throws if the given dimension is larger
@@ -82,7 +82,7 @@ class Shape {
    *
    * @return the Dim at the given dimension
    */
-  virtual Dim dim(const size_t dim) const;
+  Dim dim(const size_t dim) const;
 
   /**
    * Returns a reference to the given index
@@ -93,8 +93,8 @@ class Shape {
   /**
    * Compares two shapes. Returns true if their dim vectors are equal.
    */
-  virtual bool operator==(const Shape& other) const;
-  virtual bool operator!=(const Shape& other) const;
+  bool operator==(const Shape& other) const;
+  bool operator!=(const Shape& other) const;
 
   /**
    * Compare a shape to an initializer list.

--- a/flashlight/fl/test/tensor/IndexTest.cpp
+++ b/flashlight/fl/test/tensor/IndexTest.cpp
@@ -15,7 +15,7 @@
 using namespace ::testing;
 using namespace fl;
 
-TEST(IndexTest, seq) {
+TEST(IndexTest, range) {
   auto s1 = fl::range(3);
   ASSERT_EQ(s1.start(), 0);
   ASSERT_EQ(s1.end(), 2);
@@ -30,7 +30,7 @@ TEST(IndexTest, seq) {
   ASSERT_EQ(s3.stride(), 9);
 }
 
-TEST(IndexTest, seqEq) {
+TEST(IndexTest, rangeEq) {
   ASSERT_EQ(fl::range(4), fl::range(4));
   ASSERT_EQ(fl::range(2, 3), fl::range(2, 3));
   ASSERT_EQ(fl::range(5, 6, 7), fl::range(5, 6, 7));
@@ -61,6 +61,7 @@ TEST(IndexTest, Shape) {
   ASSERT_EQ(t(2).shape(), Shape({4}));
   ASSERT_EQ(t(fl::range(3)).shape(), Shape({3, 4}));
   ASSERT_EQ(t(fl::range(1, 2)).shape(), Shape({4}));
+  ASSERT_EQ(t(fl::range(0, fl::end)).shape(), Shape({4, 4}));
   ASSERT_EQ(t(fl::range(0, fl::end, 2)).shape(), Shape({2, 4}));
 
   auto t2 = fl::full({5, 6, 7, 8}, 3.);


### PR DESCRIPTION
Summary:
`fl::end` corresponded to index `-1` but was being translated to `-2` via the `range` constructor. To distinguish between `end` and other indices, add another type `end_t` which decays to -1 and have range ctors take a variant of the two.

`end_t` naturally decays to -1 via the matched `int` coercion in `visit`.

Differential Revision: D29318965

