### PR TITLE
Add host memory func to tensor api

### DIFF
--- a/flashlight/fl/tensor/TensorAdapter.h
+++ b/flashlight/fl/tensor/TensorAdapter.h
@@ -108,6 +108,11 @@ class TensorAdapterBase {
   virtual void device(void** out) = 0;
 
   /**
+   * Returns a pointer to the tensor in host memory.
+   */
+  virtual void host(void** out) = 0;
+
+  /**
    * Unlocks any device memory associated with the tensor that was acquired with
    * Tensor::device(), making it eligible to be freed.
    */

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -98,6 +98,13 @@ TensorBackend& Tensor::backend() const {
     void** addr = reinterpret_cast<void**>(&out);         \
     impl_->device(addr);                                  \
     return out;                                           \
+  }                                                       \
+  template <>                                             \
+  TYPE* Tensor::host() const {                            \
+    TYPE* out;                                            \
+    void** addr = reinterpret_cast<void**>(&out);         \
+    impl_->host(addr);                                    \
+    return out;                                           \
   }
 FL_CREATE_MEMORY_OPS(int);
 FL_CREATE_MEMORY_OPS(unsigned);

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -223,10 +223,20 @@ class Tensor {
    * \note The memory allocated here will not be freed until Tensor:unlock() is
    * called.
    *
-   * @return the requested pointer
+   * @return the requested pointer on the device.
    */
   template <typename T>
   T* device() const;
+
+  /**
+   * Returns a pointer to the tensor's underlying data, but on the host. If the
+   * tensor is located on a device, makes a copy of device memory and returns a
+   * buffer on the host containing the relevant memory.
+   *
+   * @return the requested pointer on the host.
+   */
+  template <typename T>
+  T* host() const;
 
   /**
    * Unlocks any device memory associated with the tensor that was acquired with

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
@@ -12,7 +12,6 @@
 #include <af/blas.h>
 #include <af/data.h>
 #include <af/device.h>
-#include <af/exception.h>
 #include <af/gfor.h>
 #include <af/lapack.h>
 #include <algorithm>

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
@@ -17,6 +17,7 @@
 #include "flashlight/fl/tensor/backend/af/Utils.h"
 
 #include <af/arith.h>
+#include <af/device.h>
 
 namespace fl {
 
@@ -136,6 +137,9 @@ void ArrayFireTensor::scalar(void* out) {
 
 void ArrayFireTensor::device(void** out) {
   AF_CHECK(af_get_device_ptr(out, getHandle().get()));
+}
+void ArrayFireTensor::host(void** out) {
+  AF_CHECK(af_get_data_ptr(out, getHandle().get()));
 }
 
 void ArrayFireTensor::unlock() {

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
@@ -9,6 +9,7 @@
 
 #include <af/algorithm.h>
 #include <af/array.h>
+#include <af/exception.h>
 #include <af/statistics.h>
 
 #include <variant>
@@ -155,6 +156,7 @@ class ArrayFireTensor : public TensorAdapterBase {
   dtype type() override;
   void scalar(void* out) override;
   void device(void** out) override;
+  void host(void** out) override;
   void unlock() override;
   Tensor astype(const dtype type) override;
   Tensor index(const std::vector<Index>& indices) override;


### PR DESCRIPTION
Summary:
Adds a templated function to return a pointer on the host from an `fl::Tensor`.

Will add functions testing some of this memory interop in a future diff once several other prerequisites are in place.

Differential Revision: D29725738

