### PR TITLE
Replace af::eval in fl::eval for array inputs

### DIFF
--- a/flashlight/fl/tensor/Compute.cpp
+++ b/flashlight/fl/tensor/Compute.cpp
@@ -31,11 +31,9 @@ void eval(Tensor& tensor) {
   Tensor().backend().eval(tensor);
 }
 
-// TODO:fl::Tensor remove once no more `af::eval` calls
+// TODO:fl::Tensor remove once no more `fl::eval` calls that take `af::array`s
 void eval(af::array& array) {
-  af::array a = array;
-  Tensor t = toTensor<ArrayFireTensor>(std::move(a));
-  fl::eval(t);
+  af::eval(array);
 }
 
 int getDevice() {


### PR DESCRIPTION
Summary: The `fl::eval(af::array&)` overload had to copy the array into a tensor since it took a reference, which bumped the ArrayFire array refcount and resulted in a copy, causing some OOMs. Use `af::eval` instead to avoid this...

Reviewed By: tlikhomanenko

Differential Revision: D30048654

