### PR TITLE
Tensor any and all

### DIFF
--- a/flashlight/fl/tensor/TensorBackend.h
+++ b/flashlight/fl/tensor/TensorBackend.h
@@ -164,10 +164,14 @@ class TensorBackend {
       const Tensor& input,
       bool bias) = 0; // TODO: consolidate w/ above
   virtual Tensor std(const Tensor& input, const std::vector<int>& axes) = 0;
-  virtual double norm(const Tensor& input) = 0;
+  virtual double norm(const Tensor& input) = 0; // TODO: consolidate w/ above
   virtual Tensor countNonzero(
       const Tensor& input,
       const std::vector<int>& axes) = 0;
+  virtual Tensor any(const Tensor& input, const std::vector<int>& axes) = 0;
+  virtual bool any(const Tensor& input) = 0; // TODO: consolidate w/ above
+  virtual Tensor all(const Tensor& input, const std::vector<int>& axes) = 0;
+  virtual bool all(const Tensor& input) = 0; // TODO: consolidate w/ above
 
   /************************** Utils ***************************/
   virtual void print(const Tensor& tensor) = 0;

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -507,6 +507,22 @@ Tensor countNonzero(const Tensor& input, const std::vector<int>& axes) {
   return input.backend().countNonzero(input, axes);
 }
 
+Tensor any(const Tensor& input, const std::vector<int>& axes) {
+  return input.backend().any(input, axes);
+}
+
+bool any(const Tensor& input) {
+  return input.backend().any(input);
+}
+
+Tensor all(const Tensor& input, const std::vector<int>& axes) {
+  return input.backend().all(input, axes);
+}
+
+bool all(const Tensor& input) {
+  return input.backend().all(input);
+}
+
 template <typename T>
 T amin(const Tensor& input) {
   return static_cast<T>(input.backend().amin(input));

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -707,7 +707,7 @@ Tensor amin(const Tensor& input, const std::vector<int>& axes);
 
 /**
  * Compute the minimum value across all axes.
- * TODO: consolidate with amin above.
+ * TODO: benchmark against amin(amin(amin(...)))/maybe avoid device-host memcpy
  *
  * @param[in] input the input along which to operate
  * @return a scalar T containing the mim
@@ -727,7 +727,7 @@ Tensor amax(const Tensor& input, const std::vector<int>& axes);
 
 /**
  * Compute the minimum value across all axes.
- * TODO: consolidate with amax above.
+ * TODO: benchmark against amax(amax(amax(...)))/maybe avoid device-host memcpy
  *
  * @param[in] input the input along which to operate
  * @return a scalar T containing the mim
@@ -746,7 +746,7 @@ Tensor sum(const Tensor& input, const std::vector<int>& axes);
 
 /**
  * Sum of array over all axes.
- * TODO: consolidate with sum above.
+ * TODO: benchmark against sum(sum(sum(...)))/maybe avoid device-host memcpy
  *
  * @param[in] input the input along which to operate
  * @return a scalar T containing the sum
@@ -765,6 +765,7 @@ Tensor mean(const Tensor& input, const std::vector<int>& axes);
 
 /**
  * Mean of array over all axes.
+ * TODO: benchmark against mean(mean(mean(...)))/maybe avoid device-host memcpy
  *
  * @param[in] input the input along which to operate
  * @return a scalar T containing the mean
@@ -784,6 +785,7 @@ var(const Tensor& input, const std::vector<int>& axes, const bool bias = false);
 
 /**
  * Variance of an array over all axes.
+ * TODO: benchmark against var(var(var(...)))/maybe avoid device-host memcpy
  *
  * @param[in] input the input along which to operate
  * @return a scalar T containing the var
@@ -802,6 +804,7 @@ Tensor std(const Tensor& input, const std::vector<int>& axes);
 
 /**
  * norm of array over all axes.
+ * TODO: benchmark against norm(norm(norm(...)))/maybe avoid device-host memcpy
  *
  * @param[in] input the input along which to operate
  * @return a double containing the norm
@@ -821,6 +824,55 @@ double norm(const Tensor& input);
  * over the entire tensor.
  */
 Tensor countNonzero(const Tensor& input, const std::vector<int>& axes = {});
+
+/**
+ * Checks for any true values in a tensor along one or more axes; returns true
+ * if any exist. If k axes are passed, returns a tensor of size k with
+ * truthiness checks along each axis.
+ *
+ * @param[in] input the input tensor
+ * @param[in] axes the axes along which to check for truthy values
+ *
+ * @return a bool tensor containing axis-wise values denoting truthy values
+ * along that axis in the input tensor.
+ */
+Tensor any(const Tensor& input, const std::vector<int>& axes);
+
+/**
+ * Checks for any true values in a tensor; returns true if any exist.
+ * TODO: benchmark against any(any(any(...)))/maybe avoid
+ * device-host memcpy
+ *
+ * @param[in] the tensor input
+ *
+ * @return true if the input tensor contains any truthy values, else false
+ */
+bool any(const Tensor& input);
+
+/**
+ * Checks if all values are true in a tensor along one or more axes; returns
+ * true if all are true and false otherwise. If k axes are passed, returns a
+ * tensor of size k with all-true checks along each axis.
+ *
+ * @param[in] input the input tensor
+ * @param[in] axes the axes along which to
+ *
+ * @return a bool tensor containing axis-wise values with true along
+ * axes that contain only true values.
+ */
+Tensor all(const Tensor& input, const std::vector<int>& axes);
+
+/**
+ * Checks if all values are true in a tensor along one or more axes; returns
+ * true if all are true and false otherwise.
+ * TODO: benchmark against all(all(all(...)))/maybe avoid
+ * device-host memcpy
+ *
+ * @param[in] the tensor input
+ *
+ * @return true if the input tensor contains all truthy values, else false
+ */
+bool all(const Tensor& input);
 
 /************************** Utilities ***************************/
 

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
@@ -35,7 +35,7 @@ af::array afReduceAxes(
   for (int dim : axes) {
     arr = func(arr, dim);
   }
-  return arr;
+  return fl::detail::condenseIndices(arr);
 }
 
 } // namespace
