### PR TITLE
Tensor backend conversion - toTensorBackend

### DIFF
--- a/flashlight/fl/tensor/TensorAdapter.h
+++ b/flashlight/fl/tensor/TensorAdapter.h
@@ -98,6 +98,13 @@ class TensorAdapterBase {
   virtual dtype type() = 0;
 
   /**
+   * Get a tensor's location, host or some device.
+   *
+   * @return the tensor's location
+   */
+  virtual Location location() = 0;
+
+  /**
    * Populate a pointer with a scalar for the first element of the tensor.
    */
   virtual void scalar(void* out) = 0;

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -55,6 +55,10 @@ const Shape& Tensor::shape() const {
   return impl_->shape();
 }
 
+Location Tensor::location() const {
+  return impl_->location();
+}
+
 size_t Tensor::size() const {
   return impl_->shape().elements();
 }

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -152,6 +152,13 @@ class Tensor {
   const Shape& shape() const;
 
   /**
+   * Get a tensor's location, host or some device.
+   *
+   * @return the tensor's location
+   */
+  Location location() const;
+
+  /**
    * Get the number of elements in the tensor.
    *
    * @return the size of the tensor in elements.

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
@@ -17,6 +17,7 @@
 #include "flashlight/fl/tensor/backend/af/Utils.h"
 
 #include <af/arith.h>
+#include <af/backend.h>
 #include <af/device.h>
 #include <af/internal.h>
 
@@ -139,6 +140,19 @@ const Shape& ArrayFireTensor::shape() {
 
 fl::dtype ArrayFireTensor::type() {
   return detail::afToFlType(getHandle().type());
+}
+
+Location ArrayFireTensor::location() {
+  switch (af::getBackendId(getHandle())) {
+    case AF_BACKEND_CUDA:
+    case AF_BACKEND_OPENCL:
+      return Location::Device;
+    case AF_BACKEND_CPU:
+      return Location::Host;
+    default:
+      throw std::logic_error(
+          "ArrayFireTensor::location got an unmatched location");
+  }
 }
 
 void ArrayFireTensor::scalar(void* out) {

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
@@ -154,6 +154,7 @@ class ArrayFireTensor : public TensorAdapterBase {
   Tensor shallowCopy() override;
   const Shape& shape() override;
   dtype type() override;
+  Location location() override;
   void scalar(void* out) override;
   void device(void** out) override;
   void host(void** out) override;

--- a/flashlight/fl/test/tensor/ArrayFireTensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/ArrayFireTensorBaseTest.cpp
@@ -7,9 +7,12 @@
 
 #include <arrayfire.h>
 #include <gtest/gtest.h>
+
 #include <stdexcept>
+#include <utility>
 
 #include "flashlight/fl/tensor/Random.h"
+#include "flashlight/fl/tensor/TensorBackend.h"
 #include "flashlight/fl/tensor/TensorBase.h"
 #include "flashlight/fl/tensor/backend/af/ArrayFireTensor.h"
 #include "flashlight/fl/tensor/backend/af/Utils.h"
@@ -56,6 +59,16 @@ TEST(ArrayFireTensorBaseTest, AfRefCountBasic) {
   auto aNoRef = toArray(tensor);
   af_get_data_ref_count(&refCount, aNoRef.get());
   ASSERT_EQ(refCount, 2);
+}
+
+TEST(ArrayFireTensorBaseTest, BackendInterop) {
+  // test toTensorType here since we know we have a backend available
+  auto a = fl::rand({10, 12});
+  ASSERT_EQ(a.backendType(), TensorBackendType::ArrayFire);
+  auto b = a;
+  auto t = fl::toTensorType<ArrayFireTensor>(std::move(a));
+  ASSERT_EQ(t.backendType(), TensorBackendType::ArrayFire);
+  ASSERT_TRUE(allClose(b, t));
 }
 
 TEST(ArrayFireTensorBaseTest, ArrayFireAssignmentOperators) {


### PR DESCRIPTION
Summary:
Backend conversion across Tensors.

The implementation requirement for `fl::Tensor::device<T>()` stipulates that memory isn't freed if the underlying tensor falls out of scope unless `unlock` is called — means a device pointer can be used even after the tensor dies since the func takes a `Tensor&&`.

UB can occur if the user creates a shallow tensor copy then converts one of the shallow copy into another tensor (depending on how each backend manipulates the underlying memory), but this could be useful in some cases to save memory, etc, so left as is for the user to control.

Differential Revision: D29856404

