### PR TITLE
Add isinf and sign tensor functions

### DIFF
--- a/flashlight/fl/tensor/Index.h
+++ b/flashlight/fl/tensor/Index.h
@@ -37,6 +37,11 @@ class range {
 
  public:
   /**
+   * Default ctor.
+   */
+  range() = default;
+
+  /**
    * Construct a range with the indices [0, idx) (i.e. [0, idx - 1])
    */
   explicit range(idx idx);
@@ -95,6 +100,11 @@ class Index {
   /* implicit */ Index(const Tensor& tensor);
   /* implicit */ Index(const range& range);
   /* implicit */ Index(const int idx);
+
+  /**
+   * Default copy assignment operator.
+   */
+  Index& operator=(const Index&) = default;
 
   /**
    * Move constructor - moves the index data.

--- a/flashlight/fl/tensor/TensorBackend.h
+++ b/flashlight/fl/tensor/TensorBackend.h
@@ -176,6 +176,9 @@ class TensorBackend {
   virtual Tensor
   mean(const Tensor& input, const std::vector<int>& axes, bool keepDims) = 0;
   virtual double mean(const Tensor& input) = 0; // TODO: consolidate w/ above
+  virtual Tensor
+  median(const Tensor& input, const std::vector<int>& axes, bool keepDims) = 0;
+  virtual double median(const Tensor& input) = 0; // TODO: consolidate w/ above
   virtual Tensor var(
       const Tensor& input,
       const std::vector<int>& axes,

--- a/flashlight/fl/tensor/TensorBackend.h
+++ b/flashlight/fl/tensor/TensorBackend.h
@@ -164,27 +164,38 @@ class TensorBackend {
       MatrixProperty rhsProp) = 0;
 
   /************************** Reductions ***************************/
-  virtual Tensor amin(const Tensor& input, const std::vector<int>& axes) = 0;
-  virtual double amin(const Tensor& input) = 0; // TODO: consoildate w/ above
-  virtual Tensor amax(const Tensor& input, const std::vector<int>& axes) = 0;
-  virtual double amax(const Tensor& input) = 0; // TODO: consoildate w/ above
-  virtual Tensor sum(const Tensor& input, const std::vector<int>& axes) = 0;
-  virtual double sum(const Tensor& input) = 0; // TODO: consolidate w/ above
-  virtual Tensor mean(const Tensor& input, const std::vector<int>& axes) = 0;
-  virtual double mean(const Tensor& input) = 0; // TODO: consolidate w/ above
   virtual Tensor
-  var(const Tensor& input, const std::vector<int>& axes, bool bias) = 0;
+  amin(const Tensor& input, const std::vector<int>& axes, bool keepDims) = 0;
+  virtual double amin(const Tensor& input) = 0; // TODO: consoildate w/ above
+  virtual Tensor
+  amax(const Tensor& input, const std::vector<int>& axes, bool keepDims) = 0;
+  virtual double amax(const Tensor& input) = 0; // TODO: consoildate w/ above
+  virtual Tensor
+  sum(const Tensor& input, const std::vector<int>& axes, bool keepDims) = 0;
+  virtual double sum(const Tensor& input) = 0; // TODO: consolidate w/ above
+  virtual Tensor
+  mean(const Tensor& input, const std::vector<int>& axes, bool keepDims) = 0;
+  virtual double mean(const Tensor& input) = 0; // TODO: consolidate w/ above
+  virtual Tensor var(
+      const Tensor& input,
+      const std::vector<int>& axes,
+      bool bias,
+      bool keepDims) = 0;
   virtual double var(
       const Tensor& input,
       bool bias) = 0; // TODO: consolidate w/ above
-  virtual Tensor std(const Tensor& input, const std::vector<int>& axes) = 0;
+  virtual Tensor
+  std(const Tensor& input, const std::vector<int>& axes, bool keepDims) = 0;
   virtual double norm(const Tensor& input) = 0; // TODO: consolidate w/ above
   virtual Tensor countNonzero(
       const Tensor& input,
-      const std::vector<int>& axes) = 0;
-  virtual Tensor any(const Tensor& input, const std::vector<int>& axes) = 0;
+      const std::vector<int>& axes,
+      bool keepDims) = 0;
+  virtual Tensor
+  any(const Tensor& input, const std::vector<int>& axes, bool keepDims) = 0;
   virtual bool any(const Tensor& input) = 0; // TODO: consolidate w/ above
-  virtual Tensor all(const Tensor& input, const std::vector<int>& axes) = 0;
+  virtual Tensor
+  all(const Tensor& input, const std::vector<int>& axes, bool keepDims) = 0;
   virtual bool all(const Tensor& input) = 0; // TODO: consolidate w/ above
 
   /************************** Utils ***************************/

--- a/flashlight/fl/tensor/TensorBackend.h
+++ b/flashlight/fl/tensor/TensorBackend.h
@@ -104,6 +104,8 @@ class TensorBackend {
   virtual Tensor
   clip(const Tensor& tensor, const Tensor& low, const Tensor& high) = 0;
   virtual Tensor isnan(const Tensor& tensor) = 0;
+  virtual Tensor isinf(const Tensor& tensor) = 0;
+  virtual Tensor sign(const Tensor& tensor) = 0;
   virtual Tensor
   where(const Tensor& condition, const Tensor& x, const Tensor& y) = 0;
 

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -433,6 +433,14 @@ Tensor isnan(const Tensor& tensor) {
   return tensor.backend().isnan(tensor);
 }
 
+Tensor isinf(const Tensor& tensor) {
+  return tensor.backend().isinf(tensor);
+}
+
+Tensor sign(const Tensor& tensor) {
+  return tensor.backend().sign(tensor);
+}
+
 Tensor where(const Tensor& condition, const Tensor& x, const Tensor& y) {
   FL_TENSOR_BACKENDS_MATCH_CHECK(condition, x, y);
   return condition.backend().where(condition, x, y);

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -222,6 +222,8 @@ EXPAND_MACRO_FUNCTION(amax);
 EXPAND_MACRO_FUNCTION(sum);
 // fl::mean<T>(const Tensor&)
 EXPAND_MACRO_FUNCTION(mean);
+// fl::mean<T>(const Tensor&)
+EXPAND_MACRO_FUNCTION(median);
 #undef EXPAND_MACRO_FUNCTION_TYPE
 #undef EXPAND_MACRO_FUNCTION
 
@@ -571,6 +573,11 @@ Tensor sum(const Tensor& input, const std::vector<int>& axes, bool keepDims) {
 
 Tensor mean(const Tensor& input, const std::vector<int>& axes, bool keepDims) {
   return input.backend().mean(input, axes, keepDims);
+}
+
+Tensor
+median(const Tensor& input, const std::vector<int>& axes, bool keepDims) {
+  return input.backend().median(input, axes, keepDims);
 }
 
 Tensor var(

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -707,6 +707,26 @@ Tensor clip(const Tensor& tensor, const double& low, const double& high);
 Tensor isnan(const Tensor& tensor);
 
 /**
+ * Returns a boolean tensor which is true where the input tensor was infinity,
+ * and false otherwise.
+ *
+ * @param[in] tensor the input tensor
+ * @return a boolean tensor with true in positions that contained Inf in the
+ * input tensor
+ */
+Tensor isinf(const Tensor& tensor);
+
+/**
+ * Returns a tensor that contains -1 if an element is less than 0, 0 if an
+ * element is 0, and 1 if an element is greater than zero. Returns NaN for NaN
+ * values.
+ *
+ * @param[in] tensor the input tensor
+ * @return a tensor containing element-wise sign values.
+ */
+Tensor sign(const Tensor& tensor);
+
+/**
  * Conditionally return elements from one of two tensors based on a condition.
  *
  * @param[in] condition a tensor that, where true, uses values from x

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -911,6 +911,29 @@ template <typename T>
 T mean(const Tensor& input);
 
 /**
+ * Median of tensor over given axes.
+ *
+ * @param[in] input the input along which to operate
+ * @param[in] axes the dimension along which to reduce.
+ * @return a tensor containing the median across given axes
+ */
+Tensor median(
+    const Tensor& input,
+    const std::vector<int>& axes,
+    bool keepDims = false);
+
+/**
+ * Median of tensor over all axes.
+ * TODO: benchmark against median(median(median(...)))/maybe avoid device-host
+ * memcpy
+ *
+ * @param[in] input the input along which to operate
+ * @return a scalar T containing the median
+ */
+template <typename T>
+T median(const Tensor& input);
+
+/**
  * Variance of an tensor over given axes.
  *
  * @param[in] input the input along which to operate

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
@@ -438,6 +438,20 @@ double ArrayFireBackend::mean(const Tensor& input) {
   return af::mean<double>(toArray(input));
 }
 
+Tensor ArrayFireBackend::median(
+    const Tensor& input,
+    const std::vector<int>& axes,
+    bool keepDims) {
+  return toTensor<ArrayFireTensor>(
+      afReduceAxes<af::array(const af::array&, const dim_t)>(
+          toArray(input), axes, af::median, keepDims));
+}
+
+// TODO: consolidate with above
+double ArrayFireBackend::median(const Tensor& input) {
+  return af::median<double>(toArray(input));
+}
+
 Tensor ArrayFireBackend::var(
     const Tensor& input,
     const std::vector<int>& axes,

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
@@ -289,6 +289,16 @@ Tensor ArrayFireBackend::isnan(const Tensor& tensor) {
   return toTensor<ArrayFireTensor>(af::isNaN(toArray(tensor)));
 }
 
+Tensor ArrayFireBackend::isinf(const Tensor& tensor) {
+  return toTensor<ArrayFireTensor>(af::isInf(toArray(tensor)));
+}
+
+Tensor ArrayFireBackend::sign(const Tensor& tensor) {
+  auto wSigned = 1 - 2 * af::sign(toArray(tensor));
+  wSigned(toArray(tensor) == 0) = 0;
+  return toTensor<ArrayFireTensor>(std::move(wSigned));
+}
+
 Tensor ArrayFireBackend::where(
     const Tensor& condition,
     const Tensor& x,

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
@@ -175,6 +175,11 @@ class ArrayFireBackend : public TensorBackend {
   Tensor mean(const Tensor& input, const std::vector<int>& axes, bool keepDims)
       override;
   double mean(const Tensor& input) override; // TODO: consolidate w/ above
+  Tensor median(
+      const Tensor& input,
+      const std::vector<int>& axes,
+      bool keepDims) override;
+  double median(const Tensor& input) override; // TODO: consolidate w/ above
   Tensor var(
       const Tensor& input,
       const std::vector<int>& axes,

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
@@ -20,11 +20,21 @@ namespace fl {
 class ArrayFireBackend : public TensorBackend {
   // TODO: consolidate the ArrayFire memory manager here so its global state can
   // be stored/we can reduce the number of singletons.
- public:
+
+  // Intentionally private. Only one instance should exist/it should be accessed
+  // via getInstance().
   ArrayFireBackend();
+
+ public:
+  static ArrayFireBackend& getInstance();
+
   ~ArrayFireBackend() override = default;
 
-  static ArrayFireBackend& getInstance();
+  // No copy or move construction or assignment
+  ArrayFireBackend(ArrayFireBackend&&) = delete;
+  ArrayFireBackend(const ArrayFireBackend&) = delete;
+  ArrayFireBackend& operator=(ArrayFireBackend&&) = delete;
+  ArrayFireBackend& operator=(const ArrayFireBackend&) = delete;
 
   /* -------------------------- Compute Functions -------------------------- */
   void sync() override;
@@ -153,25 +163,37 @@ class ArrayFireBackend : public TensorBackend {
       MatrixProperty rhsProp) override;
 
   /************************** Reductions ***************************/
-  Tensor amin(const Tensor& input, const std::vector<int>& axes) override;
-  double amin(const Tensor& input) override; // TODO: consolidate w/ above
-  Tensor amax(const Tensor& input, const std::vector<int>& axes) override;
-  double amax(const Tensor& input) override; // TODO: consolidate w/ above
-  Tensor sum(const Tensor& input, const std::vector<int>& axes) override;
-  double sum(const Tensor& input) override; // TODO: consolidate w/ above
-  Tensor mean(const Tensor& input, const std::vector<int>& axes) override;
-  double mean(const Tensor& input) override; // TODO: consolidate w/ above
-  Tensor var(const Tensor& input, const std::vector<int>& axes, const bool bias)
+  Tensor amin(const Tensor& input, const std::vector<int>& axes, bool keepDims)
       override;
+  double amin(const Tensor& input) override; // TODO: consolidate w/ above
+  Tensor amax(const Tensor& input, const std::vector<int>& axes, bool keepDims)
+      override;
+  double amax(const Tensor& input) override; // TODO: consolidate w/ above
+  Tensor sum(const Tensor& input, const std::vector<int>& axes, bool keepDims)
+      override;
+  double sum(const Tensor& input) override; // TODO: consolidate w/ above
+  Tensor mean(const Tensor& input, const std::vector<int>& axes, bool keepDims)
+      override;
+  double mean(const Tensor& input) override; // TODO: consolidate w/ above
+  Tensor var(
+      const Tensor& input,
+      const std::vector<int>& axes,
+      const bool bias,
+      bool keepDims) override;
   double var(const Tensor& input, const bool bias)
       override; // TODO: consolidate w/ above
-  Tensor std(const Tensor& input, const std::vector<int>& axes) override;
-  double norm(const Tensor& input) override;
-  Tensor countNonzero(const Tensor& input, const std::vector<int>& axes)
+  Tensor std(const Tensor& input, const std::vector<int>& axes, bool keepDims)
       override;
-  Tensor any(const Tensor& input, const std::vector<int>& axes) override;
+  double norm(const Tensor& input) override;
+  Tensor countNonzero(
+      const Tensor& input,
+      const std::vector<int>& axes,
+      bool keepDims) override;
+  Tensor any(const Tensor& input, const std::vector<int>& axes, bool keepDims)
+      override;
   bool any(const Tensor& input) override;
-  Tensor all(const Tensor& input, const std::vector<int>& axes) override;
+  Tensor all(const Tensor& input, const std::vector<int>& axes, bool keepDims)
+      override;
   bool all(const Tensor& input) override;
 
   /************************** Utils ***************************/

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
@@ -103,6 +103,8 @@ class ArrayFireBackend : public TensorBackend {
   Tensor clip(const Tensor& tensor, const Tensor& low, const Tensor& high)
       override;
   Tensor isnan(const Tensor& tensor) override;
+  Tensor isinf(const Tensor& tensor) override;
+  Tensor sign(const Tensor& tensor) override;
   Tensor where(const Tensor& condition, const Tensor& x, const Tensor& y)
       override;
 

--- a/flashlight/fl/tensor/backend/af/Utils.cpp
+++ b/flashlight/fl/tensor/backend/af/Utils.cpp
@@ -148,7 +148,11 @@ af::dim4 condenseDims(const af::dim4& dims) {
   return newDims;
 }
 
-af::array condenseIndices(const af::array& arr) {
+af::array condenseIndices(const af::array& arr, bool keepDims) {
+  // Fast path - return the Array as is if keepDims - don't consolidate
+  if (keepDims) {
+    return arr;
+  }
   // Fast path - Array has zero elements or a dim of size zero
   if (arr.elements() == 0) {
     return arr;

--- a/flashlight/fl/tensor/backend/af/Utils.h
+++ b/flashlight/fl/tensor/backend/af/Utils.h
@@ -73,8 +73,10 @@ af::dim4 condenseDims(const af::dim4& dims);
  *
  * This operation is performed before returning Array shape, etc where the
  * resulting ArrayFire shape would have 1's in it.
+ *
+ * If keepDims is true, this is a noop, and the array is returned as is.
  */
-af::array condenseIndices(const af::array& arr);
+af::array condenseIndices(const af::array& arr, bool keepDims = false);
 
 /**
  * Convert a Flashlight Location into an ArrayFire location (host or device).

--- a/flashlight/fl/test/tensor/ArrayFireTensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/ArrayFireTensorBaseTest.cpp
@@ -185,6 +185,12 @@ TEST(ArrayFireTensorBaseTest, sum) {
   ASSERT_TRUE(allClose(
       toArray(fl::sum(a, {0})),
       fl::detail::condenseIndices(af::sum(toArray(a), 0))));
+
+  auto b = fl::rand({5, 6, 7, 8});
+  ASSERT_EQ(fl::sum<float>(b), af::sum<float>(toArray(b)));
+  ASSERT_TRUE(allClose(
+      toArray(fl::sum(b, {1, 2})),
+      fl::detail::condenseIndices(af::sum(af::sum(toArray(b), 1), 2))));
 }
 
 TEST(ArrayFireTensorBaseTest, exp) {
@@ -235,7 +241,9 @@ TEST(ArrayFireTensorBaseTest, erf) {
 TEST(ArrayFireTensorBaseTest, mean) {
   auto a = fl::rand({3, 50});
   ASSERT_EQ(fl::mean<float>(a), af::mean<float>(toArray(a)));
-  ASSERT_TRUE(allClose(toArray(fl::mean(a, {0})), af::mean(toArray(a), 0)));
+  ASSERT_TRUE(allClose(
+      toArray(fl::mean(a, {0})),
+      detail::condenseIndices(af::mean(toArray(a), 0))));
 }
 
 TEST(ArrayFireTensorBaseTest, var) {
@@ -243,10 +251,10 @@ TEST(ArrayFireTensorBaseTest, var) {
   ASSERT_EQ(fl::var<float>(a), af::var<float>(toArray(a)));
   ASSERT_TRUE(allClose(
       toArray(fl::var(a, {0})),
-      af::var(toArray(a), AF_VARIANCE_POPULATION, 0)));
+      detail::condenseIndices(af::var(toArray(a), AF_VARIANCE_POPULATION, 0))));
   ASSERT_TRUE(allClose(
       toArray(fl::var(a, {1}, false)),
-      af::var(toArray(a), AF_VARIANCE_POPULATION, 1)));
+      detail::condenseIndices(af::var(toArray(a), AF_VARIANCE_POPULATION, 1))));
   // Make sure multidimension matches computing for all
   ASSERT_FLOAT_EQ(
       toArray(fl::var(a, {0, 1}, false)).scalar<float>(),

--- a/flashlight/fl/test/tensor/ArrayFireTensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/ArrayFireTensorBaseTest.cpp
@@ -246,6 +246,14 @@ TEST(ArrayFireTensorBaseTest, mean) {
       detail::condenseIndices(af::mean(toArray(a), 0))));
 }
 
+TEST(ArrayFireTensorBaseTest, median) {
+  auto a = fl::rand({3, 50});
+  ASSERT_EQ(fl::median<float>(a), af::median<float>(toArray(a)));
+  ASSERT_TRUE(allClose(
+      toArray(fl::median(a, {0})),
+      detail::condenseIndices(af::median(toArray(a), 0))));
+}
+
 TEST(ArrayFireTensorBaseTest, var) {
   auto a = fl::rand({3, 3});
   ASSERT_EQ(fl::var<float>(a), af::var<float>(toArray(a)));

--- a/flashlight/fl/test/tensor/IndexTest.cpp
+++ b/flashlight/fl/test/tensor/IndexTest.cpp
@@ -60,6 +60,7 @@ TEST(IndexTest, Shape) {
   ASSERT_EQ(t(2).shape(), Shape({4}));
   ASSERT_EQ(t(fl::range(3)).shape(), Shape({3, 4}));
   ASSERT_EQ(t(fl::range(1, 2)).shape(), Shape({4}));
+  ASSERT_EQ(t(fl::range(1, 2), fl::range(1, 2)).shape(), Shape({1}));
   ASSERT_EQ(t(fl::range(0, fl::end)).shape(), Shape({4, 4}));
   ASSERT_EQ(t(fl::range(0, fl::end, 2)).shape(), Shape({2, 4}));
 
@@ -87,6 +88,12 @@ TEST(IndexTest, IndexAssignment) {
   b += 1;
   ASSERT_TRUE(allClose(b, fl::full({3, 3}, 2.)));
   ASSERT_TRUE(allClose(c, fl::full({3, 3}, 1.)));
+
+  auto q = fl::full({4, 4}, 2.);
+  auto r = fl::full({4}, 3.);
+  q(0) = r;
+  ASSERT_TRUE(allClose(q(0), r));
+  ASSERT_TRUE(allClose(q(fl::range(1, fl::end)), fl::full({3, 4}, 2.)));
 }
 
 TEST(IndexTest, TensorIndex) {

--- a/flashlight/fl/test/tensor/TensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/TensorBaseTest.cpp
@@ -409,6 +409,16 @@ TEST(TensorBaseTest, sum) {
       allClose(fl::reshape(res, {t.dim(0), t.dim(3)}), fl::sum(t, {2, 1})));
 }
 
+TEST(TensorBaseTest, median) {
+  auto a = Tensor::fromVector<int>({0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
+  ASSERT_EQ(fl::median<double>(a), 4.5);
+  ASSERT_TRUE(allClose(fl::median(a, {0}), fl::full({1}, 4.5)));
+  ASSERT_EQ(fl::median(fl::rand({5, 6, 7, 8}), {1, 2}).shape(), Shape({5, 8}));
+  ASSERT_EQ(
+      fl::median(fl::rand({5, 6, 7, 8}), {1, 2}, /* keepDims = */ true).shape(),
+      Shape({5, 1, 1, 8}));
+}
+
 TEST(TensorBaseTest, any) {
   using fl::dtype;
   auto t = Tensor::fromVector<unsigned>({3, 3}, {1, 0, 0, 0, 0, 0, 0, 0, 1});

--- a/flashlight/fl/test/tensor/TensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/TensorBaseTest.cpp
@@ -265,6 +265,26 @@ TEST(TensorBaseTest, isnan) {
       fl::full(s, false).astype(fl::dtype::b8)));
 }
 
+TEST(TensorBaseTest, isinf) {
+  Shape s = {3, 3};
+  ASSERT_TRUE(allClose(
+      fl::isinf(fl::full(s, 1.) / 3),
+      fl::full(s, false).astype(fl::dtype::b8)));
+  ASSERT_TRUE(allClose(
+      fl::isinf(fl::full(s, 1.) / 0.),
+      fl::full(s, true).astype(fl::dtype::b8)));
+}
+
+TEST(TensorBaseTest, sign) {
+  auto vals = fl::rand({5, 5}) - 0.5;
+  vals(2, 2) = 0.;
+  auto signs = fl::sign(vals);
+  vals(vals > 0) = 1;
+  vals(vals == 0) = 0;
+  vals(vals < 0) = -1;
+  ASSERT_TRUE(allClose(signs, vals));
+}
+
 TEST(TensorBaseTest, where) {
   auto a = Tensor::fromVector<int>({2, 5}, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
   auto out = fl::where(a < 5, a, a * 10);


### PR DESCRIPTION
Summary:
Modeled after [`isnan`](https://numpy.org/doc/stable/reference/generated/numpy.isnan.html)  - add [`isinf`](https://numpy.org/doc/stable/reference/generated/numpy.isinf.html) - can change naming if others feel strongly.

Adds [`sign`](https://numpy.org/doc/stable/reference/generated/numpy.sign.html) which differs from [ArrayFire's](https://arrayfire.org/docs/group__arith__func__sign.htm) and requires an additional step to zero relevant indices.

Differential Revision: D30022375

