### PR TITLE
Tensor::strides

### DIFF
--- a/flashlight/fl/tensor/TensorAdapter.h
+++ b/flashlight/fl/tensor/TensorAdapter.h
@@ -136,6 +136,12 @@ class TensorAdapterBase {
   virtual bool isContiguous() = 0;
 
   /**
+   * Get the dimension-wise strides for this tensor - the number of bytes to
+   * step in each direction when traversing.
+   */
+  virtual Shape strides() = 0;
+
+  /**
    * Returns a tensor with elements cast as a particular type
    *
    * @param[in] the type to which to cast the tensor

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -160,6 +160,10 @@ bool Tensor::isContiguous() const {
   return impl_->isContiguous();
 }
 
+Shape Tensor::strides() const {
+  return impl_->strides();
+}
+
 void Tensor::setContext(void* context) {
   impl_->setContext(context);
 }

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -203,6 +203,14 @@ class Tensor {
   dtype type() const;
 
   /**
+   * Get this tensor's strides - the number of elements/coefficients to step
+   * when moving along each dimension when traversing the tensor.
+   *
+   * @return a Shape containing strides in each dimension.
+   */
+  Shape strides() const;
+
+  /**
    * Returns a tensor with elements cast as a particular type
    *
    * @param[in] the type to which to cast the tensor

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
@@ -175,6 +175,11 @@ bool ArrayFireTensor::isContiguous() {
   return af::isLinear(getHandle());
 }
 
+Shape ArrayFireTensor::strides() {
+  // TODO(jacobkahn) do we need to condenseDims here?
+  return detail::afToFlDims(af::getStrides(getHandle()));
+}
+
 Tensor ArrayFireTensor::astype(const dtype type) {
   auto a = getHandle().as(detail::flToAfType(type));
   return toTensor<ArrayFireTensor>(std::move(a));

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
@@ -160,6 +160,7 @@ class ArrayFireTensor : public TensorAdapterBase {
   void host(void** out) override;
   void unlock() override;
   bool isContiguous() override;
+  Shape strides() override;
   Tensor astype(const dtype type) override;
   Tensor index(const std::vector<Index>& indices) override;
   Tensor flatten() const override;

--- a/flashlight/fl/test/tensor/TensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/TensorBaseTest.cpp
@@ -310,6 +310,12 @@ TEST(TensorBaseTest, isContiguous) {
   ASSERT_TRUE(a.isContiguous());
 }
 
+TEST(TensorBaseTest, strides) {
+  // TODO(jacobkahn): fix this up/see if there's something universal
+  auto t = fl::rand({10, 10});
+  ASSERT_EQ(t.strides(), Shape({1, 10, 100, 100}));
+}
+
 TEST(TensorBaseTest, host) {
   auto a = fl::rand({10, 10});
 


### PR DESCRIPTION
Summary:
Add `fl::Tensor::strides`.

Need to investigate whether or not ArrayFire strides dims need to be condensed -- for now, leave leaving 1 dimensions as they are.

Differential Revision: D29891935

