### PR TITLE
Rewrite af-based indexing

### DIFF
--- a/flashlight/fl/tensor/Index.cpp
+++ b/flashlight/fl/tensor/Index.cpp
@@ -51,6 +51,9 @@ Index::Index(const range& range)
 
 Index::Index(const int idx) : type_(detail::IndexType::Literal), index_(idx) {}
 
+Index::Index(Index&& other) noexcept
+    : type_(other.type_), index_(std::move(other.index_)) {}
+
 detail::IndexType Index::type() const {
   return type_;
 }

--- a/flashlight/fl/tensor/Index.h
+++ b/flashlight/fl/tensor/Index.h
@@ -97,6 +97,12 @@ class Index {
   /* implicit */ Index(const int idx);
 
   /**
+   * Move constructor - moves the index data.
+   */
+  Index(Index&& index) noexcept;
+  Index(const Index& index) = default;
+
+  /**
    * Get the index type for this index.
    *
    * @return the index type.

--- a/flashlight/fl/tensor/TensorAdapter.h
+++ b/flashlight/fl/tensor/TensorAdapter.h
@@ -59,6 +59,11 @@ class TensorAdapterBase {
   virtual TensorBackend& backend() const = 0;
 
   /**
+   * Deep copy the tensor, including underlying data.
+   */
+  virtual Tensor copy() = 0;
+
+  /**
    * Get the shape of a tensor.
    *
    * @return the shape of the tensor

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -29,7 +29,13 @@ Tensor::~Tensor() {}
 
 Tensor::Tensor(const Tensor& tensor) : impl_(tensor.impl_->clone()) {}
 
+Tensor::Tensor(Tensor&& other) noexcept : impl_(std::move(other.impl_)) {}
+
 Tensor::Tensor() : impl_(detail::getDefaultAdapter()) {}
+
+Tensor Tensor::copy() const {
+  return impl_->copy();
+}
 
 const Shape& Tensor::shape() const {
   return impl_->shape();
@@ -316,7 +322,7 @@ T amin(const Tensor& input) {
 
 template <typename T>
 T amax(const Tensor& input) {
-  return static_cast<T>(input.backend().amin(input));
+  return static_cast<T>(input.backend().amax(input));
 }
 
 /************************** Utilities ***************************/

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -59,9 +59,20 @@ class Tensor {
   Tensor(const Tensor& tensor);
 
   /**
+   * Move constructor - moves the pointer to the TensorAdapter - performs no
+   * other operations.
+   */
+  Tensor(Tensor&& tensor) noexcept;
+
+  /**
    * Construct an empty tensor with the default tensor backend's tensor adapter.
    */
   Tensor();
+
+  /**
+   * Deep-copies the tensor, including underlying data.
+   */
+  Tensor copy() const;
 
   /**
    * Get the shape of a tensor.
@@ -235,7 +246,7 @@ Tensor concatenate(const std::vector<Tensor>& tensors, unsigned axis = 0);
 template <typename... Ts>
 Tensor concatenate(unsigned axis, const Ts&... args) {
   std::vector<Tensor> tensors{{args...}};
-  return concatenate(std::move(tensors), axis);
+  return concatenate(tensors, axis);
 }
 
 /**

--- a/flashlight/fl/test/tensor/ArrayFireTensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/ArrayFireTensorBaseTest.cpp
@@ -11,7 +11,6 @@
 
 #include "flashlight/fl/tensor/Random.h"
 #include "flashlight/fl/tensor/TensorBase.h"
-
 #include "flashlight/fl/tensor/backend/af/ArrayFireTensor.h"
 
 using namespace ::testing;
@@ -66,13 +65,20 @@ TEST(ArrayFireTensorBaseTest, ArrayFireAssignmentOperators) {
   af_get_data_ref_count(&refCount, aArr.get());
   ASSERT_EQ(refCount, 1);
 
-  auto b = a;
+  auto b = a; // share the same underlying array but bump refcount
+  af_get_data_ref_count(&refCount, aArr.get());
+  ASSERT_EQ(refCount, 2);
+
+  auto c = a.copy(); // defers deep copy to AF
   af_get_data_ref_count(&refCount, aArr.get());
   ASSERT_EQ(refCount, 2);
 
   af::array& bArr = toArray(b);
   b = fl::full({4, 4}, 2.);
   af_get_data_ref_count(&refCount, bArr.get());
+  ASSERT_EQ(refCount, 1);
+
+  af_get_data_ref_count(&refCount, aArr.get());
   ASSERT_EQ(refCount, 1);
 }
 

--- a/flashlight/fl/test/tensor/IndexTest.cpp
+++ b/flashlight/fl/test/tensor/IndexTest.cpp
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <arrayfire.h>
 #include <gtest/gtest.h>
 
 #include "flashlight/fl/tensor/Index.h"
@@ -70,7 +69,6 @@ TEST(IndexTest, Shape) {
 
 TEST(IndexTest, IndexAssignment) {
   auto t = fl::full({4, 4}, 0, fl::dtype::s32);
-
   t(fl::span, 0) = 1;
   t(fl::span, 1) += 1;
   t(fl::span, fl::range(2, fl::end)) += 1;
@@ -83,4 +81,27 @@ TEST(IndexTest, IndexAssignment) {
   ASSERT_TRUE(allClose(a(3, 4), fl::full({1}, 4.)));
   a(2) = fl::full({6}, 8.);
   ASSERT_TRUE(allClose(a(2), fl::full({6}, 8.)));
+
+  auto b = fl::full({3, 3}, 1.);
+  auto c = b;
+  b += 1;
+  ASSERT_TRUE(allClose(b, fl::full({3, 3}, 2.)));
+  ASSERT_TRUE(allClose(c, fl::full({3, 3}, 1.)));
+}
+
+TEST(IndexTest, TensorIndex) {
+  std::vector<int> idxs = {0, 1, 4, 9, 11, 13, 16, 91};
+  unsigned size = idxs.size();
+  auto indices = fl::full({size}, 0);
+  for (int i = 0; i < size; ++i) {
+    indices(i) = idxs[i];
+  }
+  auto a = fl::rand({100});
+  auto indexed = a(indices);
+  for (int i = 0; i < size; ++i) {
+    ASSERT_TRUE(allClose(indexed(i), a(idxs[i])));
+  }
+
+  a(indices) = 5.;
+  ASSERT_TRUE(allClose(a(indices), fl::full({size}, 5.)));
 }

--- a/flashlight/fl/test/tensor/TensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/TensorBaseTest.cpp
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <arrayfire.h>
 #include <gtest/gtest.h>
 
 #include "flashlight/fl/tensor/Index.h"
@@ -85,7 +84,7 @@ TEST(TensorBaseTest, concatenate) {
   ASSERT_EQ(out.shape(), Shape({9, 3}));
 }
 
-TEST(TensorBaseTest, DISABLED_nonzero) {
+TEST(TensorBaseTest, nonzero) {
   std::vector<int> idxs = {0, 1, 4, 9, 11, 23, 55, 82, 91};
   auto a = fl::full({10, 10}, 1, fl::dtype::u32);
   for (const auto idx : idxs) {


### PR DESCRIPTION
Summary:
Turns out storing an `af::array::array_proxy` as an lvalue isn't really supported and creates lots of problems. Instead, create a visitor which returns an array proxy as a temporary lvalue if needed for in-place operators (assignment, etc) that also returns an array ref.

This is essentially deferred, lazy indexing where indexing occurs after the tensor is used as an rvalue. lvalue tensors that hold proxies can still be operated on as in the case of-in-place assignment.

Also add some explicitly-defined move ctors to avoid some implicit copies that were happening in `Index` and `Tensor`.

Differential Revision: D29420741

