### PR TITLE
Tensor::isContiguous

### DIFF
--- a/flashlight/fl/tensor/TensorAdapter.h
+++ b/flashlight/fl/tensor/TensorAdapter.h
@@ -119,6 +119,11 @@ class TensorAdapterBase {
   virtual void unlock() = 0;
 
   /**
+   * Returns a bool based on Tensor contiguousness in memory.
+   */
+  virtual bool isContiguous() = 0;
+
+  /**
    * Returns a tensor with elements cast as a particular type
    *
    * @param[in] the type to which to cast the tensor

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -124,6 +124,10 @@ void Tensor::unlock() const {
   impl_->unlock();
 }
 
+bool Tensor::isContiguous() const {
+  return impl_->isContiguous();
+}
+
 // Generate template specializations for functions that return types
 #define EXPAND_MACRO_FUNCTION_TYPE(FUN, TYPE)             \
   template <>                                             \

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -244,6 +244,13 @@ class Tensor {
    */
   void unlock() const;
 
+  /**
+   * Returns if the Tensor is contiguous in its memory-based representation.
+   *
+   * @return a bool denoting Tensor contiguousness
+   */
+  bool isContiguous() const;
+
   /******************** Assignment Operators ********************/
 #define ASSIGN_OP(OP)                    \
   Tensor& OP(const Tensor& val);         \

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
@@ -18,6 +18,7 @@
 
 #include <af/arith.h>
 #include <af/device.h>
+#include <af/internal.h>
 
 namespace fl {
 
@@ -144,6 +145,10 @@ void ArrayFireTensor::host(void** out) {
 
 void ArrayFireTensor::unlock() {
   AF_CHECK(af_unlock_array(getHandle().get()));
+}
+
+bool ArrayFireTensor::isContiguous() {
+  return af::isLinear(getHandle());
 }
 
 Tensor ArrayFireTensor::astype(const dtype type) {

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
@@ -158,6 +158,7 @@ class ArrayFireTensor : public TensorAdapterBase {
   void device(void** out) override;
   void host(void** out) override;
   void unlock() override;
+  bool isContiguous() override;
   Tensor astype(const dtype type) override;
   Tensor index(const std::vector<Index>& indices) override;
   Tensor flatten() const override;

--- a/flashlight/fl/test/tensor/TensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/TensorBaseTest.cpp
@@ -244,3 +244,9 @@ TEST(TensorBaseTest, scalar) {
 
   ASSERT_THROW(a.scalar<int>(), std::invalid_argument);
 }
+
+TEST(TensorBaseTest, isContiguous) {
+  // Contiguous by default
+  auto a = fl::rand({10, 10});
+  ASSERT_TRUE(a.isContiguous());
+}


### PR DESCRIPTION
Summary: Adds `isContiguous`. No numpy analog for this, but checking tensor linearity matters for `DevicePtr` and other abstractions.

Differential Revision: D29726689

