### PR TITLE
Add Tensor::asContiguousTensor

### DIFF
--- a/flashlight/fl/tensor/Index.cpp
+++ b/flashlight/fl/tensor/Index.cpp
@@ -47,7 +47,10 @@ Index::Index(const Tensor& tensor)
     : type_(detail::IndexType::Tensor), index_(tensor) {}
 
 Index::Index(const range& range)
-    : type_(detail::IndexType::Range), index_(range) {}
+    : type_(
+          range == fl::range(-1, -1, 0) ? detail::IndexType::Span
+                                        : detail::IndexType::Range),
+      index_(range) {}
 
 Index::Index(const int idx) : type_(detail::IndexType::Literal), index_(idx) {}
 
@@ -59,10 +62,7 @@ detail::IndexType Index::type() const {
 }
 
 bool Index::isSpan() const {
-  if (type_ != detail::IndexType::Range) {
-    return false;
-  }
-  return get<range>() == fl::span;
+  return type_ == detail::IndexType::Span;
 }
 
 } // namespace fl

--- a/flashlight/fl/tensor/TensorAdapter.h
+++ b/flashlight/fl/tensor/TensorAdapter.h
@@ -165,6 +165,11 @@ class TensorAdapterBase {
   virtual Tensor flatten() const = 0;
 
   /**
+   * Returns a copy of the tensor that is contiguous in memory.
+   */
+  virtual Tensor asContiguousTensor() = 0;
+
+  /**
    * Sets arbitrary data on a tensor. May be a no-op for some backends.
    */
   virtual void setContext(void* context) = 0;

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -98,6 +98,10 @@ Tensor Tensor::flatten() const {
   return impl_->flatten();
 }
 
+Tensor Tensor::asContiguousTensor() const {
+  return impl_->asContiguousTensor();
+}
+
 TensorBackendType Tensor::backendType() const {
   return impl_->backendType();
 }

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -70,7 +70,7 @@ Dim Tensor::dim(const size_t dim) const {
   return shape().dim(dim);
 }
 
-unsigned Tensor::ndim() const {
+size_t Tensor::ndim() const {
   return shape().ndim();
 }
 

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -193,7 +193,7 @@ class Tensor {
    *
    * @return the number of dimensions
    */
-  unsigned ndim() const;
+  size_t ndim() const;
 
   /**
    * Returns true if the tensor has zero elements, else false.

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -265,6 +265,14 @@ class Tensor {
   Tensor flatten() const;
 
   /**
+   * Return a copy (depending on copy-on-write behavior of the underlying
+   * implementation) of this tensor that is contigous in memory.
+   *
+   * @return an identical tensor that is contiguous in memory
+   */
+  Tensor asContiguousTensor() const;
+
+  /**
    * Gets the backend enum from the underlying TensorAdapter.
    *
    * @return the backend in question

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
@@ -257,6 +257,18 @@ Tensor ArrayFireTensor::flatten() const {
   return toTensor<ArrayFireTensor>(af::flat(getHandle()), /* numDims = */ 1);
 }
 
+Tensor ArrayFireTensor::asContiguousTensor() {
+  if (isContiguous()) {
+    af::array other = getHandle();
+    return toTensor<ArrayFireTensor>(std::move(other), numDims());
+  }
+
+  const af::array& array = getHandle();
+  auto linearArray = af::array(array.dims(), array.type());
+  af::copy(linearArray, array, af::span);
+  return toTensor<ArrayFireTensor>(std::move(linearArray), numDims());
+}
+
 void ArrayFireTensor::setContext(void* context) {} // noop
 
 void* ArrayFireTensor::getContext() {

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
@@ -180,6 +180,7 @@ class ArrayFireTensor : public TensorAdapterBase {
   Tensor astype(const dtype type) override;
   Tensor index(const std::vector<Index>& indices) override;
   Tensor flatten() const override;
+  Tensor asContiguousTensor() override;
   void setContext(void* context) override; // noop
   void* getContext() override; // noop
 

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
@@ -14,6 +14,7 @@
 
 #include <variant>
 
+#include "flashlight/fl/tensor/Index.h"
 #include "flashlight/fl/tensor/Shape.h"
 #include "flashlight/fl/tensor/TensorAdapter.h"
 
@@ -45,6 +46,10 @@ class ArrayFireTensor : public TensorAdapterBase {
   // Indices in the event that this tensor is about to be indexed. Cleared the
   // next time this array handle is acquired. See getHandle().
   std::optional<std::vector<af::index>> indices_;
+  // Need to maintain the types of each index, as ArrayFire doesn't distinguish
+  // between an integer index literal and an af::seq of size one; both have
+  // slightly different behavior with fl::Tensor
+  std::optional<std::vector<detail::IndexType>> indexTypes_;
   // To be visited when this tensor is to be indexed. Indexes the underlying
   // af::array, and returns the proxy to be used as a temporary lvalue.
   struct IndexedArrayComponent {
@@ -77,23 +82,33 @@ class ArrayFireTensor : public TensorAdapterBase {
    */
   ArrayFireTensor(
       std::shared_ptr<af::array> handle,
-      std::vector<af::index>&& indices);
+      std::vector<af::index>&& afIndices,
+      std::vector<detail::IndexType>&& indexTypes,
+      unsigned numDims);
 
   /**
    * Construct an ArrayFireTensor from an ArrayFire array handle without copying
    * the handle. Used for creating guaranteed-shallow copies.
    */
-  explicit ArrayFireTensor(std::shared_ptr<af::array> arr);
+  explicit ArrayFireTensor(std::shared_ptr<af::array> arr, unsigned numDims);
 
   /*
    * A Flashlight shape that mirrors ArrayFire dims.
    *
    * NOTE: this shape is only updated on calls to ArrayFireTensor::shape()
-   * so as to satisfy API requirements as per returning a const reference..
+   * so as to satisfy API requirements as per returning a const reference.
    * af::array::dims() should be used for internal computation where
    * shape/dimensions are needed.
    */
   Shape shape_;
+
+  /**
+   * The number of dimensions in this ArrayFire tensor that are "expected" per
+   * interoperability with other tensors. Because ArrayFire doesn't distinguish
+   * between singleton dimensions that are defaults and those that are
+   * explicitly specified, this must be explicitly tracked.
+   */
+  unsigned numDims_{1};
 
  public:
   /**
@@ -109,7 +124,7 @@ class ArrayFireTensor : public TensorAdapterBase {
    * @param[in] array construct a tensor from an ArrayFire array rvalue
    * reference.
    */
-  explicit ArrayFireTensor(af::array&& array);
+  explicit ArrayFireTensor(af::array&& array, unsigned numDims);
 
   /**
    * Default initialization - empty ArrayFire array and empty shape.
@@ -146,6 +161,7 @@ class ArrayFireTensor : public TensorAdapterBase {
   af::array& getHandle();
 
   ~ArrayFireTensor() override = default;
+  unsigned numDims() const;
   // Used with the fl::Tensor copy constructor
   std::unique_ptr<TensorAdapterBase> clone() const override;
   TensorBackendType backendType() const override;

--- a/flashlight/fl/test/tensor/IndexTest.cpp
+++ b/flashlight/fl/test/tensor/IndexTest.cpp
@@ -40,7 +40,7 @@ TEST(IndexTest, Type) {
   using namespace detail;
   ASSERT_EQ(fl::Index(3).type(), IndexType::Literal);
   ASSERT_EQ(fl::Index(fl::range(3)).type(), IndexType::Range);
-  ASSERT_EQ(fl::Index(fl::span).type(), IndexType::Range);
+  ASSERT_EQ(fl::Index(fl::span).type(), IndexType::Span);
   ASSERT_EQ(fl::Index(fl::full({2, 2}, 4)).type(), IndexType::Tensor);
   ASSERT_TRUE(fl::Index(fl::span).isSpan());
 }
@@ -59,13 +59,17 @@ TEST(IndexTest, Shape) {
   ASSERT_EQ(t(2, fl::span).shape(), Shape({4}));
   ASSERT_EQ(t(2).shape(), Shape({4}));
   ASSERT_EQ(t(fl::range(3)).shape(), Shape({3, 4}));
-  ASSERT_EQ(t(fl::range(1, 2)).shape(), Shape({4}));
-  ASSERT_EQ(t(fl::range(1, 2), fl::range(1, 2)).shape(), Shape({1}));
+  ASSERT_EQ(t(fl::range(1, 2)).shape(), Shape({1, 4}));
+  ASSERT_EQ(t(fl::range(1, 2), fl::range(1, 2)).shape(), Shape({1, 1}));
   ASSERT_EQ(t(fl::range(0, fl::end)).shape(), Shape({4, 4}));
   ASSERT_EQ(t(fl::range(0, fl::end, 2)).shape(), Shape({2, 4}));
 
   auto t2 = fl::full({5, 6, 7, 8}, 3.);
   ASSERT_EQ(t2(2, fl::range(2, 4), fl::span, 3).shape(), Shape({2, 7}));
+  ASSERT_EQ(t2(fl::span, 3, fl::span, fl::span).shape(), Shape({5, 7, 8}));
+  ASSERT_EQ(
+      t2(fl::span, fl::range(1, 2), fl::span, fl::span).shape(),
+      Shape({5, 1, 7, 8}));
 }
 
 TEST(IndexTest, IndexAssignment) {
@@ -94,6 +98,37 @@ TEST(IndexTest, IndexAssignment) {
   q(0) = r;
   ASSERT_TRUE(allClose(q(0), r));
   ASSERT_TRUE(allClose(q(fl::range(1, fl::end)), fl::full({3, 4}, 2.)));
+
+  auto k = fl::rand({100, 200});
+  k(3) = fl::full({200}, 0.);
+  ASSERT_TRUE(allClose(k(3), fl::full({200}, 0.)));
+
+  auto x = fl::rand({5, 6, 7, 8});
+  x(3) = fl::full({6, 7, 8}, 0.);
+  ASSERT_TRUE(allClose(x(3), fl::full({6, 7, 8}, 0.)));
+  x(fl::span, fl::span, 2) = fl::full({5, 6, 8}, 3.);
+  ASSERT_TRUE(allClose(x(fl::span, fl::span, 2), fl::full({5, 6, 8}, 3.)));
+  ASSERT_THROW(
+      x(fl::span, fl::span, 4) -= fl::rand({5, 6, 1, 8}),
+      std::invalid_argument);
+
+  x(fl::span, fl::range(1, 3), fl::span) = fl::full({5, 2, 7, 8}, 2.);
+  ASSERT_TRUE(allClose(
+      x(fl::span, fl::range(1, 3), fl::span), fl::full({5, 2, 7, 8}, 2.)));
+
+  x(fl::span, fl::arange({5}), fl::span, fl::arange({5})) =
+      fl::full({5, 5, 7, 5}, 2.);
+  ASSERT_TRUE(allClose(
+      x(fl::span, fl::range(1, 3), fl::span), fl::full({5, 2, 7, 8}, 2.)));
+}
+
+TEST(IndexTest, IndexInPlaceOps) {
+  auto a = fl::full({4, 5, 6}, 0.);
+  auto b = fl::full({5, 6}, 1.);
+  a(2) += b;
+  ASSERT_TRUE(allClose(a(2), b));
+  a(2) -= b;
+  ASSERT_TRUE(allClose(a, fl::full({4, 5, 6}, 0.)));
 }
 
 TEST(IndexTest, TensorIndex) {

--- a/flashlight/fl/test/tensor/ShapeTest.cpp
+++ b/flashlight/fl/test/tensor/ShapeTest.cpp
@@ -12,9 +12,6 @@
 
 #include "flashlight/fl/tensor/Shape.h"
 
-// TODO: move me to an independent AF test suite
-#include "flashlight/fl/tensor/backend/af/Utils.h"
-
 using namespace ::testing;
 using namespace fl;
 
@@ -62,20 +59,4 @@ TEST(ShapeTest, Equality) {
   ASSERT_NE(Shape({5, 2, 3}), Shape({5, 2, 3, 1}));
   ASSERT_EQ(Shape({5, 2, 3, 1}), Shape({5, 2, 3, 1}));
   ASSERT_NE(Shape({5, 2, 1, 1}), Shape({5, 2, 1, 4}));
-}
-
-// TODO: move me to an independent AF test suite
-TEST(ShapeTest, ArrayFireInterop) {
-  auto dimsEq = [](const af::dim4& d, const Shape& s) {
-    return detail::afToFlDims(d) == s;
-  };
-
-  ASSERT_TRUE(dimsEq(af::dim4(), {}));
-  ASSERT_TRUE(dimsEq(af::dim4(3), {3})); // not 3, 1, 1, 1
-  ASSERT_TRUE(dimsEq(af::dim4(3, 2), {3, 2})); // not 3, 2, 1, 1
-  ASSERT_TRUE(dimsEq(af::dim4(3, 1), {3})); // 1 is indistinguishable in AF
-  ASSERT_TRUE(dimsEq(af::dim4(1, 3, 2), {1, 3, 2}));
-  ASSERT_TRUE(dimsEq(af::dim4(1), {1}));
-  ASSERT_TRUE(dimsEq(af::dim4(1, 1, 1), {1}));
-  ASSERT_TRUE(dimsEq(af::dim4(0, 1, 1, 1), {}));
 }

--- a/flashlight/fl/test/tensor/TensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/TensorBaseTest.cpp
@@ -412,6 +412,24 @@ TEST(TensorBaseTest, strides) {
   ASSERT_EQ(t.strides(), Shape({1, 10}));
 }
 
+TEST(TensorBaseTest, asContiguousTensor) {
+  auto t = fl::rand({5, 6, 7, 8});
+  auto indexed =
+      t(fl::range(1, 4, 2),
+        fl::range(0, 6, 2),
+        fl::range(0, 6, 3),
+        fl::range(0, 5, 3));
+
+  auto contiguous = indexed.asContiguousTensor();
+  std::vector<Dim> strides;
+  unsigned stride = 1;
+  for (unsigned i = 0; i < contiguous.ndim(); ++i) {
+    strides.push_back(stride);
+    stride *= contiguous.dim(i);
+  }
+  ASSERT_EQ(contiguous.strides(), Shape(strides));
+}
+
 TEST(TensorBaseTest, host) {
   auto a = fl::rand({10, 10});
 


### PR DESCRIPTION
Summary: Adds `asContiguousTensor` which returns a copy of the input tensor (or an implementation-defined copy-on-write) that's contiguous in memory.

Differential Revision: D30176609

