### PR TITLE
concatenate operation

### DIFF
--- a/flashlight/fl/tensor/Index.cpp
+++ b/flashlight/fl/tensor/Index.cpp
@@ -9,12 +9,18 @@
 
 namespace fl {
 
-range::range(int idx) : range(0, idx) {}
+range::range(idx idx) : range(0, idx) {}
 
-range::range(int start, int end) : range(start, end, /* stride */ 1) {}
+range::range(idx start, idx end) : range(start, end, /* stride */ 1) {}
 
-range::range(int start, int end, int stride)
-    : start_(start), end_(end - 1), stride_(stride) {}
+range::range(idx start, idx end, int stride)
+    : // fl::end decays to int
+      start_(std::visit([](int idx) -> int { return idx; }, start)),
+      // fl::end --> -1, else idx as int
+      end_(
+          std::holds_alternative<fl::end_t>(end) ? std::get<fl::end_t>(end)
+                                                 : std::get<int>(end) - 1),
+      stride_(stride) {}
 
 int range::start() const {
   return start_;

--- a/flashlight/fl/tensor/Index.h
+++ b/flashlight/fl/tensor/Index.h
@@ -16,20 +16,42 @@ namespace fl {
 /**
  * Represents the last index along an axis of a tensor.
  */
-constexpr int end = -1;
+struct end_t {
+  operator int() const {
+    return -1;
+  }
+};
+
+// A static alias for end that can properly decay to an index type
+static const end_t end = end_t();
 
 /**
  * An entity representing a contiguous or strided sequence of indices.
  */
 class range {
+  using idx = std::variant<end_t, int>;
+
   int start_{0};
   int end_{fl::end};
   int stride_{1};
 
  public:
-  explicit range(int idx);
-  range(int start, int end);
-  range(int start, int end, int stride);
+  /**
+   * Construct a range with the indices [0, idx) (i.e. [0, idx - 1])
+   */
+  explicit range(idx idx);
+
+  /**
+   * Construct a range with the indices [start, end) (i.e. [start, end - 1])
+   */
+  range(idx start, idx end);
+
+  /**
+   * Construct a range with the indices [start, end) (i.e. [start, end - 1])
+   * with the given stride.
+   */
+  range(idx start, idx end, int stride);
+
   int start() const;
   int end() const;
   int stride() const;

--- a/flashlight/fl/tensor/Shape.h
+++ b/flashlight/fl/tensor/Shape.h
@@ -46,7 +46,7 @@ class Shape {
 
  public:
   Shape() = default;
-  virtual ~Shape() = default;
+  ~Shape() = default;
   /**
    * Gives the maximum number of dimensions a tensor of a particular shape can
    * have.
@@ -69,12 +69,12 @@ class Shape {
   /**
    * @return the number of elements in a tensor that has the given shape.
    */
-  virtual size_t elements() const;
+  size_t elements() const;
 
   /**
    * @return Number of dimensions in the shape.
    */
-  virtual size_t nDims() const;
+  size_t nDims() const;
 
   /**
    * Get the size of a given dimension. Throws if the given dimension is larger
@@ -82,7 +82,7 @@ class Shape {
    *
    * @return the Dim at the given dimension
    */
-  virtual Dim dim(const size_t dim) const;
+  Dim dim(const size_t dim) const;
 
   /**
    * Returns a reference to the given index
@@ -93,8 +93,8 @@ class Shape {
   /**
    * Compares two shapes. Returns true if their dim vectors are equal.
    */
-  virtual bool operator==(const Shape& other) const;
-  virtual bool operator!=(const Shape& other) const;
+  bool operator==(const Shape& other) const;
+  bool operator!=(const Shape& other) const;
 
   /**
    * Compare a shape to an initializer list.

--- a/flashlight/fl/tensor/TensorBackend.h
+++ b/flashlight/fl/tensor/TensorBackend.h
@@ -37,6 +37,7 @@ class TensorBackend {
       const Tensor& tensor,
       const Shape& dims /* = {} */) = 0;
   virtual Tensor tile(const Tensor& tensor, const Shape& shape) = 0;
+  virtual Tensor concatenate(const std::vector<Tensor>& tensors, unsigned axis) = 0;
 
   /************************** Unary Operators ***************************/
   virtual Tensor exp(const Tensor& tensor) = 0;

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -137,6 +137,20 @@ Tensor tile(const Tensor& tensor, const Shape& shape) {
   return tensor.backend().tile(tensor, shape);
 }
 
+Tensor concatenate(const std::vector<Tensor>& tensors, unsigned axis) {
+  if (tensors.empty()) {
+    throw std::invalid_argument("join called on empty set of tensors");
+  }
+
+  // Check all backends match
+  TensorBackendType b = tensors.front().backendType();
+  std::all_of(tensors.begin(), tensors.end(), [b](const Tensor& t) {
+    return t.backendType() == b;
+  });
+
+  return tensors.front().backend().concatenate(tensors, axis);
+}
+
 /************************** Unary Operators ***************************/
 Tensor exp(const Tensor& tensor) {
   return tensor.backend().exp(tensor);
@@ -300,8 +314,8 @@ bool allClose(
   if (a.shape() != b.shape()) {
     return false;
   }
-  if (a.shape().elements() == 0 || b.shape().elements() == 0) {
-    return false;
+  if (a.shape().elements() == 0 && b.shape().elements() == 0) {
+    return true;
   }
   return fl::amax<double>(fl::abs(a - b)) < absTolerance;
 }

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -218,6 +218,26 @@ Tensor transpose(const Tensor& tensor, const Shape& dims = {});
  */
 Tensor tile(const Tensor& tensor, const Shape& shape);
 
+/**
+ * Join or concatenate tensors together along a particular axis.
+ *
+ * @param[in] tensors a vector of tensors to concatenate
+ * @return a concatenated tensor
+ */
+Tensor concatenate(const std::vector<Tensor>& tensors, unsigned axis = 0);
+
+/**
+ * Join or concatenate tensors together along a particular axis.
+ *
+ * @param[in] args tensors to concatenate
+ * @return a concatenated tensor
+ */
+template <typename... Ts>
+Tensor concatenate(unsigned axis, const Ts&... args) {
+  std::vector<Tensor> tensors{{args...}};
+  return concatenate(std::move(tensors), axis);
+}
+
 /************************** Unary Operators ***************************/
 /**
  * Element-wise negation of a tensor.

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
@@ -32,6 +32,8 @@ class ArrayFireBackend : public TensorBackend {
   Tensor reshape(const Tensor& tensor, const Shape& shape) override;
   Tensor transpose(const Tensor& tensor, const Shape& dims /* = {} */) override;
   Tensor tile(const Tensor& tensor, const Shape& shape) override;
+  Tensor concatenate(const std::vector<Tensor>& tensors, unsigned axis)
+      override;
 
   /************************** Unary Operators ***************************/
   Tensor exp(const Tensor& tensor) override;

--- a/flashlight/fl/tensor/backend/af/Utils.cpp
+++ b/flashlight/fl/tensor/backend/af/Utils.cpp
@@ -93,7 +93,8 @@ Shape afToFlDims(const af::dim4& d) {
 }
 
 af::seq flRangeToAfSeq(const fl::range& range) {
-  return af::seq(range.start(), range.end(), range.stride());
+  const int end = range.end();
+  return af::seq(range.start(), end == fl::end ? -1 : end, range.stride());
 }
 
 af::index flToAfIndex(const fl::Index& idx) {

--- a/flashlight/fl/test/tensor/ArrayFireTensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/ArrayFireTensorBaseTest.cpp
@@ -7,6 +7,7 @@
 
 #include <arrayfire.h>
 #include <gtest/gtest.h>
+#include <stdexcept>
 
 #include "flashlight/fl/tensor/Random.h"
 #include "flashlight/fl/tensor/TensorBase.h"
@@ -228,4 +229,9 @@ TEST(ArrayFireTensorBaseTest, transpose) {
   auto b = fl::rand({3, 5, 4, 8});
   ASSERT_TRUE(allClose(
       toArray(fl::transpose(b, {2, 0, 1})), af::reorder(toArray(b), 2, 0, 1)));
+}
+
+TEST(ArrayFireTensorBaseTest, concatenate) {
+  std::vector<fl::Tensor> tensors(11);
+  ASSERT_THROW(fl::concatenate(tensors), std::invalid_argument);
 }

--- a/flashlight/fl/test/tensor/IndexTest.cpp
+++ b/flashlight/fl/test/tensor/IndexTest.cpp
@@ -15,7 +15,7 @@
 using namespace ::testing;
 using namespace fl;
 
-TEST(IndexTest, seq) {
+TEST(IndexTest, range) {
   auto s1 = fl::range(3);
   ASSERT_EQ(s1.start(), 0);
   ASSERT_EQ(s1.end(), 2);
@@ -30,7 +30,7 @@ TEST(IndexTest, seq) {
   ASSERT_EQ(s3.stride(), 9);
 }
 
-TEST(IndexTest, seqEq) {
+TEST(IndexTest, rangeEq) {
   ASSERT_EQ(fl::range(4), fl::range(4));
   ASSERT_EQ(fl::range(2, 3), fl::range(2, 3));
   ASSERT_EQ(fl::range(5, 6, 7), fl::range(5, 6, 7));
@@ -61,6 +61,7 @@ TEST(IndexTest, Shape) {
   ASSERT_EQ(t(2).shape(), Shape({4}));
   ASSERT_EQ(t(fl::range(3)).shape(), Shape({3, 4}));
   ASSERT_EQ(t(fl::range(1, 2)).shape(), Shape({4}));
+  ASSERT_EQ(t(fl::range(0, fl::end)).shape(), Shape({4, 4}));
   ASSERT_EQ(t(fl::range(0, fl::end, 2)).shape(), Shape({2, 4}));
 
   auto t2 = fl::full({5, 6, 7, 8}, 3.);

--- a/flashlight/fl/test/tensor/TensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/TensorBaseTest.cpp
@@ -75,6 +75,16 @@ TEST(TensorBaseTest, tile) {
   ASSERT_TRUE(allClose(tiled, fl::full({8, 8}, 3.)));
 }
 
+TEST(TensorBaseTest, concatenate) {
+  auto a = fl::full({3, 3}, 1.);
+  auto b = fl::full({3, 3}, 2.);
+  auto c = fl::full({3, 3}, 3.);
+  ASSERT_TRUE(
+      allClose(fl::concatenate(0, a, b, c), fl::concatenate({a, b, c})));
+  auto out = fl::concatenate(0, a, b, c);
+  ASSERT_EQ(out.shape(), Shape({9, 3}));
+}
+
 TEST(TensorBaseTest, flatten) {
   unsigned s = 6;
   auto a = fl::full({s, s, s}, 2.);


### PR DESCRIPTION
Summary:
Adds a concatenation operation for joining tensors along a given dimension.

Docs: [[numpy](https://numpy.org/doc/stable/reference/generated/numpy.concatenate.html), [af](https://arrayfire.org/docs/group__manip__func__join.htm#ga67a36384247f6bb40254e0cb2e6d5d5c)]

Differential Revision: D29319512

