### PR TITLE
Add runtime switching of tensor backends

### DIFF
--- a/flashlight/fl/tensor/TensorAdapter.h
+++ b/flashlight/fl/tensor/TensorAdapter.h
@@ -98,6 +98,13 @@ class TensorAdapterBase {
   virtual dtype type() = 0;
 
   /**
+   * Get a tensor's location, host or some device.
+   *
+   * @return the tensor's location
+   */
+  virtual Location location() = 0;
+
+  /**
    * Populate a pointer with a scalar for the first element of the tensor.
    */
   virtual void scalar(void* out) = 0;

--- a/flashlight/fl/tensor/TensorBackend.h
+++ b/flashlight/fl/tensor/TensorBackend.h
@@ -7,6 +7,10 @@
 
 #pragma once
 
+#include <memory>
+#include <type_traits>
+#include <utility>
+
 #include "flashlight/fl/tensor/TensorBase.h"
 
 namespace fl {
@@ -176,6 +180,32 @@ class TensorBackend {
   /************************** Utils ***************************/
   virtual void print(const Tensor& tensor) = 0;
 };
+
+/**
+ * Convert a Tensor from one backend to another.
+ *
+ * The resulting tensor will have the same shape, type, and contents.
+ *
+ * @param[in]
+ */
+template <typename T>
+Tensor toTensorBackend(Tensor&& in) {
+  static_assert(
+      std::is_base_of<TensorAdapterBase, T>::value,
+      "toTensorBackend: T must be a derived type of TensorAdapterBase");
+  // Fast path - backend is the same
+  if (in.backendType() == T().backendType()) {
+    return std::move(in);
+  }
+
+  // As per impl requirements, Tensor::device() should return a pointer to host
+  // memory if the tensor resides on the host.
+  return Tensor(std::make_unique<T>(
+      in.shape(),
+      in.type(),
+      reinterpret_cast<void*>(in.device<char>()), // expects contiguous memory
+      in.location()));
+}
 
 namespace detail {
 

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -55,6 +55,10 @@ const Shape& Tensor::shape() const {
   return impl_->shape();
 }
 
+Location Tensor::location() const {
+  return impl_->location();
+}
+
 size_t Tensor::size() const {
   return impl_->shape().elements();
 }

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -151,6 +151,13 @@ class Tensor {
   const Shape& shape() const;
 
   /**
+   * Get a tensor's location, host or some device.
+   *
+   * @return the tensor's location
+   */
+  Location location() const;
+
+  /**
    * Get the number of elements in the tensor.
    *
    * @return the size of the tensor in elements.

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
@@ -17,6 +17,7 @@
 #include "flashlight/fl/tensor/backend/af/Utils.h"
 
 #include <af/arith.h>
+#include <af/backend.h>
 #include <af/device.h>
 #include <af/internal.h>
 
@@ -143,6 +144,19 @@ const Shape& ArrayFireTensor::shape() {
 
 fl::dtype ArrayFireTensor::type() {
   return detail::afToFlType(getHandle().type());
+}
+
+Location ArrayFireTensor::location() {
+  switch (af::getBackendId(getHandle())) {
+    case AF_BACKEND_CUDA:
+    case AF_BACKEND_OPENCL:
+      return Location::Device;
+    case AF_BACKEND_CPU:
+      return Location::Host;
+    default:
+      throw std::logic_error(
+          "ArrayFireTensor::location got an unmatched location");
+  }
 }
 
 void ArrayFireTensor::scalar(void* out) {

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
@@ -154,6 +154,7 @@ class ArrayFireTensor : public TensorAdapterBase {
   Tensor shallowCopy() override;
   const Shape& shape() override;
   dtype type() override;
+  Location location() override;
   void scalar(void* out) override;
   void device(void** out) override;
   void host(void** out) override;

--- a/flashlight/fl/test/tensor/ArrayFireTensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/ArrayFireTensorBaseTest.cpp
@@ -7,9 +7,12 @@
 
 #include <arrayfire.h>
 #include <gtest/gtest.h>
+
 #include <stdexcept>
+#include <utility>
 
 #include "flashlight/fl/tensor/Random.h"
+#include "flashlight/fl/tensor/TensorBackend.h"
 #include "flashlight/fl/tensor/TensorBase.h"
 #include "flashlight/fl/tensor/backend/af/ArrayFireTensor.h"
 #include "flashlight/fl/tensor/backend/af/Utils.h"
@@ -56,6 +59,16 @@ TEST(ArrayFireTensorBaseTest, AfRefCountBasic) {
   auto aNoRef = toArray(tensor);
   af_get_data_ref_count(&refCount, aNoRef.get());
   ASSERT_EQ(refCount, 2);
+}
+
+TEST(ArrayFireTensorBaseTest, BackendInterop) {
+  // test toTensorBackend here since we know we have a backend available
+  auto a = fl::rand({10, 12});
+  ASSERT_EQ(a.backendType(), TensorBackendType::ArrayFire);
+  auto b = a;
+  auto t = fl::toTensorBackend<ArrayFireTensor>(std::move(a));
+  ASSERT_EQ(t.backendType(), TensorBackendType::ArrayFire);
+  ASSERT_TRUE(allClose(b, t));
 }
 
 TEST(ArrayFireTensorBaseTest, ArrayFireAssignmentOperators) {

--- a/flashlight/fl/test/tensor/ArrayFireTensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/ArrayFireTensorBaseTest.cpp
@@ -62,13 +62,37 @@ TEST(ArrayFireTensorBaseTest, AfRefCountBasic) {
 }
 
 TEST(ArrayFireTensorBaseTest, BackendInterop) {
-  // test toTensorBackend here since we know we have a backend available
+  // TODO: test toTensorBackend here since we know we have a backend available;
+  // design a test that tests with mulitple backends once available
   auto a = fl::rand({10, 12});
   ASSERT_EQ(a.backendType(), TensorBackendType::ArrayFire);
   auto b = a;
   auto t = fl::toTensorBackend<ArrayFireTensor>(std::move(a));
   ASSERT_EQ(t.backendType(), TensorBackendType::ArrayFire);
   ASSERT_TRUE(allClose(b, t));
+}
+
+TEST(ArrayFireTensorBaseTest, DefaultTensorType) {
+  // TODO: we know we have a backend available, so test here; design a test that
+  // tests with multiple backends
+  Tensor t;
+  ASSERT_EQ(t.backendType(), TensorBackendType::ArrayFire);
+
+  fl::setDefaultTensorType<ArrayFireTensor>();
+  // Backend remains unchanged
+  Tensor u;
+  ASSERT_EQ(u.backendType(), TensorBackendType::ArrayFire);
+}
+
+TEST(ArrayFireTensorBaseTest, withTensorType) {
+  // TODO: test with here since we know we have a backend available;
+  // design a test that tests with mulitple backends once available
+  Tensor t;
+  fl::withTensorType<ArrayFireTensor>([&t]() {
+    t = fl::full({5, 5}, 6.);
+    t += 1;
+  });
+  ASSERT_TRUE(allClose(t, fl::full({5, 5}, 7.)));
 }
 
 TEST(ArrayFireTensorBaseTest, ArrayFireAssignmentOperators) {

--- a/flashlight/fl/test/tensor/TensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/TensorBaseTest.cpp
@@ -340,7 +340,7 @@ TEST(TensorBaseTest, matmul) {
     int N = lhs.dim(1);
     int K = rhs.dim(1);
 
-    Tensor out({M, K});
+    auto out = fl::full({M, K}, 0.);
     for (unsigned i = 0; i < M; ++i) {
       for (unsigned j = 0; j < K; ++j) {
         for (unsigned k = 0; k < N; ++k) {
@@ -358,19 +358,16 @@ TEST(TensorBaseTest, matmul) {
   auto a = fl::rand({i, j});
   auto b = fl::rand({j, k});
   auto ref = matmulRef(a, b);
-  ASSERT_TRUE(allClose(fl::matmul(a, b), ref, 1e-4));
+  ASSERT_TRUE(allClose(fl::matmul(a, b), ref));
   ASSERT_TRUE(allClose(
       fl::matmul(
           a,
           fl::transpose(b),
           fl::MatrixProperty::None,
           fl::MatrixProperty::Transpose),
-      ref,
-      1e-4));
+      ref));
   ASSERT_TRUE(allClose(
-      fl::matmul(fl::transpose(a), b, fl::MatrixProperty::Transpose),
-      ref,
-      1e-4));
+      fl::matmul(fl::transpose(a), b, fl::MatrixProperty::Transpose), ref));
 }
 
 TEST(TensorBaseTest, any) {


### PR DESCRIPTION
Summary:
See title.

Since tensor types are parameterized by derived types of `TensorAdapterBase`, the argument to `setDefaultTensorBackend<T>()` is a type. The type gets captured and stored via a closure on `DefaultTensorType` which returns a pointer to the adapter created with the requisite params.

Usage (see test):
```
fl::setDefaultTensorType<ArrayFireTensor>();
// ...
fl::setDefaultTensorType<FooTensor>();
```

Differential Revision: D29869330