@@ -449,6 +449,28 @@ Tensor ArrayFireBackend::countNonzero(
         af::sum);
   }
   return toTensor<ArrayFireTensor>(detail::condenseIndices(out));
+}
+
+Tensor ArrayFireBackend::any(
+    const Tensor& input,
+    const std::vector<int>& axes) {
+  return toTensor<ArrayFireTensor>(
+      afReduceAxes(toArray(input), axes, af::anyTrue));
+}
+
+bool ArrayFireBackend::any(const Tensor& input) {
+  return af::anyTrue<bool>(toArray(input));
+}
+
+Tensor ArrayFireBackend::all(
+    const Tensor& input,
+    const std::vector<int>& axes) {
+  return toTensor<ArrayFireTensor>(
+      afReduceAxes(toArray(input), axes, af::allTrue));
+}
+
+bool ArrayFireBackend::all(const Tensor& input) {
+  return af::allTrue<bool>(toArray(input));
 }
 
 void ArrayFireBackend::print(const Tensor& tensor) {

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
@@ -159,6 +159,10 @@ class ArrayFireBackend : public TensorBackend {
   double norm(const Tensor& input) override;
   Tensor countNonzero(const Tensor& input, const std::vector<int>& axes)
       override;
+  Tensor any(const Tensor& input, const std::vector<int>& axes) override;
+  bool any(const Tensor& input) override;
+  Tensor all(const Tensor& input, const std::vector<int>& axes) override;
+  bool all(const Tensor& input) override;
 
   /************************** Utils ***************************/
   void print(const Tensor& tensor) override;

--- a/flashlight/fl/test/tensor/ArrayFireTensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/ArrayFireTensorBaseTest.cpp
@@ -12,6 +12,7 @@
 #include "flashlight/fl/tensor/Random.h"
 #include "flashlight/fl/tensor/TensorBase.h"
 #include "flashlight/fl/tensor/backend/af/ArrayFireTensor.h"
+#include "flashlight/fl/tensor/backend/af/Utils.h"
 
 using namespace ::testing;
 using namespace fl;
@@ -140,19 +141,25 @@ TEST(ArrayFireTensorBaseTest, rand) {
 TEST(ArrayFireTensorBaseTest, amin) {
   auto a = fl::rand({3, 3});
   ASSERT_EQ(fl::amin<float>(a), af::min<float>(toArray(a)));
-  ASSERT_TRUE(allClose(toArray(fl::amin(a, {0})), af::min(toArray(a), 0)));
+  ASSERT_TRUE(allClose(
+      toArray(fl::amin(a, {0})),
+      fl::detail::condenseIndices(af::min(toArray(a), 0))));
 }
 
 TEST(ArrayFireTensorBaseTest, amax) {
   auto a = fl::rand({3, 3});
   ASSERT_EQ(fl::amax<float>(a), af::max<float>(toArray(a)));
-  ASSERT_TRUE(allClose(toArray(fl::amax(a, {0})), af::max(toArray(a), 0)));
+  ASSERT_TRUE(allClose(
+      toArray(fl::amax(a, {0})),
+      fl::detail::condenseIndices(af::max(toArray(a), 0))));
 }
 
 TEST(ArrayFireTensorBaseTest, sum) {
   auto a = fl::rand({3, 3});
   ASSERT_EQ(fl::sum<float>(a), af::sum<float>(toArray(a)));
-  ASSERT_TRUE(allClose(toArray(fl::sum(a, {0})), af::sum(toArray(a), 0)));
+  ASSERT_TRUE(allClose(
+      toArray(fl::sum(a, {0})),
+      fl::detail::condenseIndices(af::sum(toArray(a), 0))));
 }
 
 TEST(ArrayFireTensorBaseTest, exp) {

--- a/flashlight/fl/test/tensor/TensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/TensorBaseTest.cpp
@@ -372,3 +372,27 @@ TEST(TensorBaseTest, matmul) {
       ref,
       1e-4));
 }
+
+TEST(TensorBaseTest, any) {
+  using fl::dtype;
+  auto t = Tensor::fromVector<unsigned>({3, 3}, {1, 0, 0, 0, 0, 0, 0, 0, 1});
+  ASSERT_TRUE(allClose(
+      fl::any(t, {0}),
+      Tensor::fromVector<unsigned>({1, 0, 1}).astype(dtype::b8)));
+  ASSERT_TRUE(allClose(
+      fl::any(t, {0, 1}), Tensor::fromVector<unsigned>({1}).astype(dtype::b8)));
+  ASSERT_TRUE(fl::any(t));
+  ASSERT_FALSE(fl::any(Tensor::fromVector<unsigned>({0, 0, 0})));
+}
+
+TEST(TensorBaseTest, all) {
+  using fl::dtype;
+  auto t = Tensor::fromVector<unsigned>({3, 3}, {1, 0, 0, 0, 0, 0, 0, 0, 1});
+  ASSERT_TRUE(allClose(
+      fl::all(t, {0}),
+      Tensor::fromVector<unsigned>({0, 0, 0}).astype(dtype::b8)));
+  ASSERT_TRUE(allClose(
+      fl::all(t, {0, 1}), Tensor::fromVector<unsigned>({0}).astype(dtype::b8)));
+  ASSERT_FALSE(fl::all(t));
+  ASSERT_TRUE(fl::all(Tensor::fromVector<unsigned>({1, 1, 1})));
+}


### PR DESCRIPTION
Summary: Model `numpy`'s [any](https://numpy.org/doc/stable/reference/generated/numpy.any.html) and [all](https://numpy.org/doc/stable/reference/generated/numpy.all.html).

Differential Revision: D29784833

