### PR TITLE
Fixes to tensor host memory api

### DIFF
--- a/flashlight/fl/tensor/TensorAdapter.h
+++ b/flashlight/fl/tensor/TensorAdapter.h
@@ -108,7 +108,8 @@ class TensorAdapterBase {
   virtual void device(void** out) = 0;
 
   /**
-   * Returns a pointer to the tensor in host memory.
+   * Populates a pointer with a pointer value in memory pointing to a host
+   * buffer containing tensor data.
    */
   virtual void host(void** out) = 0;
 

--- a/flashlight/fl/tensor/TensorAdapter.h
+++ b/flashlight/fl/tensor/TensorAdapter.h
@@ -119,6 +119,11 @@ class TensorAdapterBase {
   virtual void unlock() = 0;
 
   /**
+   * Returns a bool based on Tensor contiguousness in memory.
+   */
+  virtual bool isContiguous() = 0;
+
+  /**
    * Returns a tensor with elements cast as a particular type
    *
    * @param[in] the type to which to cast the tensor

--- a/flashlight/fl/tensor/TensorBackend.h
+++ b/flashlight/fl/tensor/TensorBackend.h
@@ -80,6 +80,9 @@ class TensorBackend {
       bool bias) = 0; // TODO: consolidate w/ above
   virtual Tensor std(const Tensor& input, const std::vector<int>& axes) = 0;
   virtual double norm(const Tensor& input) = 0;
+  virtual Tensor countNonzero(
+      const Tensor& input,
+      const std::vector<int>& axes) = 0;
 
   /************************** Utils ***************************/
   virtual void print(const Tensor& tensor) = 0;

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -378,6 +378,10 @@ double norm(const Tensor& input) {
   return input.backend().norm(input);
 }
 
+Tensor countNonzero(const Tensor& input, const std::vector<int>& axes) {
+  return input.backend().countNonzero(input, axes);
+}
+
 template <typename T>
 T amin(const Tensor& input) {
   return static_cast<T>(input.backend().amin(input));

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -124,6 +124,10 @@ void Tensor::unlock() const {
   impl_->unlock();
 }
 
+bool Tensor::isContiguous() const {
+  return impl_->isContiguous();
+}
+
 // Generate template specializations for functions that return types
 #define EXPAND_MACRO_FUNCTION_TYPE(FUN, TYPE)             \
   template <>                                             \

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -244,6 +244,13 @@ class Tensor {
    */
   void unlock() const;
 
+  /**
+   * Returns if the Tensor is contiguous in its memory-based representation.
+   *
+   * @return a bool denoting Tensor contiguousness
+   */
+  bool isContiguous() const;
+
   /******************** Assignment Operators ********************/
 #define ASSIGN_OP(OP)                    \
   Tensor& OP(const Tensor& val);         \

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -151,6 +151,20 @@ class Tensor {
   const Shape& shape() const;
 
   /**
+   * Get the number of elements in the tensor.
+   *
+   * @return the size of the tensor in elements.
+   */
+  size_t size() const;
+
+  /**
+   * Get the tensor size in bytes.
+   *
+   * @return the size of the tensor in bytes.
+   */
+  size_t bytes() const;
+
+  /**
    * Get the data type of tensor.
    *
    * @return the dtype of the tensor
@@ -246,6 +260,16 @@ class Tensor {
    */
   template <typename T>
   T* host() const;
+
+  /**
+   * Populates an existinb buffer with the tensor's underlying data, but on the
+   * host. If the tensor is located on a device, makes a copy of device memory
+   * and returns a buffer on the host containing the relevant memory.
+   *
+   * @return the requested pointer on the host.
+   */
+  template <typename T>
+  void host(T* ptr) const;
 
   /**
    * Unlocks any device memory associated with the tensor that was acquired with

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -109,6 +109,15 @@ class Tensor {
     return Tensor(s, fl::dtype_traits<T>::fl_type, v.data(), Location::Host);
   }
 
+  template <typename T>
+  static Tensor fromVector(std::vector<T> v) {
+    return Tensor(
+        {static_cast<long long>(v.size())},
+        fl::dtype_traits<T>::fl_type,
+        v.data(),
+        Location::Host);
+  }
+
   /**
    * Create a tensor from an existing buffer.
    *
@@ -693,6 +702,20 @@ Tensor std(const Tensor& input, const std::vector<int>& axes);
  * @return a double containing the norm
  */
 double norm(const Tensor& input);
+
+/**
+ * Counts the number of nonzero elements in a tensor.
+ *
+ * If k axes are passed, returns a tensor of size k with element-wise nonzero
+ * counts along each axis.
+ *
+ * @param[in] input the tensor on which to operate.
+ * @param[in] dims (optional) the axis along which to give nonzeros.
+ *
+ * @return a tensor containing the number of nonzero elements along each axis or
+ * over the entire tensor.
+ */
+Tensor countNonzero(const Tensor& input, const std::vector<int>& axes = {});
 
 /************************** Utilities ***************************/
 

--- a/flashlight/fl/tensor/Types.cpp
+++ b/flashlight/fl/tensor/Types.cpp
@@ -7,6 +7,7 @@
 
 #include "flashlight/fl/tensor/Types.h"
 
+#include <stdexcept>
 #include <unordered_map>
 
 namespace fl {
@@ -24,6 +25,35 @@ const std::unordered_map<dtype, std::string> kTypeToString = {
     {dtype::u32, "u32"},
     {dtype::u64, "u64"},
 };
+
+size_t getTypeSize(dtype type) {
+  switch (type) {
+    case dtype::f16:
+      return sizeof(float) / 2;
+    case dtype::f32:
+      return sizeof(float);
+    case dtype::f64:
+      return sizeof(double);
+    case dtype::b8:
+      return sizeof(unsigned char);
+    case dtype::s16:
+      return sizeof(short);
+    case dtype::s64:
+      return sizeof(long long);
+    case dtype::s32:
+      return sizeof(int);
+    case dtype::u8:
+      return sizeof(unsigned char);
+    case dtype::u16:
+      return sizeof(unsigned short);
+    case dtype::u32:
+      return sizeof(unsigned);
+    case dtype::u64:
+      return sizeof(unsigned long long);
+    default:
+      throw std::invalid_argument("getTypeSize - invalid type queried.");
+  }
+}
 
 const std::string& dtypeToString(dtype type) {
   return kTypeToString.at(type);

--- a/flashlight/fl/tensor/Types.h
+++ b/flashlight/fl/tensor/Types.h
@@ -27,6 +27,13 @@ enum class dtype {
 };
 
 /**
+ * Returns the size of the type in bytes.
+ *
+ * @param[in] type the input type to query.
+ */
+size_t getTypeSize(dtype type);
+
+/**
  * Convert a dtype to its string representation.
  */
 const std::string& dtypeToString(dtype type);

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
@@ -14,6 +14,7 @@
 #include <af/device.h>
 #include <af/gfor.h>
 #include <af/lapack.h>
+
 #include <algorithm>
 #include <numeric>
 #include <stdexcept>
@@ -285,6 +286,24 @@ Tensor ArrayFireBackend::std(
 
 double ArrayFireBackend::norm(const Tensor& input) {
   return af::norm(toArray(input));
+}
+
+Tensor ArrayFireBackend::countNonzero(
+    const Tensor& input,
+    const std::vector<int>& axes) {
+  auto& arr = toArray(input);
+  af::array out;
+  if (axes.size() == 0) {
+    out = af::sum(af::count(arr));
+  } else if (axes.size() == 1) {
+    out = af::count(arr, axes.front());
+  } else {
+    out = afReduceAxes(
+        af::count(arr, axes.front()),
+        std::vector<int>(axes.begin() + 1, axes.end()),
+        af::sum);
+  }
+  return toTensor<ArrayFireTensor>(detail::condenseIndices(out));
 }
 
 void ArrayFireBackend::print(const Tensor& tensor) {

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
@@ -73,6 +73,8 @@ class ArrayFireBackend : public TensorBackend {
       override; // TODO: consolidate w/ above
   Tensor std(const Tensor& input, const std::vector<int>& axes) override;
   double norm(const Tensor& input) override;
+  Tensor countNonzero(const Tensor& input, const std::vector<int>& axes)
+      override;
 
   /************************** Utils ***************************/
   void print(const Tensor& tensor) override;

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
@@ -18,6 +18,7 @@
 
 #include <af/arith.h>
 #include <af/device.h>
+#include <af/internal.h>
 
 namespace fl {
 
@@ -144,6 +145,10 @@ void ArrayFireTensor::host(void** out) {
 
 void ArrayFireTensor::unlock() {
   AF_CHECK(af_unlock_array(getHandle().get()));
+}
+
+bool ArrayFireTensor::isContiguous() {
+  return af::isLinear(getHandle());
 }
 
 Tensor ArrayFireTensor::astype(const dtype type) {

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
@@ -139,8 +139,9 @@ void ArrayFireTensor::scalar(void* out) {
 void ArrayFireTensor::device(void** out) {
   AF_CHECK(af_get_device_ptr(out, getHandle().get()));
 }
+
 void ArrayFireTensor::host(void** out) {
-  AF_CHECK(af_get_data_ptr(out, getHandle().get()));
+  AF_CHECK(af_get_data_ptr(*out, getHandle().get()));
 }
 
 void ArrayFireTensor::unlock() {

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
@@ -158,6 +158,7 @@ class ArrayFireTensor : public TensorAdapterBase {
   void device(void** out) override;
   void host(void** out) override;
   void unlock() override;
+  bool isContiguous() override;
   Tensor astype(const dtype type) override;
   Tensor index(const std::vector<Index>& indices) override;
   Tensor flatten() const override;

--- a/flashlight/fl/test/tensor/TensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/TensorBaseTest.cpp
@@ -33,6 +33,13 @@ TEST(TensorBaseTest, DefaultConstruction) {
   ASSERT_EQ(v.type(), fl::dtype::u64);
 }
 
+TEST(TensorBaseTest, Metadata) {
+  int s = 9;
+  auto t = fl::rand({s, s});
+  ASSERT_EQ(t.size(), s * s);
+  ASSERT_EQ(t.bytes(), s * s * sizeof(float));
+}
+
 TEST(TensorBaseTest, BinaryOperators) {
   // TODO:fl::Tensor {testing} expand this test
   // Ensure that some binary operators work properly.
@@ -90,7 +97,7 @@ TEST(TensorBaseTest, ConstructFromData) {
   ASSERT_TRUE(allClose(fl::Tensor::fromVector(s, vec), fl::full(s, val)));
 
   ASSERT_TRUE(allClose(
-      fl::Tensor::fromBuffer(s, vec.data(), fl::Location::Host),
+      fl::Tensor::fromBuffer(s, vec.data(), fl::MemoryLocation::Host),
       fl::full(s, val)));
 
   std::vector<float> ascending = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
@@ -102,7 +109,11 @@ TEST(TensorBaseTest, ConstructFromData) {
 
   // TODO: add fixtures/check stuff
   std::vector<int> intV = {1, 2, 3};
-  ASSERT_EQ(fl::Tensor::fromVector({3, 4}, intV).type(), fl::dtype::s32);
+  ASSERT_EQ(fl::Tensor::fromVector({3}, intV).type(), fl::dtype::s32);
+
+  std::vector<float> flat = {0, 1, 2, 3, 4, 5, 6, 7};
+  unsigned size = flat.size();
+  ASSERT_EQ(fl::Tensor::fromVector(flat).shape(), Shape({size}));
 }
 
 TEST(TensorBaseTest, reshape) {
@@ -145,7 +156,7 @@ TEST(TensorBaseTest, nonzero) {
     a(idx / 10, idx % 10) = 0;
   }
   auto indices = fl::nonzero(a);
-  int nnz = a.shape().elements() - idxs.size();
+  int nnz = a.size() - idxs.size();
   ASSERT_EQ(indices.shape(), Shape({nnz}));
   ASSERT_TRUE(
       allClose(a.flatten()(indices), fl::full({nnz}, 1, fl::dtype::u32)));
@@ -158,8 +169,8 @@ TEST(TensorBaseTest, countNonzero) {
     a(idx / 10, idx % 10) = 0;
   }
 
-  ASSERT_TRUE(allClose(
-      fl::full({1}, a.shape().elements() - idxs.size()), fl::countNonzero(a)));
+  ASSERT_TRUE(
+      allClose(fl::full({1}, a.size() - idxs.size()), fl::countNonzero(a)));
 
   std::vector<unsigned> sizes(a.shape().dim(0));
   for (unsigned i = 0; i < a.shape().dim(0); ++i) {
@@ -178,8 +189,8 @@ TEST(TensorBaseTest, countNonzero) {
   std::vector<unsigned> b01 = {4, 1};
   ASSERT_TRUE(
       allClose(fl::Tensor::fromVector({2}, b01), fl::countNonzero(b, {0, 1})));
-  ASSERT_TRUE(allClose(
-      fl::full({1}, b.shape().elements() - 3), fl::countNonzero(b, {0, 1, 2})));
+  ASSERT_TRUE(
+      allClose(fl::full({1}, b.size() - 3), fl::countNonzero(b, {0, 1, 2})));
 }
 
 TEST(TensorBaseTest, flatten) {
@@ -274,4 +285,19 @@ TEST(TensorBaseTest, scalar) {
   ASSERT_TRUE(allClose(fl::full({1}, a.scalar<float>()), a(0, 0)));
 
   ASSERT_THROW(a.scalar<int>(), std::invalid_argument);
+}
+
+TEST(TensorBaseTest, host) {
+  auto a = fl::rand({10, 10});
+
+  float* ptr = a.host<float>();
+  for (int i = 0; i < a.size(); ++i) {
+    ASSERT_EQ(ptr[i], a.flatten()(i).scalar<float>());
+  }
+
+  float* existingBuffer = new float[100];
+  a.host(existingBuffer);
+  for (int i = 0; i < a.size(); ++i) {
+    ASSERT_EQ(existingBuffer[i], a.flatten()(i).scalar<float>());
+  }
 }


### PR DESCRIPTION
Summary:
Add some fixes to `fl::Tensor::host` and some tests. Add an overload that accepts a type `T*` as an existing buffer and populates that.

Adds:
- `fl::Tensor::size()` (num elements) - replaces `tensor.shape().elements()`
- `fl::Tensor::bytes()` (size in bytes)

Differential Revision: D29744822

