### PR TITLE
Add countNonzero

### DIFF
--- a/flashlight/fl/tensor/TensorAdapter.h
+++ b/flashlight/fl/tensor/TensorAdapter.h
@@ -119,6 +119,11 @@ class TensorAdapterBase {
   virtual void unlock() = 0;
 
   /**
+   * Returns a bool based on Tensor contiguousness in memory.
+   */
+  virtual bool isContiguous() = 0;
+
+  /**
    * Returns a tensor with elements cast as a particular type
    *
    * @param[in] the type to which to cast the tensor

--- a/flashlight/fl/tensor/TensorBackend.h
+++ b/flashlight/fl/tensor/TensorBackend.h
@@ -80,6 +80,9 @@ class TensorBackend {
       bool bias) = 0; // TODO: consolidate w/ above
   virtual Tensor std(const Tensor& input, const std::vector<int>& axes) = 0;
   virtual double norm(const Tensor& input) = 0;
+  virtual Tensor countNonzero(
+      const Tensor& input,
+      const std::vector<int>& axes) = 0;
 
   /************************** Utils ***************************/
   virtual void print(const Tensor& tensor) = 0;

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -378,6 +378,10 @@ double norm(const Tensor& input) {
   return input.backend().norm(input);
 }
 
+Tensor countNonzero(const Tensor& input, const std::vector<int>& axes) {
+  return input.backend().countNonzero(input, axes);
+}
+
 template <typename T>
 T amin(const Tensor& input) {
   return static_cast<T>(input.backend().amin(input));

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -124,6 +124,10 @@ void Tensor::unlock() const {
   impl_->unlock();
 }
 
+bool Tensor::isContiguous() const {
+  return impl_->isContiguous();
+}
+
 // Generate template specializations for functions that return types
 #define EXPAND_MACRO_FUNCTION_TYPE(FUN, TYPE)             \
   template <>                                             \

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -244,6 +244,13 @@ class Tensor {
    */
   void unlock() const;
 
+  /**
+   * Returns if the Tensor is contiguous in its memory-based representation.
+   *
+   * @return a bool denoting Tensor contiguousness
+   */
+  bool isContiguous() const;
+
   /******************** Assignment Operators ********************/
 #define ASSIGN_OP(OP)                    \
   Tensor& OP(const Tensor& val);         \

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -109,6 +109,15 @@ class Tensor {
     return Tensor(s, fl::dtype_traits<T>::fl_type, v.data(), Location::Host);
   }
 
+  template <typename T>
+  static Tensor fromVector(std::vector<T> v) {
+    return Tensor(
+        {static_cast<long long>(v.size())},
+        fl::dtype_traits<T>::fl_type,
+        v.data(),
+        Location::Host);
+  }
+
   /**
    * Create a tensor from an existing buffer.
    *
@@ -693,6 +702,20 @@ Tensor std(const Tensor& input, const std::vector<int>& axes);
  * @return a double containing the norm
  */
 double norm(const Tensor& input);
+
+/**
+ * Counts the number of nonzero elements in a tensor.
+ *
+ * If k axes are passed, returns a tensor of size k with element-wise nonzero
+ * counts along each axis.
+ *
+ * @param[in] input the tensor on which to operate.
+ * @param[in] dims (optional) the axis along which to give nonzeros.
+ *
+ * @return a tensor containing the number of nonzero elements along each axis or
+ * over the entire tensor.
+ */
+Tensor countNonzero(const Tensor& input, const std::vector<int>& axes = {});
 
 /************************** Utilities ***************************/
 

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
@@ -14,6 +14,7 @@
 #include <af/device.h>
 #include <af/gfor.h>
 #include <af/lapack.h>
+
 #include <algorithm>
 #include <numeric>
 #include <stdexcept>
@@ -285,6 +286,24 @@ Tensor ArrayFireBackend::std(
 
 double ArrayFireBackend::norm(const Tensor& input) {
   return af::norm(toArray(input));
+}
+
+Tensor ArrayFireBackend::countNonzero(
+    const Tensor& input,
+    const std::vector<int>& axes) {
+  auto& arr = toArray(input);
+  af::array out;
+  if (axes.size() == 0) {
+    out = af::sum(af::count(arr));
+  } else if (axes.size() == 1) {
+    out = af::count(arr, axes.front());
+  } else {
+    out = afReduceAxes(
+        af::count(arr, axes.front()),
+        std::vector<int>(axes.begin() + 1, axes.end()),
+        af::sum);
+  }
+  return toTensor<ArrayFireTensor>(detail::condenseIndices(out));
 }
 
 void ArrayFireBackend::print(const Tensor& tensor) {

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
@@ -73,6 +73,8 @@ class ArrayFireBackend : public TensorBackend {
       override; // TODO: consolidate w/ above
   Tensor std(const Tensor& input, const std::vector<int>& axes) override;
   double norm(const Tensor& input) override;
+  Tensor countNonzero(const Tensor& input, const std::vector<int>& axes)
+      override;
 
   /************************** Utils ***************************/
   void print(const Tensor& tensor) override;

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
@@ -18,6 +18,7 @@
 
 #include <af/arith.h>
 #include <af/device.h>
+#include <af/internal.h>
 
 namespace fl {
 
@@ -144,6 +145,10 @@ void ArrayFireTensor::host(void** out) {
 
 void ArrayFireTensor::unlock() {
   AF_CHECK(af_unlock_array(getHandle().get()));
+}
+
+bool ArrayFireTensor::isContiguous() {
+  return af::isLinear(getHandle());
 }
 
 Tensor ArrayFireTensor::astype(const dtype type) {

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
@@ -158,6 +158,7 @@ class ArrayFireTensor : public TensorAdapterBase {
   void device(void** out) override;
   void host(void** out) override;
   void unlock() override;
+  bool isContiguous() override;
   Tensor astype(const dtype type) override;
   Tensor index(const std::vector<Index>& indices) override;
   Tensor flatten() const override;

--- a/flashlight/fl/test/tensor/TensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/TensorBaseTest.cpp
@@ -244,3 +244,9 @@ TEST(TensorBaseTest, scalar) {
 
   ASSERT_THROW(a.scalar<int>(), std::invalid_argument);
 }
+
+TEST(TensorBaseTest, isContiguous) {
+  // Contiguous by default
+  auto a = fl::rand({10, 10});
+  ASSERT_TRUE(a.isContiguous());
+}


### PR DESCRIPTION
Summary:
Add `countNonzero` modeled after [numpy's](https://numpy.org/doc/stable/reference/generated/numpy.count_nonzero.html). Returns per-axis nonzero counts if more than one axis is specified.

Since ArrayFire doesn't have a multi-axis implementation, if more than one axis is specified, operators over that axis, then reduce along the other specified dimensions.

Differential Revision: D29742963

