### PR TITLE
Remove bias param from std op

### DIFF
--- a/flashlight/fl/tensor/TensorBackend.h
+++ b/flashlight/fl/tensor/TensorBackend.h
@@ -37,7 +37,9 @@ class TensorBackend {
       const Tensor& tensor,
       const Shape& dims /* = {} */) = 0;
   virtual Tensor tile(const Tensor& tensor, const Shape& shape) = 0;
-  virtual Tensor concatenate(const std::vector<Tensor>& tensors, unsigned axis) = 0;
+  virtual Tensor concatenate(
+      const std::vector<Tensor>& tensors,
+      unsigned axis) = 0;
 
   /************************** Unary Operators ***************************/
   virtual Tensor exp(const Tensor& tensor) = 0;
@@ -73,8 +75,7 @@ class TensorBackend {
   virtual double var(
       const Tensor& input,
       bool bias) = 0; // TODO: consolidate w/ above
-  virtual Tensor
-  std(const Tensor& input, const std::vector<int>& axes, const bool bias) = 0;
+  virtual Tensor std(const Tensor& input, const std::vector<int>& axes) = 0;
   virtual double norm(const Tensor& input) = 0;
 
   /************************** Utils ***************************/

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -289,8 +289,8 @@ GENERATE_VAR(short);
 GENERATE_VAR(unsigned short);
 #undef GENERATE_VAR
 
-Tensor std(const Tensor& input, const std::vector<int>& axes, const bool bias) {
-  return input.backend().std(input, axes, bias);
+Tensor std(const Tensor& input, const std::vector<int>& axes) {
+  return input.backend().std(input, axes);
 }
 
 double norm(const Tensor& input) {

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -544,8 +544,7 @@ T var(const Tensor& input, const bool bias = false);
  * @param[in] axes the dimension along which to reduce.
  * @return a tensor containing the var across given axes
  */
-Tensor
-std(const Tensor& input, const std::vector<int>& axes, const bool bias = false);
+Tensor std(const Tensor& input, const std::vector<int>& axes);
 
 /**
  * norm of array over all axes.

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
@@ -278,16 +278,12 @@ double ArrayFireBackend::var(const Tensor& input, const bool bias) {
 
 Tensor ArrayFireBackend::std(
     const Tensor& input,
-    const std::vector<int>& axes,
-    const bool bias) {
+    const std::vector<int>& axes) {
   if (axes.size() == 1) {
     // Use arrayfire default for one dimension which may be optimized
-    return toTensor<ArrayFireTensor>(af::stdev(
-        toArray(input),
-        bias ? AF_VARIANCE_SAMPLE : AF_VARIANCE_POPULATION,
-        axes[0]));
+    return toTensor<ArrayFireTensor>(af::stdev(toArray(input), axes[0]));
   }
-  return this->sqrt(this->var(input, axes, bias));
+  return this->sqrt(this->var(input, axes, /* bias = */ false));
 }
 
 double ArrayFireBackend::norm(const Tensor& input) {

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
@@ -68,8 +68,7 @@ class ArrayFireBackend : public TensorBackend {
       override;
   double var(const Tensor& input, const bool bias)
       override; // TODO: consolidate w/ above
-  Tensor std(const Tensor& input, const std::vector<int>& axes, const bool bias)
-      override;
+  Tensor std(const Tensor& input, const std::vector<int>& axes) override;
   double norm(const Tensor& input) override;
 
   /************************** Utils ***************************/

--- a/flashlight/fl/test/tensor/ArrayFireTensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/ArrayFireTensorBaseTest.cpp
@@ -216,19 +216,11 @@ TEST(ArrayFireTensorBaseTest, var) {
 TEST(ArrayFireTensorBaseTest, std) {
   auto a = fl::rand({3, 3});
   ASSERT_TRUE(allClose(toArray(fl::std(a, {0})), af::stdev(toArray(a), 0)));
-  ASSERT_TRUE(allClose(
-      toArray(fl::std(a, {1}, false)),
-      af::stdev(toArray(a), AF_VARIANCE_POPULATION, 1)));
-  ASSERT_TRUE(allClose(
-      toArray(fl::std(a, {1}, true)),
-      af::stdev(toArray(a), AF_VARIANCE_SAMPLE, 1)));
+  ASSERT_TRUE(allClose(toArray(fl::std(a, {1})), af::stdev(toArray(a), 1)));
   // Make sure multidimension matches computing for all
   ASSERT_FLOAT_EQ(
-      toArray(fl::std(a, {0, 1}, false)).scalar<float>(),
+      toArray(fl::std(a, {0, 1})).scalar<float>(),
       std::sqrt(af::var<float>(toArray(a))));
-  ASSERT_FLOAT_EQ(
-      toArray(fl::std(a, {0, 1}, true)).scalar<float>(),
-      std::sqrt(af::var<float>(toArray(a), AF_VARIANCE_SAMPLE)));
 }
 
 TEST(ArrayFireTensorBaseTest, norm) {


### PR DESCRIPTION
Summary: AF < 3.8 doesn't support selecting bias in stdev - remove the param from the API for now This diff can be backed out once AF 3.8 is a minimum requirement.

Differential Revision: D29375853

