### PR TITLE
Tensor API updates pre-autograd integration

### DIFF
--- a/flashlight/fl/tensor/Index.h
+++ b/flashlight/fl/tensor/Index.h
@@ -37,6 +37,11 @@ class range {
 
  public:
   /**
+   * Default ctor.
+   */
+  range() = default;
+
+  /**
    * Construct a range with the indices [0, idx) (i.e. [0, idx - 1])
    */
   explicit range(idx idx);
@@ -95,6 +100,11 @@ class Index {
   /* implicit */ Index(const Tensor& tensor);
   /* implicit */ Index(const range& range);
   /* implicit */ Index(const int idx);
+
+  /**
+   * Default copy assignment operator.
+   */
+  Index& operator=(const Index&) = default;
 
   /**
    * Move constructor - moves the index data.

--- a/flashlight/fl/tensor/TensorBackend.h
+++ b/flashlight/fl/tensor/TensorBackend.h
@@ -164,27 +164,38 @@ class TensorBackend {
       MatrixProperty rhsProp) = 0;
 
   /************************** Reductions ***************************/
-  virtual Tensor amin(const Tensor& input, const std::vector<int>& axes) = 0;
-  virtual double amin(const Tensor& input) = 0; // TODO: consoildate w/ above
-  virtual Tensor amax(const Tensor& input, const std::vector<int>& axes) = 0;
-  virtual double amax(const Tensor& input) = 0; // TODO: consoildate w/ above
-  virtual Tensor sum(const Tensor& input, const std::vector<int>& axes) = 0;
-  virtual double sum(const Tensor& input) = 0; // TODO: consolidate w/ above
-  virtual Tensor mean(const Tensor& input, const std::vector<int>& axes) = 0;
-  virtual double mean(const Tensor& input) = 0; // TODO: consolidate w/ above
   virtual Tensor
-  var(const Tensor& input, const std::vector<int>& axes, bool bias) = 0;
+  amin(const Tensor& input, const std::vector<int>& axes, bool keepDims) = 0;
+  virtual double amin(const Tensor& input) = 0; // TODO: consoildate w/ above
+  virtual Tensor
+  amax(const Tensor& input, const std::vector<int>& axes, bool keepDims) = 0;
+  virtual double amax(const Tensor& input) = 0; // TODO: consoildate w/ above
+  virtual Tensor
+  sum(const Tensor& input, const std::vector<int>& axes, bool keepDims) = 0;
+  virtual double sum(const Tensor& input) = 0; // TODO: consolidate w/ above
+  virtual Tensor
+  mean(const Tensor& input, const std::vector<int>& axes, bool keepDims) = 0;
+  virtual double mean(const Tensor& input) = 0; // TODO: consolidate w/ above
+  virtual Tensor var(
+      const Tensor& input,
+      const std::vector<int>& axes,
+      bool bias,
+      bool keepDims) = 0;
   virtual double var(
       const Tensor& input,
       bool bias) = 0; // TODO: consolidate w/ above
-  virtual Tensor std(const Tensor& input, const std::vector<int>& axes) = 0;
+  virtual Tensor
+  std(const Tensor& input, const std::vector<int>& axes, bool keepDims) = 0;
   virtual double norm(const Tensor& input) = 0; // TODO: consolidate w/ above
   virtual Tensor countNonzero(
       const Tensor& input,
-      const std::vector<int>& axes) = 0;
-  virtual Tensor any(const Tensor& input, const std::vector<int>& axes) = 0;
+      const std::vector<int>& axes,
+      bool keepDims) = 0;
+  virtual Tensor
+  any(const Tensor& input, const std::vector<int>& axes, bool keepDims) = 0;
   virtual bool any(const Tensor& input) = 0; // TODO: consolidate w/ above
-  virtual Tensor all(const Tensor& input, const std::vector<int>& axes) = 0;
+  virtual Tensor
+  all(const Tensor& input, const std::vector<int>& axes, bool keepDims) = 0;
   virtual bool all(const Tensor& input) = 0; // TODO: consolidate w/ above
 
   /************************** Utils ***************************/

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
@@ -20,11 +20,21 @@ namespace fl {
 class ArrayFireBackend : public TensorBackend {
   // TODO: consolidate the ArrayFire memory manager here so its global state can
   // be stored/we can reduce the number of singletons.
- public:
+
+  // Intentionally private. Only one instance should exist/it should be accessed
+  // via getInstance().
   ArrayFireBackend();
+
+ public:
+  static ArrayFireBackend& getInstance();
+
   ~ArrayFireBackend() override = default;
 
-  static ArrayFireBackend& getInstance();
+  // No copy or move construction or assignment
+  ArrayFireBackend(ArrayFireBackend&&) = delete;
+  ArrayFireBackend(const ArrayFireBackend&) = delete;
+  ArrayFireBackend& operator=(ArrayFireBackend&&) = delete;
+  ArrayFireBackend& operator=(const ArrayFireBackend&) = delete;
 
   /* -------------------------- Compute Functions -------------------------- */
   void sync() override;
@@ -153,25 +163,37 @@ class ArrayFireBackend : public TensorBackend {
       MatrixProperty rhsProp) override;
 
   /************************** Reductions ***************************/
-  Tensor amin(const Tensor& input, const std::vector<int>& axes) override;
-  double amin(const Tensor& input) override; // TODO: consolidate w/ above
-  Tensor amax(const Tensor& input, const std::vector<int>& axes) override;
-  double amax(const Tensor& input) override; // TODO: consolidate w/ above
-  Tensor sum(const Tensor& input, const std::vector<int>& axes) override;
-  double sum(const Tensor& input) override; // TODO: consolidate w/ above
-  Tensor mean(const Tensor& input, const std::vector<int>& axes) override;
-  double mean(const Tensor& input) override; // TODO: consolidate w/ above
-  Tensor var(const Tensor& input, const std::vector<int>& axes, const bool bias)
+  Tensor amin(const Tensor& input, const std::vector<int>& axes, bool keepDims)
       override;
+  double amin(const Tensor& input) override; // TODO: consolidate w/ above
+  Tensor amax(const Tensor& input, const std::vector<int>& axes, bool keepDims)
+      override;
+  double amax(const Tensor& input) override; // TODO: consolidate w/ above
+  Tensor sum(const Tensor& input, const std::vector<int>& axes, bool keepDims)
+      override;
+  double sum(const Tensor& input) override; // TODO: consolidate w/ above
+  Tensor mean(const Tensor& input, const std::vector<int>& axes, bool keepDims)
+      override;
+  double mean(const Tensor& input) override; // TODO: consolidate w/ above
+  Tensor var(
+      const Tensor& input,
+      const std::vector<int>& axes,
+      const bool bias,
+      bool keepDims) override;
   double var(const Tensor& input, const bool bias)
       override; // TODO: consolidate w/ above
-  Tensor std(const Tensor& input, const std::vector<int>& axes) override;
-  double norm(const Tensor& input) override;
-  Tensor countNonzero(const Tensor& input, const std::vector<int>& axes)
+  Tensor std(const Tensor& input, const std::vector<int>& axes, bool keepDims)
       override;
-  Tensor any(const Tensor& input, const std::vector<int>& axes) override;
+  double norm(const Tensor& input) override;
+  Tensor countNonzero(
+      const Tensor& input,
+      const std::vector<int>& axes,
+      bool keepDims) override;
+  Tensor any(const Tensor& input, const std::vector<int>& axes, bool keepDims)
+      override;
   bool any(const Tensor& input) override;
-  Tensor all(const Tensor& input, const std::vector<int>& axes) override;
+  Tensor all(const Tensor& input, const std::vector<int>& axes, bool keepDims)
+      override;
   bool all(const Tensor& input) override;
 
   /************************** Utils ***************************/

--- a/flashlight/fl/tensor/backend/af/Utils.cpp
+++ b/flashlight/fl/tensor/backend/af/Utils.cpp
@@ -148,7 +148,11 @@ af::dim4 condenseDims(const af::dim4& dims) {
   return newDims;
 }
 
-af::array condenseIndices(const af::array& arr) {
+af::array condenseIndices(const af::array& arr, bool keepDims) {
+  // Fast path - return the Array as is if keepDims - don't consolidate
+  if (keepDims) {
+    return arr;
+  }
   // Fast path - Array has zero elements or a dim of size zero
   if (arr.elements() == 0) {
     return arr;

--- a/flashlight/fl/tensor/backend/af/Utils.h
+++ b/flashlight/fl/tensor/backend/af/Utils.h
@@ -73,8 +73,10 @@ af::dim4 condenseDims(const af::dim4& dims);
  *
  * This operation is performed before returning Array shape, etc where the
  * resulting ArrayFire shape would have 1's in it.
+ *
+ * If keepDims is true, this is a noop, and the array is returned as is.
  */
-af::array condenseIndices(const af::array& arr);
+af::array condenseIndices(const af::array& arr, bool keepDims = false);
 
 /**
  * Convert a Flashlight Location into an ArrayFire location (host or device).

--- a/flashlight/fl/test/tensor/ArrayFireTensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/ArrayFireTensorBaseTest.cpp
@@ -185,6 +185,12 @@ TEST(ArrayFireTensorBaseTest, sum) {
   ASSERT_TRUE(allClose(
       toArray(fl::sum(a, {0})),
       fl::detail::condenseIndices(af::sum(toArray(a), 0))));
+
+  auto b = fl::rand({5, 6, 7, 8});
+  ASSERT_EQ(fl::sum<float>(b), af::sum<float>(toArray(b)));
+  ASSERT_TRUE(allClose(
+      toArray(fl::sum(b, {1, 2})),
+      fl::detail::condenseIndices(af::sum(af::sum(toArray(b), 1), 2))));
 }
 
 TEST(ArrayFireTensorBaseTest, exp) {
@@ -235,7 +241,9 @@ TEST(ArrayFireTensorBaseTest, erf) {
 TEST(ArrayFireTensorBaseTest, mean) {
   auto a = fl::rand({3, 50});
   ASSERT_EQ(fl::mean<float>(a), af::mean<float>(toArray(a)));
-  ASSERT_TRUE(allClose(toArray(fl::mean(a, {0})), af::mean(toArray(a), 0)));
+  ASSERT_TRUE(allClose(
+      toArray(fl::mean(a, {0})),
+      detail::condenseIndices(af::mean(toArray(a), 0))));
 }
 
 TEST(ArrayFireTensorBaseTest, var) {
@@ -243,10 +251,10 @@ TEST(ArrayFireTensorBaseTest, var) {
   ASSERT_EQ(fl::var<float>(a), af::var<float>(toArray(a)));
   ASSERT_TRUE(allClose(
       toArray(fl::var(a, {0})),
-      af::var(toArray(a), AF_VARIANCE_POPULATION, 0)));
+      detail::condenseIndices(af::var(toArray(a), AF_VARIANCE_POPULATION, 0))));
   ASSERT_TRUE(allClose(
       toArray(fl::var(a, {1}, false)),
-      af::var(toArray(a), AF_VARIANCE_POPULATION, 1)));
+      detail::condenseIndices(af::var(toArray(a), AF_VARIANCE_POPULATION, 1))));
   // Make sure multidimension matches computing for all
   ASSERT_FLOAT_EQ(
       toArray(fl::var(a, {0, 1}, false)).scalar<float>(),

--- a/flashlight/fl/test/tensor/IndexTest.cpp
+++ b/flashlight/fl/test/tensor/IndexTest.cpp
@@ -60,6 +60,7 @@ TEST(IndexTest, Shape) {
   ASSERT_EQ(t(2).shape(), Shape({4}));
   ASSERT_EQ(t(fl::range(3)).shape(), Shape({3, 4}));
   ASSERT_EQ(t(fl::range(1, 2)).shape(), Shape({4}));
+  ASSERT_EQ(t(fl::range(1, 2), fl::range(1, 2)).shape(), Shape({1}));
   ASSERT_EQ(t(fl::range(0, fl::end)).shape(), Shape({4, 4}));
   ASSERT_EQ(t(fl::range(0, fl::end, 2)).shape(), Shape({2, 4}));
 
@@ -87,6 +88,12 @@ TEST(IndexTest, IndexAssignment) {
   b += 1;
   ASSERT_TRUE(allClose(b, fl::full({3, 3}, 2.)));
   ASSERT_TRUE(allClose(c, fl::full({3, 3}, 1.)));
+
+  auto q = fl::full({4, 4}, 2.);
+  auto r = fl::full({4}, 3.);
+  q(0) = r;
+  ASSERT_TRUE(allClose(q(0), r));
+  ASSERT_TRUE(allClose(q(fl::range(1, fl::end)), fl::full({3, 4}, 2.)));
 }
 
 TEST(IndexTest, TensorIndex) {


### PR DESCRIPTION
Summary:
- Add a `keepDims` parameter to reductions, which functions like numpy's ([example]
(https://numpy.org/doc/stable/reference/generated/numpy.amax.html)) which doesn't remoce dimensions that are reduced over in reductions
- Add power overload that takes a double
- Add a `where` overload that takes double(s)
- Fix several edge cases with dimensions not being condensed after reductions
- Fix copy assignment for `Index` and default construction for `range`
- Add a constructor for `Tensor` that takes only an `fl::dtype`
- Remove unused `matmulNT` and `matmulTN` header decls
Make the `ArrayFireBackend` copy/move ctors/assignment operators private as well as the ctor
  - only `ArrayFireBackend::getInstance()` is public ensuring that only one instance can be constructed at a time
- Make `shallowCopy` private and friend with `DevicePtr` (which uses it).
  - This API guarantee means that implementers of dataflow graphs don't need to worry about mutations to things earlier in the graph via shallow copies
  - Tensors passed to `DevicePtr` are never accessible outside of `DevicePtr` and therefore can't introduce additional subtrees into computation graphs

Differential Revision: D29903005

