### PR TITLE
Rename nDims ndim, add Tensor::isEmpty

### DIFF
--- a/flashlight/fl/tensor/Shape.cpp
+++ b/flashlight/fl/tensor/Shape.cpp
@@ -24,7 +24,7 @@ size_t Shape::elements() const {
   return std::accumulate(dims_.begin(), dims_.end(), 1, std::multiplies<Dim>());
 }
 
-size_t Shape::nDims() const {
+size_t Shape::ndim() const {
   return dims_.size();
 }
 
@@ -63,7 +63,7 @@ bool Shape::operator!=(const std::initializer_list<Dim>& other) const {
 }
 
 std::ostream& operator<<(std::ostream& ostr, const Shape& s) {
-  for (size_t i = 0; i < s.nDims(); ++i) {
+  for (size_t i = 0; i < s.ndim(); ++i) {
     ostr << s.dim(i) << " ";
   }
   return ostr;

--- a/flashlight/fl/tensor/Shape.h
+++ b/flashlight/fl/tensor/Shape.h
@@ -74,7 +74,7 @@ class Shape {
   /**
    * @return Number of dimensions in the shape.
    */
-  size_t nDims() const;
+  size_t ndim() const;
 
   /**
    * Get the size of a given dimension in the number of arguments. Throws if the

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -63,6 +63,14 @@ Dim Tensor::dim(const size_t dim) const {
   return shape().dim(dim);
 }
 
+unsigned Tensor::ndim() const {
+  return shape().ndim();
+}
+
+bool Tensor::isEmpty() const {
+  return size() == 0;
+}
+
 size_t Tensor::bytes() const {
   return size() * getTypeSize(type());
 }

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -168,6 +168,20 @@ class Tensor {
   Dim dim(const size_t dim) const;
 
   /**
+   * Get the number of directions of the tensor.
+   *
+   * @return the number of dimensions
+   */
+  unsigned ndim() const;
+
+  /**
+   * Returns true if the tensor has zero elements, else false.
+   *
+   * @return true if the tensor is empty
+   */
+  bool isEmpty() const;
+
+  /**
    * Get the tensor size in bytes.
    *
    * @return the size of the tensor in bytes.

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
@@ -144,17 +144,17 @@ Tensor ArrayFireBackend::reshape(const Tensor& tensor, const Shape& shape) {
 Tensor ArrayFireBackend::transpose(
     const Tensor& tensor,
     const Shape& dims /* = {} */) {
-  if (tensor.shape().nDims() == 2 &&
-      (dims.nDims() == 0 || dims == Shape({1, 0}))) {
+  if (tensor.shape().ndim() == 2 &&
+      (dims.ndim() == 0 || dims == Shape({1, 0}))) {
     // fastpath for matrices
     return toTensor<ArrayFireTensor>(
         detail::condenseIndices(af::transpose(toArray(tensor))));
-  } else if (dims.nDims() == 0) {
+  } else if (dims.ndim() == 0) {
     // flip all dimensions
     return toTensor<ArrayFireTensor>(
         detail::condenseIndices(af::reorder(toArray(tensor), 3, 2, 1, 0)));
   } else {
-    if (dims.nDims() > AF_MAX_DIMS) {
+    if (dims.ndim() > AF_MAX_DIMS) {
       throw std::invalid_argument(
           "ArrayFire tensor transpose was given "
           "permutation dims with > 4 axes");
@@ -162,7 +162,7 @@ Tensor ArrayFireBackend::transpose(
     // reorder based on specified dimensions
     std::vector<dim_t> d(AF_MAX_DIMS);
     std::iota(std::begin(d), std::end(d), 0);
-    for (size_t i = 0; i < dims.nDims(); ++i) {
+    for (size_t i = 0; i < dims.ndim(); ++i) {
       d[i] = dims[i];
     }
     return toTensor<ArrayFireTensor>(detail::condenseIndices(

--- a/flashlight/fl/tensor/backend/af/Utils.cpp
+++ b/flashlight/fl/tensor/backend/af/Utils.cpp
@@ -63,7 +63,7 @@ af_mat_prop flToAfMatrixProperty(MatrixProperty property) {
 }
 
 af::dim4 flToAfDims(const Shape& shape) {
-  if (shape.nDims() > 4) {
+  if (shape.ndim() > 4) {
     throw std::invalid_argument(
         "flToAfDims: ArrayFire shapes can't be more than 4 dimensions");
   }
@@ -71,7 +71,7 @@ af::dim4 flToAfDims(const Shape& shape) {
     return af::dim4(0);
   }
   af::dim4 out(1, 1, 1, 1);
-  for (size_t i = 0; i < shape.nDims(); ++i) {
+  for (size_t i = 0; i < shape.ndim(); ++i) {
     out.dims[i] = shape.dim(i);
   }
   return out;

--- a/flashlight/fl/test/tensor/ShapeTest.cpp
+++ b/flashlight/fl/test/tensor/ShapeTest.cpp
@@ -20,7 +20,7 @@ using namespace fl;
 
 TEST(ShapeTest, Basic) {
   auto s = Shape({3, 4});
-  ASSERT_EQ(s.nDims(), 2);
+  ASSERT_EQ(s.ndim(), 2);
   ASSERT_EQ(s.dim(0), 3);
   ASSERT_EQ(s.dim(1), 4);
   EXPECT_THROW(s.dim(5), std::invalid_argument);
@@ -31,19 +31,19 @@ TEST(ShapeTest, ManyDims) {
     GTEST_SKIP() << "Max shape dimensions is <= 4";
   }
   auto many = Shape({1, 2, 3, 4, 5, 6, 7});
-  ASSERT_EQ(many.nDims(), 7);
+  ASSERT_EQ(many.ndim(), 7);
   ASSERT_EQ(many.dim(5), 6);
 }
 
-TEST(ShapeTest, nDims) {
-  ASSERT_EQ(Shape().nDims(), 0);
-  ASSERT_EQ(Shape({1, 1, 1}).nDims(), 3);
-  ASSERT_EQ(Shape({5, 2, 3}).nDims(), 3);
-  ASSERT_EQ(Shape({1, 2, 3, 6}).nDims(), 4);
+TEST(ShapeTest, ndim) {
+  ASSERT_EQ(Shape().ndim(), 0);
+  ASSERT_EQ(Shape({1, 1, 1}).ndim(), 3);
+  ASSERT_EQ(Shape({5, 2, 3}).ndim(), 3);
+  ASSERT_EQ(Shape({1, 2, 3, 6}).ndim(), 4);
   if (Shape::kMaxDims > 4) {
-    ASSERT_EQ(Shape({1, 2, 3, 1, 1, 1}).nDims(), 6);
-    ASSERT_EQ(Shape({1, 2, 3, 1, 1, 1, 5}).nDims(), 7);
-    ASSERT_EQ(Shape({4, 2, 3, 1, 1, 1, 5}).nDims(), 7);
+    ASSERT_EQ(Shape({1, 2, 3, 1, 1, 1}).ndim(), 6);
+    ASSERT_EQ(Shape({1, 2, 3, 1, 1, 1, 5}).ndim(), 7);
+    ASSERT_EQ(Shape({4, 2, 3, 1, 1, 1, 5}).ndim(), 7);
   }
 }
 

--- a/flashlight/fl/test/tensor/TensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/TensorBaseTest.cpp
@@ -37,7 +37,11 @@ TEST(TensorBaseTest, Metadata) {
   int s = 9;
   auto t = fl::rand({s, s});
   ASSERT_EQ(t.size(), s * s);
+  ASSERT_FALSE(t.isEmpty());
   ASSERT_EQ(t.bytes(), s * s * sizeof(float));
+
+  Tensor e;
+  ASSERT_TRUE(e.isEmpty());
 }
 
 TEST(TensorBaseTest, BinaryOperators) {


### PR DESCRIPTION
Summary: See title - renames `Shape::nDims` to be `Shape::ndim` and add `Tensor::ndim()` to adhere to [numpy](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.ndim.html).

Differential Revision: D29888494

