### PR TITLE
Tensor pad operator

### DIFF
--- a/flashlight/fl/tensor/TensorBackend.h
+++ b/flashlight/fl/tensor/TensorBackend.h
@@ -77,6 +77,10 @@ class TensorBackend {
       const std::vector<Tensor>& tensors,
       unsigned axis) = 0;
   virtual Tensor nonzero(const Tensor& tensor) = 0;
+  virtual Tensor pad(
+      const Tensor& input,
+      const std::vector<std::pair<int, int>>& padWidths,
+      const PadType type) = 0;
 
   /************************** Unary Operators ***************************/
   virtual Tensor exp(const Tensor& tensor) = 0;

--- a/flashlight/fl/tensor/TensorBackend.h
+++ b/flashlight/fl/tensor/TensorBackend.h
@@ -62,6 +62,10 @@ class TensorBackend {
 #undef FL_FULL_FUN_BACKEND_DEF
 
   virtual Tensor identity(const Dim dim, const dtype type) = 0;
+  virtual Tensor
+  arange(const Shape& shape, const Dim seqDim, const dtype type) = 0;
+  virtual Tensor
+  iota(const Shape& dims, const Shape& tileDims, const dtype type) = 0;
 
   /************************ Shaping and Indexing *************************/
   virtual Tensor reshape(const Tensor& tensor, const Shape& shape) = 0;

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -181,25 +181,25 @@ EXPAND_MACRO_FUNCTION(mean);
 
 /******************** Assignment Operators ********************/
 #define FL_ASSIGN_OP_TYPE(OP, FUN, TYPE) \
-  Tensor& Tensor::OP(const TYPE& val) {  \
+  Tensor& Tensor::OP(TYPE val) {         \
     impl_->FUN(val);                     \
     return *this;                        \
   }
-#define FL_ASSIGN_OP(OP, FUN)                 \
-  FL_ASSIGN_OP_TYPE(OP, FUN, Tensor);         \
-  FL_ASSIGN_OP_TYPE(OP, FUN, double);         \
-  FL_ASSIGN_OP_TYPE(OP, FUN, float);          \
-  FL_ASSIGN_OP_TYPE(OP, FUN, int);            \
-  FL_ASSIGN_OP_TYPE(OP, FUN, unsigned);       \
-  FL_ASSIGN_OP_TYPE(OP, FUN, bool);           \
-  FL_ASSIGN_OP_TYPE(OP, FUN, char);           \
-  FL_ASSIGN_OP_TYPE(OP, FUN, unsigned char);  \
-  FL_ASSIGN_OP_TYPE(OP, FUN, short);          \
-  FL_ASSIGN_OP_TYPE(OP, FUN, unsigned short); \
-  FL_ASSIGN_OP_TYPE(OP, FUN, long);           \
-  FL_ASSIGN_OP_TYPE(OP, FUN, unsigned long);  \
-  FL_ASSIGN_OP_TYPE(OP, FUN, long long);      \
-  FL_ASSIGN_OP_TYPE(OP, FUN, unsigned long long);
+#define FL_ASSIGN_OP(OP, FUN)                        \
+  FL_ASSIGN_OP_TYPE(OP, FUN, const Tensor&);         \
+  FL_ASSIGN_OP_TYPE(OP, FUN, const double&);         \
+  FL_ASSIGN_OP_TYPE(OP, FUN, const float&);          \
+  FL_ASSIGN_OP_TYPE(OP, FUN, const int&);            \
+  FL_ASSIGN_OP_TYPE(OP, FUN, const unsigned&);       \
+  FL_ASSIGN_OP_TYPE(OP, FUN, const bool&);           \
+  FL_ASSIGN_OP_TYPE(OP, FUN, const char&);           \
+  FL_ASSIGN_OP_TYPE(OP, FUN, const unsigned char&);  \
+  FL_ASSIGN_OP_TYPE(OP, FUN, const short&);          \
+  FL_ASSIGN_OP_TYPE(OP, FUN, const unsigned short&); \
+  FL_ASSIGN_OP_TYPE(OP, FUN, const long&);           \
+  FL_ASSIGN_OP_TYPE(OP, FUN, const unsigned long&);  \
+  FL_ASSIGN_OP_TYPE(OP, FUN, const long long&);      \
+  FL_ASSIGN_OP_TYPE(OP, FUN, const unsigned long long&);
 
 // (operator, function name on impl)
 FL_ASSIGN_OP(operator=, assign);
@@ -235,6 +235,30 @@ FL_FULL_FUN_DEF(const unsigned short&);
 
 Tensor identity(const Dim dim, const dtype type) {
   return Tensor().backend().identity(dim, type);
+}
+
+#define FL_ARANGE_FUN_DEF(TYPE)                                             \
+  template <>                                                               \
+  Tensor arange(TYPE start, TYPE end, TYPE step, const dtype type) {        \
+    return fl::arange({static_cast<long>((end - start) / step)}, 0, type) * \
+        step +                                                              \
+        start;                                                              \
+  }
+FL_ARANGE_FUN_DEF(const double&);
+FL_ARANGE_FUN_DEF(const float&);
+FL_ARANGE_FUN_DEF(const int&);
+FL_ARANGE_FUN_DEF(const unsigned&);
+FL_ARANGE_FUN_DEF(const long&);
+FL_ARANGE_FUN_DEF(const unsigned long&);
+FL_ARANGE_FUN_DEF(const long long&);
+FL_ARANGE_FUN_DEF(const unsigned long long&);
+
+Tensor arange(const Shape& shape, const Dim seqDim, const dtype type) {
+  return Tensor().backend().arange(shape, seqDim, type);
+}
+
+Tensor iota(const Shape& dims, const Shape& tileDims, const dtype type) {
+  return Tensor().backend().iota(dims, tileDims, type);
 }
 
 /************************ Shaping and Indexing *************************/

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -298,6 +298,13 @@ Tensor nonzero(const Tensor& tensor) {
   return tensor.backend().nonzero(tensor);
 }
 
+Tensor pad(
+    const Tensor& input,
+    const std::vector<std::pair<int, int>>& padWidths,
+    const PadType type) {
+  return input.backend().pad(input, padWidths, type);
+}
+
 /************************** Unary Operators ***************************/
 Tensor exp(const Tensor& tensor) {
   return tensor.backend().exp(tensor);

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -10,6 +10,7 @@
 #include <functional>
 #include <memory>
 #include <optional>
+#include <utility>
 #include <vector>
 
 #include "flashlight/fl/tensor/Shape.h"
@@ -468,6 +469,29 @@ Tensor concatenate(unsigned axis, const Ts&... args) {
  */
 Tensor nonzero(const Tensor& tensor);
 
+/**
+ * Padding types for the pad operator.
+ * - Constant: pad with a constant zero value symmetrically.
+ * - Edge: pad with the values at the edges of the tensor
+ * - Symmetric: pad with a reflection of the tensor mirrored along each edge
+ */
+enum class PadType { Constant, Edge, Symmetric };
+
+/**
+ * Pad a tensor with zeros.
+ *
+ * @param[in] the input tensor to pad
+ * @param[in] padWidths a vector of tuples representing padding (before, after)
+ * tuples for each axis
+ * @param[in] type the padding mode with which to pad the tensor - see `PadType`
+ *
+ * @return the padded tensor
+ */
+Tensor pad(
+    const Tensor& input,
+    const std::vector<std::pair<int, int>>& padWidths,
+    const PadType type = PadType::Constant);
+
 /************************** Unary Operators ***************************/
 /**
  * Element-wise negation of a tensor.
@@ -597,7 +621,7 @@ Tensor clip(const Tensor& tensor, const double& low, const double& high);
  * false otherwise.
  *
  * @param[in] tensor the input tensor
- * @return a boolean array with true in positions that contained NaN in the
+ * @return a boolean tensor with true in positions that contained NaN in the
  * input tensor
  */
 Tensor isnan(const Tensor& tensor);
@@ -786,7 +810,7 @@ template <typename T>
 T amax(const Tensor& input);
 
 /**
- * Sum of array over given axes.
+ * Sum of tensor over given axes.
  *
  * @param[in] input the input along which to operate
  * @param[in] axes the dimension along which to reduce.
@@ -795,7 +819,7 @@ T amax(const Tensor& input);
 Tensor sum(const Tensor& input, const std::vector<int>& axes);
 
 /**
- * Sum of array over all axes.
+ * Sum of tensor over all axes.
  * TODO: benchmark against sum(sum(sum(...)))/maybe avoid device-host memcpy
  *
  * @param[in] input the input along which to operate
@@ -805,7 +829,7 @@ template <typename T>
 T sum(const Tensor& input);
 
 /**
- * Mean of array over given axes.
+ * Mean of tensor over given axes.
  *
  * @param[in] input the input along which to operate
  * @param[in] axes the dimension along which to reduce.
@@ -814,7 +838,7 @@ T sum(const Tensor& input);
 Tensor mean(const Tensor& input, const std::vector<int>& axes);
 
 /**
- * Mean of array over all axes.
+ * Mean of tensor over all axes.
  * TODO: benchmark against mean(mean(mean(...)))/maybe avoid device-host memcpy
  *
  * @param[in] input the input along which to operate
@@ -824,7 +848,7 @@ template <typename T>
 T mean(const Tensor& input);
 
 /**
- * Variance of an array over given axes.
+ * Variance of an tensor over given axes.
  *
  * @param[in] input the input along which to operate
  * @param[in] axes the dimension along which to reduce.
@@ -834,7 +858,7 @@ Tensor
 var(const Tensor& input, const std::vector<int>& axes, const bool bias = false);
 
 /**
- * Variance of an array over all axes.
+ * Variance of an tensor over all axes.
  * TODO: benchmark against var(var(var(...)))/maybe avoid device-host memcpy
  *
  * @param[in] input the input along which to operate
@@ -844,7 +868,7 @@ template <typename T>
 T var(const Tensor& input, const bool bias = false);
 
 /**
- * Standard deviation of an array over given axes.
+ * Standard deviation of an tensor over given axes.
  *
  * @param[in] input the input along which to operate
  * @param[in] axes the dimension along which to reduce.
@@ -853,7 +877,7 @@ T var(const Tensor& input, const bool bias = false);
 Tensor std(const Tensor& input, const std::vector<int>& axes);
 
 /**
- * norm of array over all axes.
+ * norm of tensor over all axes.
  * TODO: benchmark against norm(norm(norm(...)))/maybe avoid device-host memcpy
  *
  * @param[in] input the input along which to operate

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -356,6 +356,56 @@ Tensor full(
  */
 Tensor identity(const Dim dim, const dtype type = dtype::f32);
 
+/**
+ * Return evenly-spaced values in a given interval. Generate values in the
+ * interval `[start, stop)` steppping each element by the passed step.
+ *
+ * @param[in] start the start of the range
+ * @param[in] end the end of the range, inclusive
+ * @param[in] step the increment for each consecutive value in the range
+ * @param[in] type the dtype of the resulting tensor
+ *
+ * @return a tensor containing the evenly-spaced values
+ */
+template <typename T>
+Tensor arange(
+    const T& start,
+    const T& end,
+    const T& step = 1,
+    const dtype type = dtype_traits<T>::ctype);
+
+/**
+ * Create a tensor with [0, N] values along dimension given by seqDim and
+ * tiled along the other dimensions. N is equal to the size of the shape along
+ * the seqDim dimension.
+ *
+ * @param[in] shape the shape of the output tensor.
+ * @param[in] seqDim (optional) the dimension along which the sequence increases
+ * @param[in] type (optional) the dtype of the resulting tensor
+ *
+ * @return a tensor with the given shape with the sequence along the given
+ * dimension, tiled along other dimensions.
+ */
+Tensor
+arange(const Shape& shape, const Dim seqDim = 0, const dtype type = dtype::f32);
+
+/**
+ * Creates a sequence with the range `[0, dims.elements())` sequentially in the
+ * shape given by dims, then tiles the result along the specified tile
+ * dimensions.
+ * TODO: this is an AF-specific function.
+ *
+ * @param[in] dims the dimensions of the range
+ * @param[in] tileDims the dimensions along which to tile
+ * @param[in] type the dtype of the resulting tensoe
+ *
+ * @return
+ */
+Tensor iota(
+    const Shape& dims,
+    const Shape& tileDims = {1},
+    const dtype type = dtype::f32);
+
 /************************ Shaping and Indexing *************************/
 
 /**

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
@@ -196,6 +196,28 @@ Tensor ArrayFireBackend::nonzero(const Tensor& tensor) {
   return toTensor<ArrayFireTensor>(af::where(toArray(tensor)));
 }
 
+Tensor ArrayFireBackend::pad(
+    const Tensor& input,
+    const std::vector<std::pair<int, int>>& padWidths,
+    const PadType type) {
+  if (padWidths.size() > AF_MAX_DIMS) {
+    throw std::invalid_argument(
+        "ArrayFireBackend::pad - given padWidths for more than 4 dimensions");
+  }
+
+  // convert ((begin_1, end_1), ..., (begin_k, end_k)) to ((begin_1, ...,
+  // begin_k), (end_1, ..., end_k)) for ArrayFire
+  af::dim4 beginPadding, endPadding;
+  for (size_t i = 0; i < padWidths.size(); ++i) {
+    auto& [first, second] = padWidths[i];
+    beginPadding[i] = first;
+    endPadding[i] = second;
+  }
+
+  return toTensor<ArrayFireTensor>(af::pad(
+      toArray(input), beginPadding, endPadding, detail::flToAfPadType(type)));
+}
+
 /************************** Unary Operators ***************************/
 
 Tensor ArrayFireBackend::exp(const Tensor& tensor) {

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
@@ -117,6 +117,24 @@ Tensor ArrayFireBackend::identity(const Dim dim, const dtype type) {
       af::identity({dim, dim}, detail::flToAfType(type)));
 }
 
+Tensor ArrayFireBackend::arange(
+    const Shape& shape,
+    const Dim seqDim,
+    const dtype type) {
+  return toTensor<ArrayFireTensor>(
+      af::range(detail::flToAfDims(shape), seqDim, detail::flToAfType(type)));
+}
+
+Tensor ArrayFireBackend::iota(
+    const Shape& dims,
+    const Shape& tileDims,
+    const dtype type) {
+  return toTensor<ArrayFireTensor>(af::iota(
+      detail::flToAfDims(dims),
+      detail::flToAfDims(tileDims),
+      detail::flToAfType(type)));
+}
+
 /************************ Shaping and Indexing *************************/
 Tensor ArrayFireBackend::reshape(const Tensor& tensor, const Shape& shape) {
   return toTensor<ArrayFireTensor>(

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
@@ -70,6 +70,10 @@ class ArrayFireBackend : public TensorBackend {
   Tensor concatenate(const std::vector<Tensor>& tensors, unsigned axis)
       override;
   Tensor nonzero(const Tensor& tensor) override;
+  Tensor pad(
+      const Tensor& input,
+      const std::vector<std::pair<int, int>>& padWidths,
+      const PadType type) override;
 
   /************************** Unary Operators ***************************/
   Tensor exp(const Tensor& tensor) override;

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
@@ -58,6 +58,10 @@ class ArrayFireBackend : public TensorBackend {
 #undef FL_FULL_FUN_BACKEND_DEF
 
   Tensor identity(const Dim dim, const dtype type) override;
+  Tensor arange(const Shape& shape, const Dim seqDim, const dtype type)
+      override;
+  Tensor iota(const Shape& dims, const Shape& tileDims, const dtype type)
+      override;
 
   /************************ Shaping and Indexing *************************/
   Tensor reshape(const Tensor& tensor, const Shape& shape) override;

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
@@ -85,11 +85,7 @@ af::array& ArrayFireTensor::ArrayComponent::get(const ArrayFireTensor& inst) {
 }
 
 const af::array& ArrayFireTensor::getHandle() const {
-  if (!std::holds_alternative<ArrayComponent>(handle_)) {
-    throw std::logic_error(
-        "ArrayFireTensor::getHandle() - underlying tensor is an array_proxy");
-  }
-  return *arrayHandle_;
+  return const_cast<ArrayFireTensor*>(this)->getHandle();
 }
 
 af::array& ArrayFireTensor::getHandle() {

--- a/flashlight/fl/tensor/backend/af/Utils.cpp
+++ b/flashlight/fl/tensor/backend/af/Utils.cpp
@@ -218,5 +218,20 @@ af::array fromFlData(
   }
 }
 
+af_border_type flToAfPadType(PadType type) {
+  switch (type) {
+    case PadType::Constant:
+      return AF_PAD_ZERO; // constant padding --> zero padding in AF
+    case PadType::Edge:
+      return AF_PAD_CLAMP_TO_EDGE;
+    case PadType::Symmetric:
+      return AF_PAD_SYM;
+    default:
+      throw std::invalid_argument(
+          "flToAfPadType: Flashlight padding "
+          "type not supported by ArrayFire");
+  }
+}
+
 } // namespace detail
 } // namespace fl

--- a/flashlight/fl/tensor/backend/af/Utils.h
+++ b/flashlight/fl/tensor/backend/af/Utils.h
@@ -90,5 +90,11 @@ af::array fromFlData(
     fl::dtype type,
     fl::Location memoryLocation);
 
+/**
+ * Convert a Flashlight PadType to an ArrayFire af_border_type for describing
+ * padding.
+ */
+af_border_type flToAfPadType(PadType type);
+
 } // namespace detail
 } // namespace fl

--- a/flashlight/fl/test/tensor/TensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/TensorBaseTest.cpp
@@ -396,3 +396,35 @@ TEST(TensorBaseTest, all) {
   ASSERT_FALSE(fl::all(t));
   ASSERT_TRUE(fl::all(Tensor::fromVector<unsigned>({1, 1, 1})));
 }
+
+TEST(TensorBaseTest, arange) {
+  // Range/step overload
+  ASSERT_TRUE(
+      allClose(fl::arange(2, 10, 2), Tensor::fromVector<int>({2, 4, 6, 8})));
+  ASSERT_TRUE(
+      allClose(fl::arange(0, 6), Tensor::fromVector<int>({0, 1, 2, 3, 4, 5})));
+  ASSERT_TRUE(allClose(
+      fl::arange(0., 1.22, 0.25),
+      Tensor::fromVector<float>({0., 0.25, 0.5, 0.75})));
+  ASSERT_TRUE(allClose(
+      fl::arange(0., 4.1), Tensor::fromVector<float>({0., 1., 2., 3.})));
+
+  // Shape overload
+  auto v = Tensor::fromVector<float>({0., 1., 2., 3.});
+  ASSERT_TRUE(allClose(fl::arange({4}), v));
+
+  ASSERT_TRUE(allClose(fl::arange({4, 5}), fl::tile(v, {1, 5})));
+  ASSERT_TRUE(allClose(
+      fl::arange({4, 5}, 1),
+      fl::tile(
+          fl::reshape(Tensor::fromVector<float>({0., 1., 2., 3., 4.}), {1, 5}),
+          {4})));
+  ASSERT_EQ(fl::arange({2, 6}, 0, fl::dtype::f64).type(), fl::dtype::f64);
+}
+
+TEST(TensorBaseTest, iota) {
+  ASSERT_TRUE(allClose(
+      fl::iota({5, 3}, {1, 2}),
+      fl::tile(fl::reshape(fl::arange({15}), {5, 3}), {1, 2})));
+  ASSERT_EQ(fl::iota({2, 2}, {2, 2}, fl::dtype::f64).type(), fl::dtype::f64);
+}


### PR DESCRIPTION
Summary: Add `fl::pad` which mirrors [numpy](https://numpy.org/doc/stable/reference/generated/numpy.pad.html)'s. Only supports `Constant` (with 0), `Edge` and `Symmetric` padding modes for now as those are the only modes ArrayFire supports. More modes can be later as needed.

Differential Revision: D29827519

