### PR TITLE
Add sigmoid and erf Tensor ops

### DIFF
--- a/flashlight/fl/tensor/TensorAdapter.h
+++ b/flashlight/fl/tensor/TensorAdapter.h
@@ -136,6 +136,12 @@ class TensorAdapterBase {
   virtual bool isContiguous() = 0;
 
   /**
+   * Get the dimension-wise strides for this tensor - the number of bytes to
+   * step in each direction when traversing.
+   */
+  virtual Shape strides() = 0;
+
+  /**
    * Returns a tensor with elements cast as a particular type
    *
    * @param[in] the type to which to cast the tensor

--- a/flashlight/fl/tensor/TensorBackend.h
+++ b/flashlight/fl/tensor/TensorBackend.h
@@ -99,6 +99,8 @@ class TensorBackend {
   virtual Tensor floor(const Tensor& tensor) = 0;
   virtual Tensor ceil(const Tensor& tensor) = 0;
   virtual Tensor absolute(const Tensor& tensor) = 0;
+  virtual Tensor sigmoid(const Tensor& tensor) = 0;
+  virtual Tensor erf(const Tensor& tensor) = 0;
   virtual Tensor
   clip(const Tensor& tensor, const Tensor& low, const Tensor& high) = 0;
   virtual Tensor isnan(const Tensor& tensor) = 0;

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -160,6 +160,10 @@ bool Tensor::isContiguous() const {
   return impl_->isContiguous();
 }
 
+Shape Tensor::strides() const {
+  return impl_->strides();
+}
+
 void Tensor::setContext(void* context) {
   impl_->setContext(context);
 }

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -378,6 +378,14 @@ Tensor absolute(const Tensor& tensor) {
   return tensor.backend().absolute(tensor);
 }
 
+Tensor sigmoid(const Tensor& tensor) {
+  return tensor.backend().sigmoid(tensor);
+}
+
+Tensor erf(const Tensor& tensor) {
+  return tensor.backend().erf(tensor);
+}
+
 Tensor clip(const Tensor& tensor, const Tensor& low, const Tensor& high) {
   FL_TENSOR_BACKENDS_MATCH_CHECK(tensor, low, high);
   return tensor.backend().clip(tensor, low, high);

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -203,6 +203,14 @@ class Tensor {
   dtype type() const;
 
   /**
+   * Get this tensor's strides - the number of elements/coefficients to step
+   * when moving along each dimension when traversing the tensor.
+   *
+   * @return a Shape containing strides in each dimension.
+   */
+  Shape strides() const;
+
+  /**
    * Returns a tensor with elements cast as a particular type
    *
    * @param[in] the type to which to cast the tensor

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -645,6 +645,21 @@ inline Tensor abs(const Tensor& tensor) {
 }
 
 /**
+ * Returns the element-wise sigmoid the input:
+ * \f[ out_i = \frac{1}{1 + \exp(-var_i)} \f]
+ *
+ * @param[in] tensor the tensor on which to compute
+ * @return the resulting tensor
+ */
+Tensor sigmoid(const Tensor& tensor);
+
+/**
+ * Computes the element-wise error function the input: see
+ * [here](https://en.wikipedia.org/wiki/Error_function) for details.
+ */
+Tensor erf(const Tensor& tensor);
+
+/**
  * Clip (limit) the values of a tensor. Given some interval of values, set
  * values outside of that interval to be the boundaries of the interval. All
  * values larger than the max become the max, and all values smaller than the

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
@@ -268,6 +268,14 @@ Tensor ArrayFireBackend::absolute(const Tensor& tensor) {
   return toTensor<ArrayFireTensor>(af::abs(toArray(tensor)));
 }
 
+Tensor ArrayFireBackend::sigmoid(const Tensor& tensor) {
+  return toTensor<ArrayFireTensor>(af::sigmoid(toArray(tensor)));
+}
+
+Tensor ArrayFireBackend::erf(const Tensor& tensor) {
+  return toTensor<ArrayFireTensor>(af::erf(toArray(tensor)));
+}
+
 Tensor ArrayFireBackend::clip(
     const Tensor& tensor,
     const Tensor& low,

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
@@ -88,6 +88,8 @@ class ArrayFireBackend : public TensorBackend {
   Tensor floor(const Tensor& tensor) override;
   Tensor ceil(const Tensor& tensor) override;
   Tensor absolute(const Tensor& tensor) override;
+  Tensor sigmoid(const Tensor& tensor) override;
+  Tensor erf(const Tensor& tensor) override;
   Tensor clip(const Tensor& tensor, const Tensor& low, const Tensor& high)
       override;
   Tensor isnan(const Tensor& tensor) override;

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
@@ -175,6 +175,11 @@ bool ArrayFireTensor::isContiguous() {
   return af::isLinear(getHandle());
 }
 
+Shape ArrayFireTensor::strides() {
+  // TODO(jacobkahn) do we need to condenseDims here?
+  return detail::afToFlDims(af::getStrides(getHandle()));
+}
+
 Tensor ArrayFireTensor::astype(const dtype type) {
   auto a = getHandle().as(detail::flToAfType(type));
   return toTensor<ArrayFireTensor>(std::move(a));

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
@@ -160,6 +160,7 @@ class ArrayFireTensor : public TensorAdapterBase {
   void host(void** out) override;
   void unlock() override;
   bool isContiguous() override;
+  Shape strides() override;
   Tensor astype(const dtype type) override;
   Tensor index(const std::vector<Index>& indices) override;
   Tensor flatten() const override;

--- a/flashlight/fl/test/tensor/ArrayFireTensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/ArrayFireTensorBaseTest.cpp
@@ -227,6 +227,11 @@ TEST(ArrayFireTensorBaseTest, absolute) {
   ASSERT_TRUE(allClose(fl::abs(fl::full({3, 3}, val)), fl::full({3, 3}, -val)));
 }
 
+TEST(ArrayFireTensorBaseTest, erf) {
+  auto in = fl::rand({3, 3});
+  ASSERT_TRUE(allClose(toArray(fl::erf(in)), af::erf(toArray(in))));
+}
+
 TEST(ArrayFireTensorBaseTest, mean) {
   auto a = fl::rand({3, 50});
   ASSERT_EQ(fl::mean<float>(a), af::mean<float>(toArray(a)));

--- a/flashlight/fl/test/tensor/TensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/TensorBaseTest.cpp
@@ -292,6 +292,11 @@ TEST(TensorBaseTest, ceil) {
   ASSERT_TRUE(allClose((a >= 1).astype(fl::dtype::f32), fl::ceil(a) - 1));
 }
 
+TEST(TensorBaseTest, sigmoid) {
+  auto a = fl::rand({10, 10});
+  ASSERT_TRUE(allClose(1 / (1 + fl::exp(-a)), fl::sigmoid(a)));
+}
+
 TEST(TensorBaseTest, scalar) {
   // TODO: exhaustively test all types + fixture
   float val = 8.47;

--- a/flashlight/fl/test/tensor/TensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/TensorBaseTest.cpp
@@ -310,6 +310,12 @@ TEST(TensorBaseTest, isContiguous) {
   ASSERT_TRUE(a.isContiguous());
 }
 
+TEST(TensorBaseTest, strides) {
+  // TODO(jacobkahn): fix this up/see if there's something universal
+  auto t = fl::rand({10, 10});
+  ASSERT_EQ(t.strides(), Shape({1, 10, 100, 100}));
+}
+
 TEST(TensorBaseTest, host) {
   auto a = fl::rand({10, 10});
 


### PR DESCRIPTION
Summary: Add sigmoid and [erf](https://en.wikipedia.org/wiki/Error_function) ops to the `fl::Tensor` API for convenience.

Differential Revision: D29893512

