### PR TITLE
Add arange, iota

### DIFF
--- a/flashlight/fl/tensor/TensorBackend.h
+++ b/flashlight/fl/tensor/TensorBackend.h
@@ -164,10 +164,14 @@ class TensorBackend {
       const Tensor& input,
       bool bias) = 0; // TODO: consolidate w/ above
   virtual Tensor std(const Tensor& input, const std::vector<int>& axes) = 0;
-  virtual double norm(const Tensor& input) = 0;
+  virtual double norm(const Tensor& input) = 0; // TODO: consolidate w/ above
   virtual Tensor countNonzero(
       const Tensor& input,
       const std::vector<int>& axes) = 0;
+  virtual Tensor any(const Tensor& input, const std::vector<int>& axes) = 0;
+  virtual bool any(const Tensor& input) = 0; // TODO: consolidate w/ above
+  virtual Tensor all(const Tensor& input, const std::vector<int>& axes) = 0;
+  virtual bool all(const Tensor& input) = 0; // TODO: consolidate w/ above
 
   /************************** Utils ***************************/
   virtual void print(const Tensor& tensor) = 0;

--- a/flashlight/fl/tensor/TensorBackend.h
+++ b/flashlight/fl/tensor/TensorBackend.h
@@ -62,6 +62,10 @@ class TensorBackend {
 #undef FL_FULL_FUN_BACKEND_DEF
 
   virtual Tensor identity(const Dim dim, const dtype type) = 0;
+  virtual Tensor
+  arange(const Shape& shape, const Dim seqDim, const dtype type) = 0;
+  virtual Tensor
+  iota(const Shape& dims, const Shape& tileDims, const dtype type) = 0;
 
   /************************ Shaping and Indexing *************************/
   virtual Tensor reshape(const Tensor& tensor, const Shape& shape) = 0;

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -507,6 +507,22 @@ Tensor countNonzero(const Tensor& input, const std::vector<int>& axes) {
   return input.backend().countNonzero(input, axes);
 }
 
+Tensor any(const Tensor& input, const std::vector<int>& axes) {
+  return input.backend().any(input, axes);
+}
+
+bool any(const Tensor& input) {
+  return input.backend().any(input);
+}
+
+Tensor all(const Tensor& input, const std::vector<int>& axes) {
+  return input.backend().all(input, axes);
+}
+
+bool all(const Tensor& input) {
+  return input.backend().all(input);
+}
+
 template <typename T>
 T amin(const Tensor& input) {
   return static_cast<T>(input.backend().amin(input));

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -181,25 +181,25 @@ EXPAND_MACRO_FUNCTION(mean);
 
 /******************** Assignment Operators ********************/
 #define FL_ASSIGN_OP_TYPE(OP, FUN, TYPE) \
-  Tensor& Tensor::OP(const TYPE& val) {  \
+  Tensor& Tensor::OP(TYPE val) {         \
     impl_->FUN(val);                     \
     return *this;                        \
   }
-#define FL_ASSIGN_OP(OP, FUN)                 \
-  FL_ASSIGN_OP_TYPE(OP, FUN, Tensor);         \
-  FL_ASSIGN_OP_TYPE(OP, FUN, double);         \
-  FL_ASSIGN_OP_TYPE(OP, FUN, float);          \
-  FL_ASSIGN_OP_TYPE(OP, FUN, int);            \
-  FL_ASSIGN_OP_TYPE(OP, FUN, unsigned);       \
-  FL_ASSIGN_OP_TYPE(OP, FUN, bool);           \
-  FL_ASSIGN_OP_TYPE(OP, FUN, char);           \
-  FL_ASSIGN_OP_TYPE(OP, FUN, unsigned char);  \
-  FL_ASSIGN_OP_TYPE(OP, FUN, short);          \
-  FL_ASSIGN_OP_TYPE(OP, FUN, unsigned short); \
-  FL_ASSIGN_OP_TYPE(OP, FUN, long);           \
-  FL_ASSIGN_OP_TYPE(OP, FUN, unsigned long);  \
-  FL_ASSIGN_OP_TYPE(OP, FUN, long long);      \
-  FL_ASSIGN_OP_TYPE(OP, FUN, unsigned long long);
+#define FL_ASSIGN_OP(OP, FUN)                        \
+  FL_ASSIGN_OP_TYPE(OP, FUN, const Tensor&);         \
+  FL_ASSIGN_OP_TYPE(OP, FUN, const double&);         \
+  FL_ASSIGN_OP_TYPE(OP, FUN, const float&);          \
+  FL_ASSIGN_OP_TYPE(OP, FUN, const int&);            \
+  FL_ASSIGN_OP_TYPE(OP, FUN, const unsigned&);       \
+  FL_ASSIGN_OP_TYPE(OP, FUN, const bool&);           \
+  FL_ASSIGN_OP_TYPE(OP, FUN, const char&);           \
+  FL_ASSIGN_OP_TYPE(OP, FUN, const unsigned char&);  \
+  FL_ASSIGN_OP_TYPE(OP, FUN, const short&);          \
+  FL_ASSIGN_OP_TYPE(OP, FUN, const unsigned short&); \
+  FL_ASSIGN_OP_TYPE(OP, FUN, const long&);           \
+  FL_ASSIGN_OP_TYPE(OP, FUN, const unsigned long&);  \
+  FL_ASSIGN_OP_TYPE(OP, FUN, const long long&);      \
+  FL_ASSIGN_OP_TYPE(OP, FUN, const unsigned long long&);
 
 // (operator, function name on impl)
 FL_ASSIGN_OP(operator=, assign);
@@ -235,6 +235,30 @@ FL_FULL_FUN_DEF(const unsigned short&);
 
 Tensor identity(const Dim dim, const dtype type) {
   return Tensor().backend().identity(dim, type);
+}
+
+#define FL_ARANGE_FUN_DEF(TYPE)                                             \
+  template <>                                                               \
+  Tensor arange(TYPE start, TYPE end, TYPE step, const dtype type) {        \
+    return fl::arange({static_cast<long>((end - start) / step)}, 0, type) * \
+        step +                                                              \
+        start;                                                              \
+  }
+FL_ARANGE_FUN_DEF(const double&);
+FL_ARANGE_FUN_DEF(const float&);
+FL_ARANGE_FUN_DEF(const int&);
+FL_ARANGE_FUN_DEF(const unsigned&);
+FL_ARANGE_FUN_DEF(const long&);
+FL_ARANGE_FUN_DEF(const unsigned long&);
+FL_ARANGE_FUN_DEF(const long long&);
+FL_ARANGE_FUN_DEF(const unsigned long long&);
+
+Tensor arange(const Shape& shape, const Dim seqDim, const dtype type) {
+  return Tensor().backend().arange(shape, seqDim, type);
+}
+
+Tensor iota(const Shape& dims, const Shape& tileDims, const dtype type) {
+  return Tensor().backend().iota(dims, tileDims, type);
 }
 
 /************************ Shaping and Indexing *************************/

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -707,7 +707,7 @@ Tensor amin(const Tensor& input, const std::vector<int>& axes);
 
 /**
  * Compute the minimum value across all axes.
- * TODO: consolidate with amin above.
+ * TODO: benchmark against amin(amin(amin(...)))/maybe avoid device-host memcpy
  *
  * @param[in] input the input along which to operate
  * @return a scalar T containing the mim
@@ -727,7 +727,7 @@ Tensor amax(const Tensor& input, const std::vector<int>& axes);
 
 /**
  * Compute the minimum value across all axes.
- * TODO: consolidate with amax above.
+ * TODO: benchmark against amax(amax(amax(...)))/maybe avoid device-host memcpy
  *
  * @param[in] input the input along which to operate
  * @return a scalar T containing the mim
@@ -746,7 +746,7 @@ Tensor sum(const Tensor& input, const std::vector<int>& axes);
 
 /**
  * Sum of array over all axes.
- * TODO: consolidate with sum above.
+ * TODO: benchmark against sum(sum(sum(...)))/maybe avoid device-host memcpy
  *
  * @param[in] input the input along which to operate
  * @return a scalar T containing the sum
@@ -765,6 +765,7 @@ Tensor mean(const Tensor& input, const std::vector<int>& axes);
 
 /**
  * Mean of array over all axes.
+ * TODO: benchmark against mean(mean(mean(...)))/maybe avoid device-host memcpy
  *
  * @param[in] input the input along which to operate
  * @return a scalar T containing the mean
@@ -784,6 +785,7 @@ var(const Tensor& input, const std::vector<int>& axes, const bool bias = false);
 
 /**
  * Variance of an array over all axes.
+ * TODO: benchmark against var(var(var(...)))/maybe avoid device-host memcpy
  *
  * @param[in] input the input along which to operate
  * @return a scalar T containing the var
@@ -802,6 +804,7 @@ Tensor std(const Tensor& input, const std::vector<int>& axes);
 
 /**
  * norm of array over all axes.
+ * TODO: benchmark against norm(norm(norm(...)))/maybe avoid device-host memcpy
  *
  * @param[in] input the input along which to operate
  * @return a double containing the norm
@@ -821,6 +824,55 @@ double norm(const Tensor& input);
  * over the entire tensor.
  */
 Tensor countNonzero(const Tensor& input, const std::vector<int>& axes = {});
+
+/**
+ * Checks for any true values in a tensor along one or more axes; returns true
+ * if any exist. If k axes are passed, returns a tensor of size k with
+ * truthiness checks along each axis.
+ *
+ * @param[in] input the input tensor
+ * @param[in] axes the axes along which to check for truthy values
+ *
+ * @return a bool tensor containing axis-wise values denoting truthy values
+ * along that axis in the input tensor.
+ */
+Tensor any(const Tensor& input, const std::vector<int>& axes);
+
+/**
+ * Checks for any true values in a tensor; returns true if any exist.
+ * TODO: benchmark against any(any(any(...)))/maybe avoid
+ * device-host memcpy
+ *
+ * @param[in] the tensor input
+ *
+ * @return true if the input tensor contains any truthy values, else false
+ */
+bool any(const Tensor& input);
+
+/**
+ * Checks if all values are true in a tensor along one or more axes; returns
+ * true if all are true and false otherwise. If k axes are passed, returns a
+ * tensor of size k with all-true checks along each axis.
+ *
+ * @param[in] input the input tensor
+ * @param[in] axes the axes along which to
+ *
+ * @return a bool tensor containing axis-wise values with true along
+ * axes that contain only true values.
+ */
+Tensor all(const Tensor& input, const std::vector<int>& axes);
+
+/**
+ * Checks if all values are true in a tensor along one or more axes; returns
+ * true if all are true and false otherwise.
+ * TODO: benchmark against all(all(all(...)))/maybe avoid
+ * device-host memcpy
+ *
+ * @param[in] the tensor input
+ *
+ * @return true if the input tensor contains all truthy values, else false
+ */
+bool all(const Tensor& input);
 
 /************************** Utilities ***************************/
 

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -356,6 +356,56 @@ Tensor full(
  */
 Tensor identity(const Dim dim, const dtype type = dtype::f32);
 
+/**
+ * Return evenly-spaced values in a given interval. Generate values in the
+ * interval `[start, stop)` steppping each element by the passed step.
+ *
+ * @param[in] start the start of the range
+ * @param[in] end the end of the range, inclusive
+ * @param[in] step the increment for each consecutive value in the range
+ * @param[in] type the dtype of the resulting tensor
+ *
+ * @return a tensor containing the evenly-spaced values
+ */
+template <typename T>
+Tensor arange(
+    const T& start,
+    const T& end,
+    const T& step = 1,
+    const dtype type = dtype_traits<T>::ctype);
+
+/**
+ * Create a tensor with [0, N] values along dimension given by seqDim and
+ * tiled along the other dimensions. N is equal to the size of the shape along
+ * the seqDim dimension.
+ *
+ * @param[in] shape the shape of the output tensor.
+ * @param[in] seqDim (optional) the dimension along which the sequence increases
+ * @param[in] type (optional) the dtype of the resulting tensor
+ *
+ * @return a tensor with the given shape with the sequence along the given
+ * dimension, tiled along other dimensions.
+ */
+Tensor
+arange(const Shape& shape, const Dim seqDim = 0, const dtype type = dtype::f32);
+
+/**
+ * Creates a sequence with the range `[0, dims.elements())` sequentially in the
+ * shape given by dims, then tiles the result along the specified tile
+ * dimensions.
+ * TODO: this is an AF-specific function.
+ *
+ * @param[in] dims the dimensions of the range
+ * @param[in] tileDims the dimensions along which to tile
+ * @param[in] type the dtype of the resulting tensoe
+ *
+ * @return
+ */
+Tensor iota(
+    const Shape& dims,
+    const Shape& tileDims = {1},
+    const dtype type = dtype::f32);
+
 /************************ Shaping and Indexing *************************/
 
 /**

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
@@ -35,7 +35,7 @@ af::array afReduceAxes(
   for (int dim : axes) {
     arr = func(arr, dim);
   }
-  return arr;
+  return fl::detail::condenseIndices(arr);
 }
 
 } // namespace
@@ -449,6 +449,28 @@ Tensor ArrayFireBackend::countNonzero(
         af::sum);
   }
   return toTensor<ArrayFireTensor>(detail::condenseIndices(out));
+}
+
+Tensor ArrayFireBackend::any(
+    const Tensor& input,
+    const std::vector<int>& axes) {
+  return toTensor<ArrayFireTensor>(
+      afReduceAxes(toArray(input), axes, af::anyTrue));
+}
+
+bool ArrayFireBackend::any(const Tensor& input) {
+  return af::anyTrue<bool>(toArray(input));
+}
+
+Tensor ArrayFireBackend::all(
+    const Tensor& input,
+    const std::vector<int>& axes) {
+  return toTensor<ArrayFireTensor>(
+      afReduceAxes(toArray(input), axes, af::allTrue));
+}
+
+bool ArrayFireBackend::all(const Tensor& input) {
+  return af::allTrue<bool>(toArray(input));
 }
 
 void ArrayFireBackend::print(const Tensor& tensor) {

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
@@ -117,6 +117,24 @@ Tensor ArrayFireBackend::identity(const Dim dim, const dtype type) {
       af::identity({dim, dim}, detail::flToAfType(type)));
 }
 
+Tensor ArrayFireBackend::arange(
+    const Shape& shape,
+    const Dim seqDim,
+    const dtype type) {
+  return toTensor<ArrayFireTensor>(
+      af::range(detail::flToAfDims(shape), seqDim, detail::flToAfType(type)));
+}
+
+Tensor ArrayFireBackend::iota(
+    const Shape& dims,
+    const Shape& tileDims,
+    const dtype type) {
+  return toTensor<ArrayFireTensor>(af::iota(
+      detail::flToAfDims(dims),
+      detail::flToAfDims(tileDims),
+      detail::flToAfType(type)));
+}
+
 /************************ Shaping and Indexing *************************/
 Tensor ArrayFireBackend::reshape(const Tensor& tensor, const Shape& shape) {
   return toTensor<ArrayFireTensor>(

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
@@ -58,6 +58,10 @@ class ArrayFireBackend : public TensorBackend {
 #undef FL_FULL_FUN_BACKEND_DEF
 
   Tensor identity(const Dim dim, const dtype type) override;
+  Tensor arange(const Shape& shape, const Dim seqDim, const dtype type)
+      override;
+  Tensor iota(const Shape& dims, const Shape& tileDims, const dtype type)
+      override;
 
   /************************ Shaping and Indexing *************************/
   Tensor reshape(const Tensor& tensor, const Shape& shape) override;

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
@@ -159,6 +159,10 @@ class ArrayFireBackend : public TensorBackend {
   double norm(const Tensor& input) override;
   Tensor countNonzero(const Tensor& input, const std::vector<int>& axes)
       override;
+  Tensor any(const Tensor& input, const std::vector<int>& axes) override;
+  bool any(const Tensor& input) override;
+  Tensor all(const Tensor& input, const std::vector<int>& axes) override;
+  bool all(const Tensor& input) override;
 
   /************************** Utils ***************************/
   void print(const Tensor& tensor) override;

--- a/flashlight/fl/test/tensor/ArrayFireTensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/ArrayFireTensorBaseTest.cpp
@@ -12,6 +12,7 @@
 #include "flashlight/fl/tensor/Random.h"
 #include "flashlight/fl/tensor/TensorBase.h"
 #include "flashlight/fl/tensor/backend/af/ArrayFireTensor.h"
+#include "flashlight/fl/tensor/backend/af/Utils.h"
 
 using namespace ::testing;
 using namespace fl;
@@ -140,19 +141,25 @@ TEST(ArrayFireTensorBaseTest, rand) {
 TEST(ArrayFireTensorBaseTest, amin) {
   auto a = fl::rand({3, 3});
   ASSERT_EQ(fl::amin<float>(a), af::min<float>(toArray(a)));
-  ASSERT_TRUE(allClose(toArray(fl::amin(a, {0})), af::min(toArray(a), 0)));
+  ASSERT_TRUE(allClose(
+      toArray(fl::amin(a, {0})),
+      fl::detail::condenseIndices(af::min(toArray(a), 0))));
 }
 
 TEST(ArrayFireTensorBaseTest, amax) {
   auto a = fl::rand({3, 3});
   ASSERT_EQ(fl::amax<float>(a), af::max<float>(toArray(a)));
-  ASSERT_TRUE(allClose(toArray(fl::amax(a, {0})), af::max(toArray(a), 0)));
+  ASSERT_TRUE(allClose(
+      toArray(fl::amax(a, {0})),
+      fl::detail::condenseIndices(af::max(toArray(a), 0))));
 }
 
 TEST(ArrayFireTensorBaseTest, sum) {
   auto a = fl::rand({3, 3});
   ASSERT_EQ(fl::sum<float>(a), af::sum<float>(toArray(a)));
-  ASSERT_TRUE(allClose(toArray(fl::sum(a, {0})), af::sum(toArray(a), 0)));
+  ASSERT_TRUE(allClose(
+      toArray(fl::sum(a, {0})),
+      fl::detail::condenseIndices(af::sum(toArray(a), 0))));
 }
 
 TEST(ArrayFireTensorBaseTest, exp) {

--- a/flashlight/fl/test/tensor/TensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/TensorBaseTest.cpp
@@ -372,3 +372,27 @@ TEST(TensorBaseTest, matmul) {
       ref,
       1e-4));
 }
+
+TEST(TensorBaseTest, any) {
+  using fl::dtype;
+  auto t = Tensor::fromVector<unsigned>({3, 3}, {1, 0, 0, 0, 0, 0, 0, 0, 1});
+  ASSERT_TRUE(allClose(
+      fl::any(t, {0}),
+      Tensor::fromVector<unsigned>({1, 0, 1}).astype(dtype::b8)));
+  ASSERT_TRUE(allClose(
+      fl::any(t, {0, 1}), Tensor::fromVector<unsigned>({1}).astype(dtype::b8)));
+  ASSERT_TRUE(fl::any(t));
+  ASSERT_FALSE(fl::any(Tensor::fromVector<unsigned>({0, 0, 0})));
+}
+
+TEST(TensorBaseTest, all) {
+  using fl::dtype;
+  auto t = Tensor::fromVector<unsigned>({3, 3}, {1, 0, 0, 0, 0, 0, 0, 0, 1});
+  ASSERT_TRUE(allClose(
+      fl::all(t, {0}),
+      Tensor::fromVector<unsigned>({0, 0, 0}).astype(dtype::b8)));
+  ASSERT_TRUE(allClose(
+      fl::all(t, {0, 1}), Tensor::fromVector<unsigned>({0}).astype(dtype::b8)));
+  ASSERT_FALSE(fl::all(t));
+  ASSERT_TRUE(fl::all(Tensor::fromVector<unsigned>({1, 1, 1})));
+}

--- a/flashlight/fl/test/tensor/TensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/TensorBaseTest.cpp
@@ -396,3 +396,35 @@ TEST(TensorBaseTest, all) {
   ASSERT_FALSE(fl::all(t));
   ASSERT_TRUE(fl::all(Tensor::fromVector<unsigned>({1, 1, 1})));
 }
+
+TEST(TensorBaseTest, arange) {
+  // Range/step overload
+  ASSERT_TRUE(
+      allClose(fl::arange(2, 10, 2), Tensor::fromVector<int>({2, 4, 6, 8})));
+  ASSERT_TRUE(
+      allClose(fl::arange(0, 6), Tensor::fromVector<int>({0, 1, 2, 3, 4, 5})));
+  ASSERT_TRUE(allClose(
+      fl::arange(0., 1.22, 0.25),
+      Tensor::fromVector<float>({0., 0.25, 0.5, 0.75})));
+  ASSERT_TRUE(allClose(
+      fl::arange(0., 4.1), Tensor::fromVector<float>({0., 1., 2., 3.})));
+
+  // Shape overload
+  auto v = Tensor::fromVector<float>({0., 1., 2., 3.});
+  ASSERT_TRUE(allClose(fl::arange({4}), v));
+
+  ASSERT_TRUE(allClose(fl::arange({4, 5}), fl::tile(v, {1, 5})));
+  ASSERT_TRUE(allClose(
+      fl::arange({4, 5}, 1),
+      fl::tile(
+          fl::reshape(Tensor::fromVector<float>({0., 1., 2., 3., 4.}), {1, 5}),
+          {4})));
+  ASSERT_EQ(fl::arange({2, 6}, 0, fl::dtype::f64).type(), fl::dtype::f64);
+}
+
+TEST(TensorBaseTest, iota) {
+  ASSERT_TRUE(allClose(
+      fl::iota({5, 3}, {1, 2}),
+      fl::tile(fl::reshape(fl::arange({15}), {5, 3}), {1, 2})));
+  ASSERT_EQ(fl::iota({2, 2}, {2, 2}, fl::dtype::f64).type(), fl::dtype::f64);
+}


### PR DESCRIPTION
Summary: Add `arange` (both a [numpy-like](https://numpy.org/doc/stable/reference/generated/numpy.arange.html) version modeled after ArrayFire's [`range`](https://arrayfire.org/docs/group__data__func__range.htm)) and [`iota`](https://arrayfire.org/docs/group__data__func__iota.htm), which is ArrayFire-specific and has no analog in numpy. There's no numpy-style `arange` equivalent in ArrayFire so the implementation in fl::Tensor uses arithmetic ops to create the same effect.

Differential Revision: D29810629

