### PR TITLE
Add proxy views and fix lvalue indexing for ArrayFireTensor

### DIFF
--- a/flashlight/fl/tensor/TensorAdapter.h
+++ b/flashlight/fl/tensor/TensorAdapter.h
@@ -70,7 +70,7 @@ class TensorAdapterBase {
    *
    * @return the dtype of the tensor
    */
-  virtual dtype type() const = 0;
+  virtual dtype type() = 0;
 
   /**
    * Returns a tensor with elements cast as a particular type
@@ -86,7 +86,7 @@ class TensorAdapterBase {
    * @param[in] indices a vector of Index references
    * @return an indexed tensor
    */
-  virtual Tensor index(const std::vector<Index>& indices) const = 0;
+  virtual Tensor index(const std::vector<Index>& indices) = 0;
 
   /**
    * Returns a representation of the tensor in 1 dimension.

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
@@ -20,7 +20,14 @@
 
 namespace fl {
 
-af::array& toArray(const Tensor& tensor) {
+const af::array& toArray(const Tensor& tensor) {
+  if (tensor.backendType() != TensorBackendType::ArrayFire) {
+    throw std::invalid_argument("toArray: tensor is not ArrayFire-backed");
+  }
+  return tensor.getAdapter<ArrayFireTensor>().getHandle();
+}
+
+af::array& toArray(Tensor& tensor) {
   if (tensor.backendType() != TensorBackendType::ArrayFire) {
     throw std::invalid_argument("toArray: tensor is not ArrayFire-backed");
   }
@@ -28,12 +35,40 @@ af::array& toArray(const Tensor& tensor) {
 }
 
 ArrayFireTensor::ArrayFireTensor(af::array&& array)
-    : array_(std::move(array)), shape_(detail::afToFlDims(array_.dims())) {}
+    : handle_(std::move(array)) {}
+
+ArrayFireTensor::ArrayFireTensor(af::array::array_proxy&& proxy)
+    : handle_(std::move(proxy)) {}
 
 ArrayFireTensor::ArrayFireTensor() {}
 
+af::array& ArrayFireTensor::handle() {
+  // If the handle is currently an af::array::array_proxy, upcast to an
+  // af::array via its operator array() and update the handle.
+  // Additionally, since we can't directly mutate the dimensions of an
+  // af::array::array_proxy, condense the indices of the resulting array after
+  // the conversion.
+  if (!std::holds_alternative<af::array>(handle_)) {
+    handle_ = detail::condenseIndices(
+        af::array(std::get<af::array::array_proxy>(handle_)));
+  }
+  return std::get<af::array>(handle_);
+}
+
+const af::array& ArrayFireTensor::getHandle() const {
+  if (!std::holds_alternative<af::array>(handle_)) {
+    throw std::logic_error(
+        "ArrayFireTensor::getHandle() - underlying tensor is an array_proxy");
+  }
+  return std::get<af::array>(handle_);
+}
+
+af::array& ArrayFireTensor::getHandle() {
+  return handle();
+}
+
 std::unique_ptr<TensorAdapterBase> ArrayFireTensor::clone() const {
-  af::array arr = array_; // increment internal AF refcount
+  af::array arr = getHandle(); // increment internal AF refcount
   return std::make_unique<ArrayFireTensor>(std::move(arr));
 }
 
@@ -47,21 +82,22 @@ TensorBackend& ArrayFireTensor::backend() const {
 }
 
 const Shape& ArrayFireTensor::shape() {
-  // Update the Shape in-place
-  detail::afToFlDims(array_.dims(), shape_);
+  // Update the Shape in-place. Doesn't change any underlying data; only the
+  // mirrored Shape metadata.
+  detail::afToFlDims(handle().dims(), shape_);
   return shape_;
 }
 
-fl::dtype ArrayFireTensor::type() const {
-  return detail::afToFlType(array_.type());
+fl::dtype ArrayFireTensor::type() {
+  return detail::afToFlType(handle().type());
 }
 
 Tensor ArrayFireTensor::astype(const dtype type) {
-  auto a = array_.as(detail::flToAfType(type));
+  auto a = handle().as(detail::flToAfType(type));
   return toTensor<ArrayFireTensor>(std::move(a));
 }
 
-Tensor ArrayFireTensor::index(const std::vector<Index>& indices) const {
+Tensor ArrayFireTensor::index(const std::vector<Index>& indices) {
   if (indices.size() > AF_MAX_DIMS) {
     throw std::invalid_argument(
         "ArrayFire-backed tensor was indexed with > 4 elements:"
@@ -71,44 +107,39 @@ Tensor ArrayFireTensor::index(const std::vector<Index>& indices) const {
   for (size_t i = 0; i < indices.size(); ++i) {
     afIndices[i] = detail::flToAfIndex(indices[i]);
   }
-  af::array out = detail::condenseIndices(
-      array_(afIndices[0], afIndices[1], afIndices[2], afIndices[3]));
-  return toTensor<ArrayFireTensor>(std::move(out));
+  // Returns a tensor whose internal handle is an af::array::array_proxy
+  af::array::array_proxy _p =
+      handle()(afIndices[0], afIndices[1], afIndices[2], afIndices[3]);
+  // Calling the private ctor that takes an array_proxy.
+  return fl::Tensor(
+      std::unique_ptr<ArrayFireTensor>(new ArrayFireTensor(std::move(_p))));
 }
 
 Tensor ArrayFireTensor::flatten() const {
-  return toTensor<ArrayFireTensor>(af::flat(array_));
-}
-
-af::array& ArrayFireTensor::getHandle() {
-  return array_;
-}
-
-const af::array& ArrayFireTensor::getHandle() const {
-  return array_;
+  return toTensor<ArrayFireTensor>(af::flat(getHandle()));
 }
 
 /******************** Assignment Operators ********************/
-#define ASSIGN_OP_TYPE(FUN, AF_OP, TYPE)       \
-  void ArrayFireTensor::FUN(const TYPE& val) { \
-    array_ AF_OP val;                          \
+#define ASSIGN_OP_TYPE(FUN, AF_OP, TYPE)                       \
+  void ArrayFireTensor::FUN(const TYPE& val) {                 \
+    std::visit([val](auto&& arr) { arr AF_OP val; }, handle_); \
   }
-#define ASSIGN_OP(FUN, AF_OP)                       \
-  void ArrayFireTensor::FUN(const Tensor& tensor) { \
-    array_ AF_OP toArray(tensor);                   \
-  }                                                 \
-  ASSIGN_OP_TYPE(FUN, AF_OP, double);               \
-  ASSIGN_OP_TYPE(FUN, AF_OP, float);                \
-  ASSIGN_OP_TYPE(FUN, AF_OP, int);                  \
-  ASSIGN_OP_TYPE(FUN, AF_OP, unsigned);             \
-  ASSIGN_OP_TYPE(FUN, AF_OP, bool);                 \
-  ASSIGN_OP_TYPE(FUN, AF_OP, char);                 \
-  ASSIGN_OP_TYPE(FUN, AF_OP, unsigned char);        \
-  ASSIGN_OP_TYPE(FUN, AF_OP, short);                \
-  ASSIGN_OP_TYPE(FUN, AF_OP, unsigned short);       \
-  ASSIGN_OP_TYPE(FUN, AF_OP, long);                 \
-  ASSIGN_OP_TYPE(FUN, AF_OP, unsigned long);        \
-  ASSIGN_OP_TYPE(FUN, AF_OP, long long);            \
+#define ASSIGN_OP(FUN, AF_OP)                                                  \
+  void ArrayFireTensor::FUN(const Tensor& tensor) {                            \
+    std::visit([&tensor](auto&& arr) { arr AF_OP toArray(tensor); }, handle_); \
+  }                                                                            \
+  ASSIGN_OP_TYPE(FUN, AF_OP, double);                                          \
+  ASSIGN_OP_TYPE(FUN, AF_OP, float);                                           \
+  ASSIGN_OP_TYPE(FUN, AF_OP, int);                                             \
+  ASSIGN_OP_TYPE(FUN, AF_OP, unsigned);                                        \
+  ASSIGN_OP_TYPE(FUN, AF_OP, bool);                                            \
+  ASSIGN_OP_TYPE(FUN, AF_OP, char);                                            \
+  ASSIGN_OP_TYPE(FUN, AF_OP, unsigned char);                                   \
+  ASSIGN_OP_TYPE(FUN, AF_OP, short);                                           \
+  ASSIGN_OP_TYPE(FUN, AF_OP, unsigned short);                                  \
+  ASSIGN_OP_TYPE(FUN, AF_OP, long);                                            \
+  ASSIGN_OP_TYPE(FUN, AF_OP, unsigned long);                                   \
+  ASSIGN_OP_TYPE(FUN, AF_OP, long long);                                       \
   ASSIGN_OP_TYPE(FUN, AF_OP, unsigned long long);
 
 // (function name, AF op). Use build-in AF operators.

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
@@ -11,6 +11,8 @@
 #include <af/array.h>
 #include <af/statistics.h>
 
+#include <variant>
+
 #include "flashlight/fl/tensor/Shape.h"
 #include "flashlight/fl/tensor/TensorAdapter.h"
 
@@ -21,17 +23,41 @@ namespace fl {
  * Flashlight Tensors to ArrayFire
  */
 class ArrayFireTensor : public TensorAdapterBase {
-  // The internal ArrayFire array handle
-  af::array array_;
+  // The internal ArrayFire handle. This can be an af::array or an
+  // af::array::array_proxy as in the case of a view (lvalues only)
+  std::variant<af::array, af::array::array_proxy> handle_;
+
+  /**
+   * Internal getter for a handle. If the handle is an array_proxy, promote to
+   * an array, condense dimensions as needed, replace the handle variant, and
+   * return a reference.
+   */
+  af::array& handle();
 
   /*
    * A Flashlight shape that mirrors ArrayFire dims.
    *
-   * NOTE: this shape is only updated on calls to ArrayFireTensor::shape() so as
-   * to satisfy API requirements. af::array::dims() should be used for internal
-   * computation where shape/dimensions are needed.
+   * NOTE: this shape is only updated on calls to ArrayFireTensor::shape() so
+   * as to satisfy API requirements. af::array::dims() should be used for
+   * internal computation where shape/dimensions are needed.
    */
   Shape shape_;
+
+  /**
+   * Constructs an ArrayFireTensor from an af::array::array_proxy.
+   *
+   * This constructor is for internal use only. In order to properly construct
+   * views/proxies of arrays when they're lvalues, we need to sometimes create
+   * ArrayFireTensors which hold proxies and not arrays.
+   *
+   * Whenever these ArrayFireTensors are mutated, ArrayFireTensor::handle() is
+   * called, which upcasts the array_proxy to a full af::array on which
+   * operations can be performed.
+   *
+   * @param[in] arrayProxy construct a tensor from an ArrayFire array_proxy
+   * rvalue reference.
+   */
+  explicit ArrayFireTensor(af::array::array_proxy&& arrayProxy);
 
  public:
   /**
@@ -40,11 +66,11 @@ class ArrayFireTensor : public TensorAdapterBase {
    * Since af::arrays are refcounted, an instance of this class
    * can only be created using arrays that are moved therein.
    *
-   * Tensor operations occurring directly on this tensor's underlying af::array
-   * should not copy the array else take a performance penalty (via an internal
-   * copy if refcount is > 1 in some cases).
+   * Tensor operations occurring directly on this tensor's underlying
+   * af::array should not copy the array else take a performance penalty (via
+   * an internal copy if refcount is > 1 in some cases).
    *
-   * @param[in] array&& construct a tensor from an ArrayFire array rvalue
+   * @param[in] array construct a tensor from an ArrayFire array rvalue
    * reference.
    */
   explicit ArrayFireTensor(af::array&& array);
@@ -57,17 +83,22 @@ class ArrayFireTensor : public TensorAdapterBase {
   /**
    * Gets an ArrayFire Array from this impl.
    */
-  af::array& getHandle();
   const af::array& getHandle() const;
+
+  /**
+   * Gets an ArrayFire Array from this impl. If the underlying handle is an
+   * array_proxy, may promote it to an af::array.
+   */
+  af::array& getHandle();
 
   ~ArrayFireTensor() override = default;
   std::unique_ptr<TensorAdapterBase> clone() const override;
   TensorBackendType backendType() const override;
   TensorBackend& backend() const override;
   const Shape& shape() override;
-  dtype type() const override;
+  dtype type() override;
   Tensor astype(const dtype type) override;
-  Tensor index(const std::vector<Index>& indices) const override;
+  Tensor index(const std::vector<Index>& indices) override;
   Tensor flatten() const override;
 
   /******************** Assignment Operators ********************/
@@ -105,6 +136,7 @@ class ArrayFireTensor : public TensorAdapterBase {
  * @param[in] tensor the input tensor
  * @return the array underying the Tensor
  */
-af::array& toArray(const Tensor& tensor);
+const af::array& toArray(const Tensor& tensor);
+af::array& toArray(Tensor& tensor);
 
 } // namespace fl

--- a/flashlight/fl/tensor/backend/af/Utils.cpp
+++ b/flashlight/fl/tensor/backend/af/Utils.cpp
@@ -115,23 +115,37 @@ af::index flToAfIndex(const fl::Index& idx) {
   }
 }
 
-af::array condenseIndices(const af::array& arr) {
-  // Fast path - Array has zero elements or a dim of size zero
-  if (arr.elements() == 0) {
-    return arr;
+af::dim4 condenseDims(const af::dim4& dims) {
+  if (dims.elements() == 0) {
+    return af::dim4(0);
   }
 
   // Find the condensed shape
   af::dim4 newDims(1, 1, 1, 1);
   unsigned newDimIdx = 0;
   for (unsigned i = 0; i < AF_MAX_DIMS; ++i) {
-    if (arr.dims(i) != 1) {
+    if (dims[i] != 1) {
       // found a non-1 dim size - populate newDims
-      newDims[newDimIdx] = arr.dims(i);
+      newDims[newDimIdx] = dims[i];
       newDimIdx++;
     }
   }
-  return af::moddims(arr, newDims);
+  return newDims;
+}
+
+af::array condenseIndices(const af::array& arr) {
+  // Fast path - Array has zero elements or a dim of size zero
+  if (arr.elements() == 0) {
+    return arr;
+  }
+
+  // Only change dims if condensing is possible
+  af::dim4 newDims = condenseDims(arr.dims());
+  if (newDims != arr.dims()) {
+    return af::moddims(arr, newDims);
+  } else {
+    return arr;
+  }
 }
 
 } // namespace detail

--- a/flashlight/fl/tensor/backend/af/Utils.h
+++ b/flashlight/fl/tensor/backend/af/Utils.h
@@ -57,11 +57,16 @@ af::seq flRangeToAfSeq(const fl::range& range);
 af::index flToAfIndex(const fl::Index& idx);
 
 /**
+ * Strip leading 1 indices from an ArrayFire dim4.
+ */
+af::dim4 condenseDims(const af::dim4& dims);
+
+/**
  * Modify the dimensions (in place via af::moddims) or an Array to have no 1
  * indices. For example, an Array of shape (1, 2, 1, 6) becomes (2, 6).
  *
- * This operation is performed after indexing, etc where the resulting ArrayFire
- * shape would have 1's in it.
+ * This operation is performed before returning Array shape, etc where the
+ * resulting ArrayFire shape would have 1's in it.
  */
 af::array condenseIndices(const af::array& arr);
 

--- a/flashlight/fl/test/tensor/IndexTest.cpp
+++ b/flashlight/fl/test/tensor/IndexTest.cpp
@@ -66,5 +66,21 @@ TEST(IndexTest, Shape) {
 
   auto t2 = fl::full({5, 6, 7, 8}, 3.);
   ASSERT_EQ(t2(2, fl::range(2, 4), fl::span, 3).shape(), Shape({2, 7}));
-  // TODO: add more comprehensive tests
+}
+
+TEST(IndexTest, IndexAssignment) {
+  auto t = fl::full({4, 4}, 0, fl::dtype::s32);
+
+  t(fl::span, 0) = 1;
+  t(fl::span, 1) += 1;
+  t(fl::span, fl::range(2, fl::end)) += 1;
+  t(fl::span, fl::span) *= 7;
+  t /= 7;
+  ASSERT_TRUE(allClose(t, fl::full({4, 4}, 1)));
+
+  auto a = fl::full({6, 6}, 0.);
+  a(3, 4) = 4.;
+  ASSERT_TRUE(allClose(a(3, 4), fl::full({1}, 4.)));
+  a(2) = fl::full({6}, 8.);
+  ASSERT_TRUE(allClose(a(2), fl::full({6}, 8.)));
 }


### PR DESCRIPTION
Summary:
`ArrayFireTensor::index()` internally returned an `af::array::array_proxy` when `af::array::operator()` was used, but that was auto upcast to an `af::array` via `af::array::array_proxy::operator array()`, which caused a copy on write semantic that precluded proper in-place mutations for lvalue `fl::Tensor`s.

The fix is to allow `ArrayFireTensor` to also store an `af::array::array_proxy` as might be needed for some lvalues. As soon as an `af::array` handle is requested or some other op that requires an `af::array` is called, `ArrayFireTensor::handle()` upcasts the proxy to an `af::array` via the aforementioned operator.

This is implemented via a `variant` storing both array and proxy types, and methods that are on either are called as visitors.

Because getting an array handle now might mutate the `ArrayFireTensor` internals via promotion from a proxy to an array, some constness fixes were needed throughout. Methods on `fl::Tensor` remain const, but methods on `TensorAdapter` don't have const requirements anymore.

Differential Revision: D29356855

