### PR TITLE
Fixes to ArrayFireTensor indexing and ops

### DIFF
--- a/flashlight/fl/tensor/Index.cpp
+++ b/flashlight/fl/tensor/Index.cpp
@@ -47,7 +47,10 @@ Index::Index(const Tensor& tensor)
     : type_(detail::IndexType::Tensor), index_(tensor) {}
 
 Index::Index(const range& range)
-    : type_(detail::IndexType::Range), index_(range) {}
+    : type_(
+          range == fl::range(-1, -1, 0) ? detail::IndexType::Span
+                                        : detail::IndexType::Range),
+      index_(range) {}
 
 Index::Index(const int idx) : type_(detail::IndexType::Literal), index_(idx) {}
 
@@ -59,10 +62,7 @@ detail::IndexType Index::type() const {
 }
 
 bool Index::isSpan() const {
-  if (type_ != detail::IndexType::Range) {
-    return false;
-  }
-  return get<range>() == fl::span;
+  return type_ == detail::IndexType::Span;
 }
 
 } // namespace fl

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -70,7 +70,7 @@ Dim Tensor::dim(const size_t dim) const {
   return shape().dim(dim);
 }
 
-unsigned Tensor::ndim() const {
+size_t Tensor::ndim() const {
   return shape().ndim();
 }
 

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -193,7 +193,7 @@ class Tensor {
    *
    * @return the number of dimensions
    */
-  unsigned ndim() const;
+  size_t ndim() const;
 
   /**
    * Returns true if the tensor has zero elements, else false.

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
@@ -41,6 +41,14 @@ af::array afReduceAxes(
   return fl::detail::condenseIndices(arr, keepDims);
 }
 
+unsigned getReducedNumDims(unsigned inSize, unsigned axisSize, bool keepDims) {
+  if (keepDims) {
+    return inSize;
+  } else {
+    return inSize - axisSize;
+  }
+}
+
 } // namespace
 
 ArrayFireBackend::ArrayFireBackend() {
@@ -82,22 +90,26 @@ void ArrayFireBackend::setSeed(int seed) {
 
 Tensor ArrayFireBackend::randn(const Shape& shape, dtype type) {
   return toTensor<ArrayFireTensor>(
-      af::randn(detail::flToAfDims(shape), detail::flToAfType(type)));
+      af::randn(detail::flToAfDims(shape), detail::flToAfType(type)),
+      shape.ndim());
 }
 
 Tensor ArrayFireBackend::rand(const Shape& shape, dtype type) {
   return toTensor<ArrayFireTensor>(
-      af::randu(detail::flToAfDims(shape), detail::flToAfType(type)));
+      af::randu(detail::flToAfDims(shape), detail::flToAfType(type)),
+      shape.ndim());
 }
 
 /* --------------------------- Tensor Operators --------------------------- */
 
 /******************** Tensor Creation Functions ********************/
-#define AF_BACKEND_FULL_FUN_DEF(TYPE)                                \
-  Tensor ArrayFireBackend::full(                                     \
-      const Shape& dims, TYPE value, const dtype type) {             \
-    return toTensor<ArrayFireTensor>(af::constant(                   \
-        value, detail::flToAfDims(dims), detail::flToAfType(type))); \
+#define AF_BACKEND_FULL_FUN_DEF(TYPE)                                    \
+  Tensor ArrayFireBackend::full(                                         \
+      const Shape& shape, TYPE value, const dtype type) {                \
+    return toTensor<ArrayFireTensor>(                                    \
+        af::constant(                                                    \
+            value, detail::flToAfDims(shape), detail::flToAfType(type)), \
+        shape.ndim());                                                   \
   }
 AF_BACKEND_FULL_FUN_DEF(const double&);
 AF_BACKEND_FULL_FUN_DEF(const float&);
@@ -115,7 +127,7 @@ AF_BACKEND_FULL_FUN_DEF(const unsigned short&);
 
 Tensor ArrayFireBackend::identity(const Dim dim, const dtype type) {
   return toTensor<ArrayFireTensor>(
-      af::identity({dim, dim}, detail::flToAfType(type)));
+      af::identity({dim, dim}, detail::flToAfType(type)), /* numDims = */ 2);
 }
 
 Tensor ArrayFireBackend::arange(
@@ -123,37 +135,41 @@ Tensor ArrayFireBackend::arange(
     const Dim seqDim,
     const dtype type) {
   return toTensor<ArrayFireTensor>(
-      af::range(detail::flToAfDims(shape), seqDim, detail::flToAfType(type)));
+      af::range(detail::flToAfDims(shape), seqDim, detail::flToAfType(type)),
+      shape.ndim());
 }
 
 Tensor ArrayFireBackend::iota(
     const Shape& dims,
     const Shape& tileDims,
     const dtype type) {
-  return toTensor<ArrayFireTensor>(af::iota(
-      detail::flToAfDims(dims),
-      detail::flToAfDims(tileDims),
-      detail::flToAfType(type)));
+  return toTensor<ArrayFireTensor>(
+      af::iota(
+          detail::flToAfDims(dims),
+          detail::flToAfDims(tileDims),
+          detail::flToAfType(type)),
+      // TODO: check
+      tileDims.ndim());
 }
 
 /************************ Shaping and Indexing *************************/
 Tensor ArrayFireBackend::reshape(const Tensor& tensor, const Shape& shape) {
   return toTensor<ArrayFireTensor>(
-      af::moddims(toArray(tensor), detail::flToAfDims(shape)));
+      af::moddims(toArray(tensor), detail::flToAfDims(shape)), shape.ndim());
 }
 
 Tensor ArrayFireBackend::transpose(
     const Tensor& tensor,
     const Shape& dims /* = {} */) {
-  if (tensor.shape().ndim() == 2 &&
-      (dims.ndim() == 0 || dims == Shape({1, 0}))) {
+  if (tensor.ndim() == 2 && (dims.ndim() == 0 || dims == Shape({1, 0}))) {
     // fastpath for matrices
     return toTensor<ArrayFireTensor>(
-        detail::condenseIndices(af::transpose(toArray(tensor))));
+        detail::condenseIndices(af::transpose(toArray(tensor))), tensor.ndim());
   } else if (dims.ndim() == 0) {
     // flip all dimensions
     return toTensor<ArrayFireTensor>(
-        detail::condenseIndices(af::reorder(toArray(tensor), 3, 2, 1, 0)));
+        detail::condenseIndices(af::reorder(toArray(tensor), 3, 2, 1, 0)),
+        tensor.ndim());
   } else {
     if (dims.ndim() > AF_MAX_DIMS) {
       throw std::invalid_argument(
@@ -166,23 +182,33 @@ Tensor ArrayFireBackend::transpose(
     for (size_t i = 0; i < dims.ndim(); ++i) {
       d[i] = dims[i];
     }
-    return toTensor<ArrayFireTensor>(detail::condenseIndices(
-        af::reorder(toArray(tensor), d[0], d[1], d[2], d[3])));
+    return toTensor<ArrayFireTensor>(
+        detail::condenseIndices(
+            af::reorder(toArray(tensor), d[0], d[1], d[2], d[3])),
+        tensor.ndim());
   }
 }
 
 Tensor ArrayFireBackend::tile(const Tensor& tensor, const Shape& shape) {
   return toTensor<ArrayFireTensor>(
-      af::tile(toArray(tensor), detail::flToAfDims(shape)));
+      af::tile(toArray(tensor), detail::flToAfDims(shape)),
+      // TODO: check
+      std::max(tensor.ndim(), shape.ndim()));
 }
 
 Tensor ArrayFireBackend::concatenate(
     const std::vector<Tensor>& tensors,
     unsigned axis) {
+  // TODO: write this in a custom way with index assignment so as to avoid this
+  // limitation
   if (tensors.size() > 10) {
     throw std::invalid_argument(
         "ArrayFire concatenate doesn't support > 10 tensors");
   }
+  if (tensors.size() == 0) {
+    return toTensor<ArrayFireTensor>(ArrayFireTensor()); // empty tensor
+  }
+
   std::vector<af_array> arrs(tensors.size());
   std::transform(
       tensors.begin(), tensors.end(), arrs.begin(), [](const Tensor& t) {
@@ -190,11 +216,19 @@ Tensor ArrayFireBackend::concatenate(
       });
   af_array handle = nullptr;
   AF_CHECK(af_join_many(&handle, axis, tensors.size(), arrs.data()));
-  return toTensor<ArrayFireTensor>(af::array(handle));
+
+  unsigned numDims = tensors[0].ndim();
+  if (axis > numDims - 1) {
+    numDims = axis + 1;
+  }
+
+  // All tensors have the same numdims
+  return toTensor<ArrayFireTensor>(af::array(handle), numDims);
 }
 
 Tensor ArrayFireBackend::nonzero(const Tensor& tensor) {
-  return toTensor<ArrayFireTensor>(af::where(toArray(tensor)));
+  return toTensor<ArrayFireTensor>(
+      af::where(toArray(tensor)), /* numDims = */ 1);
 }
 
 Tensor ArrayFireBackend::pad(
@@ -215,66 +249,72 @@ Tensor ArrayFireBackend::pad(
     endPadding[i] = second;
   }
 
-  return toTensor<ArrayFireTensor>(af::pad(
-      toArray(input), beginPadding, endPadding, detail::flToAfPadType(type)));
+  return toTensor<ArrayFireTensor>(
+      af::pad(
+          toArray(input),
+          beginPadding,
+          endPadding,
+          detail::flToAfPadType(type)),
+      /* numDims = */ // TODO: check
+      std::max(input.ndim(), padWidths.size()));
 }
 
 /************************** Unary Operators ***************************/
 
 Tensor ArrayFireBackend::exp(const Tensor& tensor) {
-  return toTensor<ArrayFireTensor>(af::exp(toArray(tensor)));
+  return toTensor<ArrayFireTensor>(af::exp(toArray(tensor)), tensor.ndim());
 }
 
 Tensor ArrayFireBackend::log(const Tensor& tensor) {
-  return toTensor<ArrayFireTensor>(af::log(toArray(tensor)));
+  return toTensor<ArrayFireTensor>(af::log(toArray(tensor)), tensor.ndim());
 }
 
 Tensor ArrayFireBackend::negative(const Tensor& tensor) {
-  return toTensor<ArrayFireTensor>(-toArray(tensor));
+  return toTensor<ArrayFireTensor>(-toArray(tensor), tensor.ndim());
 }
 
 Tensor ArrayFireBackend::logicalNot(const Tensor& tensor) {
-  return toTensor<ArrayFireTensor>(!toArray(tensor));
+  return toTensor<ArrayFireTensor>(!toArray(tensor), tensor.ndim());
 }
 
 Tensor ArrayFireBackend::log1p(const Tensor& tensor) {
-  return toTensor<ArrayFireTensor>(af::log1p(toArray(tensor)));
+  return toTensor<ArrayFireTensor>(af::log1p(toArray(tensor)), tensor.ndim());
 }
 
 Tensor ArrayFireBackend::sin(const Tensor& tensor) {
-  return toTensor<ArrayFireTensor>(af::sin(toArray(tensor)));
+  return toTensor<ArrayFireTensor>(af::sin(toArray(tensor)), tensor.ndim());
 }
 
 Tensor ArrayFireBackend::cos(const Tensor& tensor) {
-  return toTensor<ArrayFireTensor>(af::cos(toArray(tensor)));
+  return toTensor<ArrayFireTensor>(af::cos(toArray(tensor)), tensor.ndim());
 }
 
 Tensor ArrayFireBackend::sqrt(const Tensor& tensor) {
-  return toTensor<ArrayFireTensor>(af::sqrt(toArray(tensor)));
+  return toTensor<ArrayFireTensor>(af::sqrt(toArray(tensor)), tensor.ndim());
 }
 
 Tensor ArrayFireBackend::tanh(const Tensor& tensor) {
-  return toTensor<ArrayFireTensor>(af::tanh(toArray(tensor)));
+  return toTensor<ArrayFireTensor>(af::tanh(toArray(tensor)), tensor.ndim());
 }
 
 Tensor ArrayFireBackend::floor(const Tensor& tensor) {
-  return toTensor<ArrayFireTensor>(af::floor(toArray(tensor)));
+  return toTensor<ArrayFireTensor>(af::floor(toArray(tensor)), tensor.ndim());
 }
 
 Tensor ArrayFireBackend::ceil(const Tensor& tensor) {
-  return toTensor<ArrayFireTensor>(af::ceil(toArray(tensor)));
+  return toTensor<ArrayFireTensor>(af::ceil(toArray(tensor)), tensor.ndim());
 }
 
 Tensor ArrayFireBackend::absolute(const Tensor& tensor) {
-  return toTensor<ArrayFireTensor>(af::abs(toArray(tensor)));
+  return toTensor<ArrayFireTensor>(af::abs(toArray(tensor)), tensor.ndim());
 }
 
 Tensor ArrayFireBackend::sigmoid(const Tensor& tensor) {
-  return toTensor<ArrayFireTensor>(af::sigmoid(toArray(tensor)));
+  return toTensor<ArrayFireTensor>(af::sigmoid(toArray(tensor)), tensor.ndim());
 }
 
 Tensor ArrayFireBackend::erf(const Tensor& tensor) {
-  return toTensor<ArrayFireTensor>(af::erf(toArray(tensor)));
+  return toTensor<ArrayFireTensor>(af::erf(toArray(tensor)), tensor.ndim());
 }
 
 Tensor ArrayFireBackend::clip(
@@ -282,31 +322,31 @@ Tensor ArrayFireBackend::clip(
     const Tensor& low,
     const Tensor& high) {
   return toTensor<ArrayFireTensor>(
-      af::clamp(toArray(tensor), toArray(low), toArray(high)));
+      af::clamp(toArray(tensor), toArray(low), toArray(high)), tensor.ndim());
 }
 
 Tensor ArrayFireBackend::isnan(const Tensor& tensor) {
-  return toTensor<ArrayFireTensor>(af::isNaN(toArray(tensor)));
+  return toTensor<ArrayFireTensor>(af::isNaN(toArray(tensor)), tensor.ndim());
 }
 
 Tensor ArrayFireBackend::isinf(const Tensor& tensor) {
-  return toTensor<ArrayFireTensor>(af::isInf(toArray(tensor)));
+  return toTensor<ArrayFireTensor>(af::isInf(toArray(tensor)), tensor.ndim());
 }
 
 Tensor ArrayFireBackend::sign(const Tensor& tensor) {
   auto wSigned = 1 - 2 * af::sign(toArray(tensor));
   wSigned(toArray(tensor) == 0) = 0;
-  return toTensor<ArrayFireTensor>(std::move(wSigned));
+  return toTensor<ArrayFireTensor>(std::move(wSigned), tensor.ndim());
 }
 
 Tensor ArrayFireBackend::tril(const Tensor& tensor) {
   return toTensor<ArrayFireTensor>(
-      af::lower(toArray(tensor), /* is_unit_diag = */ false));
+      af::lower(toArray(tensor), /* is_unit_diag = */ false), tensor.ndim());
 }
 
 Tensor ArrayFireBackend::triu(const Tensor& tensor) {
   return toTensor<ArrayFireTensor>(
-      af::upper(toArray(tensor), /* is_unit_diag = */ false));
+      af::upper(toArray(tensor), /* is_unit_diag = */ false), tensor.ndim());
 }
 
 Tensor ArrayFireBackend::where(
@@ -321,12 +361,12 @@ Tensor ArrayFireBackend::where(
 /************************** Binary Operators ***************************/
 // For ArrayFire, af::array already implements overloads for all needed
 // operators -- use these by default.
-#define FL_AF_BINARY_OP_TYPE_DEF(FUNC, OP, TYPE)             \
-  Tensor ArrayFireBackend::FUNC(const Tensor& a, TYPE rhs) { \
-    return toTensor<ArrayFireTensor>(toArray(a) OP rhs);     \
-  }                                                          \
-  Tensor ArrayFireBackend::FUNC(TYPE lhs, const Tensor& a) { \
-    return toTensor<ArrayFireTensor>(lhs OP toArray(a));     \
+#define FL_AF_BINARY_OP_TYPE_DEF(FUNC, OP, TYPE)                   \
+  Tensor ArrayFireBackend::FUNC(const Tensor& a, TYPE rhs) {       \
+    return toTensor<ArrayFireTensor>(toArray(a) OP rhs, a.ndim()); \
+  }                                                                \
+  Tensor ArrayFireBackend::FUNC(TYPE lhs, const Tensor& a) {       \
+    return toTensor<ArrayFireTensor>(lhs OP toArray(a), a.ndim()); \
   }
 
 #define FL_AF_BINARY_OP_LITERALS_DEF(FUNC, OP)                   \
@@ -348,7 +388,8 @@ Tensor ArrayFireBackend::where(
 // already defined on af::arrays
 #define FL_AF_BINARY_OP_DEF(OP, FUNC)                                   \
   Tensor ArrayFireBackend::FUNC(const Tensor& lhs, const Tensor& rhs) { \
-    return toTensor<ArrayFireTensor>(toArray(lhs) OP toArray(rhs));     \
+    return toTensor<ArrayFireTensor>(                                   \
+        toArray(lhs) OP toArray(rhs), lhs.ndim());                      \
   }                                                                     \
   FL_AF_BINARY_OP_LITERALS_DEF(FUNC, OP);
 
@@ -378,29 +419,34 @@ FL_AF_BINARY_OP_DEF(>>, rShift);
 #undef FL_AF_BINARY_OP_LITERALS_DEF
 
 Tensor ArrayFireBackend::minimum(const Tensor& lhs, const Tensor& rhs) {
-  return toTensor<ArrayFireTensor>(af::min(toArray(lhs), toArray(rhs)));
+  return toTensor<ArrayFireTensor>(
+      af::min(toArray(lhs), toArray(rhs)), lhs.ndim());
 }
 
 Tensor ArrayFireBackend::maximum(const Tensor& lhs, const Tensor& rhs) {
-  return toTensor<ArrayFireTensor>(af::max(toArray(lhs), toArray(rhs)));
+  return toTensor<ArrayFireTensor>(
+      af::max(toArray(lhs), toArray(rhs)), lhs.ndim());
 }
 
 Tensor ArrayFireBackend::power(const Tensor& lhs, const Tensor& rhs) {
-  return toTensor<ArrayFireTensor>(af::pow(toArray(lhs), toArray(rhs)));
+  return toTensor<ArrayFireTensor>(
+      af::pow(toArray(lhs), toArray(rhs)), lhs.ndim());
 }
 
-/************************** Matrix Multiply ***************************/
+/************************** BLAS ***************************/
 
 Tensor ArrayFireBackend::matmul(
     const Tensor& lhs,
     const Tensor& rhs,
     MatrixProperty lhsProp,
     MatrixProperty rhsProp) {
-  return toTensor<ArrayFireTensor>(af::matmul(
-      toArray(lhs),
-      toArray(rhs),
-      detail::flToAfMatrixProperty(lhsProp),
-      detail::flToAfMatrixProperty(rhsProp)));
+  return toTensor<ArrayFireTensor>(
+      af::matmul(
+          toArray(lhs),
+          toArray(rhs),
+          detail::flToAfMatrixProperty(lhsProp),
+          detail::flToAfMatrixProperty(rhsProp)),
+      /* numDims = */ std::max(lhs.ndim(), rhs.ndim()));
 }
 
 /************************** Reductions ***************************/
@@ -410,7 +456,8 @@ Tensor ArrayFireBackend::amin(
     const std::vector<int>& axes,
     bool keepDims) {
   return toTensor<ArrayFireTensor>(
-      afReduceAxes(toArray(input), axes, af::min, keepDims));
+      afReduceAxes(toArray(input), axes, af::min, keepDims),
+      getReducedNumDims(input.ndim(), axes.size(), keepDims));
 }
 
 // TODO: consolidate with above
@@ -423,7 +470,8 @@ Tensor ArrayFireBackend::amax(
     const std::vector<int>& axes,
     bool keepDims) {
   return toTensor<ArrayFireTensor>(
-      afReduceAxes(toArray(input), axes, af::max, keepDims));
+      afReduceAxes(toArray(input), axes, af::max, keepDims),
+      getReducedNumDims(input.ndim(), axes.size(), keepDims));
 }
 
 // TODO: consolidate with above
@@ -436,7 +484,8 @@ Tensor ArrayFireBackend::sum(
     const std::vector<int>& axes,
     bool keepDims) {
   return toTensor<ArrayFireTensor>(
-      afReduceAxes(toArray(input), axes, af::sum, keepDims));
+      afReduceAxes(toArray(input), axes, af::sum, keepDims),
+      getReducedNumDims(input.ndim(), axes.size(), keepDims));
 }
 
 // TODO: consolidate with above
@@ -450,7 +499,8 @@ Tensor ArrayFireBackend::mean(
     bool keepDims) {
   return toTensor<ArrayFireTensor>(
       afReduceAxes<af::array(const af::array&, const dim_t)>(
-          toArray(input), axes, af::mean, keepDims));
+          toArray(input), axes, af::mean, keepDims),
+      getReducedNumDims(input.ndim(), axes.size(), keepDims));
 }
 
 // TODO: consolidate with above
@@ -464,7 +514,8 @@ Tensor ArrayFireBackend::median(
     bool keepDims) {
   return toTensor<ArrayFireTensor>(
       afReduceAxes<af::array(const af::array&, const dim_t)>(
-          toArray(input), axes, af::median, keepDims));
+          toArray(input), axes, af::median, keepDims),
+      getReducedNumDims(input.ndim(), axes.size(), keepDims));
 }
 
 // TODO: consolidate with above
@@ -477,13 +528,17 @@ Tensor ArrayFireBackend::var(
     const std::vector<int>& axes,
     const bool bias,
     bool keepDims) {
-  // Use arrayfire default for one dimension which may be optimized
+  // Use ArrayFire default for one dimension which may be optimized
   auto& arr = toArray(input);
   if (axes.size() == 1) {
-    return toTensor<ArrayFireTensor>(detail::condenseIndices(
-        af::var(
-            arr, bias ? AF_VARIANCE_SAMPLE : AF_VARIANCE_POPULATION, axes[0]),
-        keepDims));
+    return toTensor<ArrayFireTensor>(
+        detail::condenseIndices(
+            af::var(
+                arr,
+                bias ? AF_VARIANCE_SAMPLE : AF_VARIANCE_POPULATION,
+                axes[0]),
+            keepDims),
+        /* numDims = */ input.ndim() - 1);
   }
   auto meanArr = mean(input, axes, /* keepDims = */ false);
   // TODO Replace when we have batchFunc for fl::Tensor
@@ -501,7 +556,9 @@ Tensor ArrayFireBackend::var(
   }
 
   x = x / denominator;
-  return toTensor<ArrayFireTensor>(detail::condenseIndices(x, keepDims));
+  return toTensor<ArrayFireTensor>(
+      detail::condenseIndices(x, keepDims),
+      getReducedNumDims(input.ndim(), axes.size(), keepDims));
 }
 
 // TODO: consolidate with above
@@ -515,7 +572,9 @@ Tensor ArrayFireBackend::std(
     bool keepDims) {
   if (axes.size() == 1) {
     // Use arrayfire default for one dimension which may be optimized
-    return toTensor<ArrayFireTensor>(af::stdev(toArray(input), axes[0]));
+    // TODO: update this? stddev is deprecated.
+    return toTensor<ArrayFireTensor>(
+        af::stdev(toArray(input), axes[0]), /* numDims = */ input.ndim() - 1);
   }
   return this->sqrt(this->var(input, axes, /* bias = */ false, keepDims));
 }
@@ -529,19 +588,24 @@ Tensor ArrayFireBackend::countNonzero(
     const std::vector<int>& axes,
     bool keepDims) {
   auto& arr = toArray(input);
+  unsigned numDims;
   af::array out;
   if (axes.size() == 0) {
     out = af::sum(af::count(arr));
+    numDims = 1;
   } else if (axes.size() == 1) {
     out = af::count(arr, axes.front());
+    numDims = getReducedNumDims(input.ndim(), axes.size(), keepDims);
   } else {
     out = afReduceAxes(
         af::count(arr, axes.front()),
         std::vector<int>(axes.begin() + 1, axes.end()),
         af::sum,
         keepDims);
+    numDims = getReducedNumDims(input.ndim(), axes.size(), keepDims);
   }
-  return toTensor<ArrayFireTensor>(detail::condenseIndices(out, keepDims));
+  return toTensor<ArrayFireTensor>(
+      detail::condenseIndices(out, keepDims), numDims);
 }
 
 Tensor ArrayFireBackend::any(
@@ -549,7 +613,8 @@ Tensor ArrayFireBackend::any(
     const std::vector<int>& axes,
     bool keepDims) {
   return toTensor<ArrayFireTensor>(
-      afReduceAxes(toArray(input), axes, af::anyTrue, keepDims));
+      afReduceAxes(toArray(input), axes, af::anyTrue, keepDims),
+      getReducedNumDims(input.ndim(), axes.size(), keepDims));
 }
 
 bool ArrayFireBackend::any(const Tensor& input) {
@@ -561,7 +626,8 @@ Tensor ArrayFireBackend::all(
     const std::vector<int>& axes,
     bool keepDims) {
   return toTensor<ArrayFireTensor>(
-      afReduceAxes(toArray(input), axes, af::allTrue, keepDims));
+      afReduceAxes(toArray(input), axes, af::allTrue, keepDims),
+      getReducedNumDims(input.ndim(), axes.size(), keepDims));
 }
 
 bool ArrayFireBackend::all(const Tensor& input) {

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
@@ -37,18 +37,25 @@ af::array& toArray(Tensor& tensor) {
   return tensor.getAdapter<ArrayFireTensor>().getHandle();
 }
 
-ArrayFireTensor::ArrayFireTensor(af::array&& array)
-    : arrayHandle_(std::make_shared<af::array>(std::move(array))) {}
+ArrayFireTensor::ArrayFireTensor(af::array&& array, unsigned numDims)
+    : arrayHandle_(std::make_shared<af::array>(std::move(array))),
+      numDims_(numDims) {}
 
 ArrayFireTensor::ArrayFireTensor(
     std::shared_ptr<af::array> arr,
-    std::vector<af::index>&& indices)
+    std::vector<af::index>&& afIndices,
+    std::vector<detail::IndexType>&& indexTypes,
+    unsigned numDims)
     : arrayHandle_(arr),
-      indices_(std::move(indices)),
-      handle_(IndexedArrayComponent()) {}
+      indices_(std::move(afIndices)),
+      indexTypes_(std::move(indexTypes)),
+      handle_(IndexedArrayComponent()),
+      numDims_(numDims) {}
 
-ArrayFireTensor::ArrayFireTensor(std::shared_ptr<af::array> arr)
-    : arrayHandle_(arr) {}
+ArrayFireTensor::ArrayFireTensor(
+    std::shared_ptr<af::array> arr,
+    unsigned numDims)
+    : arrayHandle_(arr), numDims_(numDims) {}
 
 ArrayFireTensor::ArrayFireTensor() : handle_(ArrayComponent()) {}
 
@@ -59,7 +66,12 @@ ArrayFireTensor::ArrayFireTensor(
     Location memoryLocation)
     : arrayHandle_(std::make_shared<af::array>(
           detail::fromFlData(shape, ptr, type, memoryLocation))),
-      handle_(ArrayComponent()) {}
+      handle_(ArrayComponent()),
+      numDims_(shape.ndim()) {}
+
+unsigned ArrayFireTensor::numDims() const {
+  return numDims_;
+}
 
 af::array::array_proxy ArrayFireTensor::IndexedArrayComponent::get(
     const ArrayFireTensor& inst) {
@@ -98,28 +110,33 @@ af::array& ArrayFireTensor::getHandle() {
   // the conversion.
   if (!std::holds_alternative<ArrayComponent>(handle_)) {
     arrayHandle_ = std::make_shared<af::array>(detail::condenseIndices(
-        std::get<IndexedArrayComponent>(handle_).get(*this)));
+        std::get<IndexedArrayComponent>(handle_).get(*this),
+        /* keepDims = */ false,
+        indexTypes_));
+    // Clear state
     handle_ = ArrayComponent(); // set to passthrough
     indices_ = {}; // remove indices
+    indexTypes_ = {}; // remove IndexTypes
   }
   return *arrayHandle_;
 }
 
 std::unique_ptr<TensorAdapterBase> ArrayFireTensor::clone() const {
   af::array arr = getHandle(); // increment internal AF refcount
-  return std::unique_ptr<ArrayFireTensor>(new ArrayFireTensor(std::move(arr)));
+  return std::unique_ptr<ArrayFireTensor>(
+      new ArrayFireTensor(std::move(arr), numDims()));
 }
 
 Tensor ArrayFireTensor::copy() {
-  return toTensor<ArrayFireTensor>(arrayHandle_->copy());
+  return toTensor<ArrayFireTensor>(arrayHandle_->copy(), numDims());
 }
 
 Tensor ArrayFireTensor::shallowCopy() {
   // ensure indexing is resolved so copying a handle ref is sufficient
   getHandle();
 
-  return Tensor(
-      std::unique_ptr<ArrayFireTensor>(new ArrayFireTensor(arrayHandle_)));
+  return Tensor(std::unique_ptr<ArrayFireTensor>(
+      new ArrayFireTensor(arrayHandle_, numDims())));
 }
 
 TensorBackendType ArrayFireTensor::backendType() const {
@@ -134,7 +151,7 @@ TensorBackend& ArrayFireTensor::backend() const {
 const Shape& ArrayFireTensor::shape() {
   // Update the Shape in-place. Doesn't change any underlying data; only the
   // mirrored Shape metadata.
-  detail::afToFlDims(getHandle().dims(), shape_);
+  detail::afToFlDims(getHandle().dims(), numDims(), shape_);
   return shape_;
 }
 
@@ -176,13 +193,12 @@ bool ArrayFireTensor::isContiguous() {
 }
 
 Shape ArrayFireTensor::strides() {
-  // TODO(jacobkahn) do we need to condenseDims here?
-  return detail::afToFlDims(af::getStrides(getHandle()));
+  return detail::afToFlDims(af::getStrides(getHandle()), numDims());
 }
 
 Tensor ArrayFireTensor::astype(const dtype type) {
   auto a = getHandle().as(detail::flToAfType(type));
-  return toTensor<ArrayFireTensor>(std::move(a));
+  return toTensor<ArrayFireTensor>(std::move(a), numDims());
 }
 
 Tensor ArrayFireTensor::index(const std::vector<Index>& indices) {
@@ -193,25 +209,52 @@ Tensor ArrayFireTensor::index(const std::vector<Index>& indices) {
   }
 
   // If indexing with a single element and it's an Array, don't use spans
-  // TODO: vet and stress test this a lot more
+  // TODO: vet and stress test this a lot more/add proper support for
+  // multi-tensor
+  bool tensorIndex = indices.size() == 1 &&
+      indices.front().type() == detail::IndexType::Tensor;
   std::vector<af::index> afIndices;
-  if (indices.size() == 1 &&
-      indices.front().type() == detail::IndexType::Tensor) {
+  if (tensorIndex) {
+    tensorIndex = true;
     afIndices = {af::index(0)};
   } else {
-    afIndices = {af::span, af::span, af::span, af::span};
+    afIndices = {af::span, af::span, af::span, af::span}; // implicit spans
   }
-  for (size_t i = 0; i < indices.size(); ++i) {
+
+  // Fill in corresponding index types for each af index
+  std::vector<detail::IndexType> indexTypes(afIndices.size());
+  size_t i = 0;
+  for (; i < indices.size(); ++i) {
+    indexTypes[i] = indices[i].type();
     afIndices[i] = detail::flToAfIndex(indices[i]);
+  }
+  // If we're adding implicit spans, fill those indexTypes in
+  for (; i < indexTypes.size(); ++i) {
+    indexTypes[i] = detail::IndexType::Span;
   }
 
   getHandle(); // if this tensor was a view, run indexing and promote
-  return fl::Tensor(std::unique_ptr<ArrayFireTensor>(
-      new ArrayFireTensor(arrayHandle_, std::move(afIndices))));
+
+  // Compute numDums for the new Tensor
+  unsigned newNumDims = numDims();
+  if (tensorIndex) {
+    // TODO/FIXME: compute this based on the number of els in the indexing
+    // tensor(s)
+    newNumDims = 1;
+  } else {
+    for (const auto& type : indexTypes) {
+      if (type == detail::IndexType::Literal) {
+        newNumDims--;
+      }
+    }
+  }
+
+  return fl::Tensor(std::unique_ptr<ArrayFireTensor>(new ArrayFireTensor(
+      arrayHandle_, std::move(afIndices), std::move(indexTypes), newNumDims)));
 }
 
 Tensor ArrayFireTensor::flatten() const {
-  return toTensor<ArrayFireTensor>(af::flat(getHandle()));
+  return toTensor<ArrayFireTensor>(af::flat(getHandle()), /* numDims = */ 1);
 }
 
 void ArrayFireTensor::setContext(void* context) {} // noop
@@ -226,25 +269,49 @@ void* ArrayFireTensor::getContext() {
     std::visit(                                                          \
         [val, this](auto&& arr) { arr.get(*this) AF_OP val; }, handle_); \
   }
-#define ASSIGN_OP(FUN, AF_OP)                                                  \
-  void ArrayFireTensor::FUN(const Tensor& tensor) {                            \
-    std::visit(                                                                \
-        [&tensor, this](auto&& arr) { arr.get(*this) AF_OP toArray(tensor); }, \
-        handle_);                                                              \
-  }                                                                            \
-  ASSIGN_OP_TYPE(FUN, AF_OP, double);                                          \
-  ASSIGN_OP_TYPE(FUN, AF_OP, float);                                           \
-  ASSIGN_OP_TYPE(FUN, AF_OP, int);                                             \
-  ASSIGN_OP_TYPE(FUN, AF_OP, unsigned);                                        \
-  ASSIGN_OP_TYPE(FUN, AF_OP, bool);                                            \
-  ASSIGN_OP_TYPE(FUN, AF_OP, char);                                            \
-  ASSIGN_OP_TYPE(FUN, AF_OP, unsigned char);                                   \
-  ASSIGN_OP_TYPE(FUN, AF_OP, short);                                           \
-  ASSIGN_OP_TYPE(FUN, AF_OP, unsigned short);                                  \
-  ASSIGN_OP_TYPE(FUN, AF_OP, long);                                            \
-  ASSIGN_OP_TYPE(FUN, AF_OP, unsigned long);                                   \
-  ASSIGN_OP_TYPE(FUN, AF_OP, long long);                                       \
+
+#define ASSIGN_OP_LITERALS(FUN, AF_OP)        \
+  ASSIGN_OP_TYPE(FUN, AF_OP, double);         \
+  ASSIGN_OP_TYPE(FUN, AF_OP, float);          \
+  ASSIGN_OP_TYPE(FUN, AF_OP, int);            \
+  ASSIGN_OP_TYPE(FUN, AF_OP, unsigned);       \
+  ASSIGN_OP_TYPE(FUN, AF_OP, bool);           \
+  ASSIGN_OP_TYPE(FUN, AF_OP, char);           \
+  ASSIGN_OP_TYPE(FUN, AF_OP, unsigned char);  \
+  ASSIGN_OP_TYPE(FUN, AF_OP, short);          \
+  ASSIGN_OP_TYPE(FUN, AF_OP, unsigned short); \
+  ASSIGN_OP_TYPE(FUN, AF_OP, long);           \
+  ASSIGN_OP_TYPE(FUN, AF_OP, unsigned long);  \
+  ASSIGN_OP_TYPE(FUN, AF_OP, long long);      \
   ASSIGN_OP_TYPE(FUN, AF_OP, unsigned long long);
+
+#define ASSIGN_OP_TENSOR(FUN, AF_OP)                                       \
+  void ArrayFireTensor::FUN(const Tensor& tensor) {                        \
+    std::visit(                                                            \
+        [&tensor, this](auto&& arr) {                                      \
+          /* optimstically try to moddims the operand's singleton dims */  \
+          const af::dim4& preIdxDims = arrayHandle_->dims();               \
+          const af::array& operandArr = toArray(tensor);                   \
+          const af::dim4 newDims = detail::remapToIndexedDims(             \
+              preIdxDims,                                                  \
+              indices_.value_or(std::vector<af::index>()),                 \
+              indexTypes_.value_or(std::vector<detail::IndexType>()),      \
+              operandArr.dims());                                          \
+          /* af::moddims involves in an eval. This will be fixed in        \
+           * AF 3.8.1/3.8.2 */                                             \
+          bool doModdims = operandArr.dims() != newDims;                   \
+          af::array operandArrNew =                                        \
+              (doModdims ? af::moddims(operandArr, newDims) : operandArr); \
+          arr.get(*this) AF_OP operandArrNew;                              \
+          /* this is wrong - fix this behavior */                          \
+          this->numDims_ = tensor.ndim();                                  \
+        },                                                                 \
+        handle_);                                                          \
+  }
+
+#define ASSIGN_OP(FUN, AF_OP)  \
+  ASSIGN_OP_TENSOR(FUN, AF_OP) \
+  ASSIGN_OP_LITERALS(FUN, AF_OP)
 
 // (function name, AF op). Use build-in AF operators.
 ASSIGN_OP(assign, =);

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
@@ -14,6 +14,7 @@
 
 #include <variant>
 
+#include "flashlight/fl/tensor/Index.h"
 #include "flashlight/fl/tensor/Shape.h"
 #include "flashlight/fl/tensor/TensorAdapter.h"
 
@@ -45,6 +46,10 @@ class ArrayFireTensor : public TensorAdapterBase {
   // Indices in the event that this tensor is about to be indexed. Cleared the
   // next time this array handle is acquired. See getHandle().
   std::optional<std::vector<af::index>> indices_;
+  // Need to maintain the types of each index, as ArrayFire doesn't distinguish
+  // between an integer index literal and an af::seq of size one; both have
+  // slightly different behavior with fl::Tensor
+  std::optional<std::vector<detail::IndexType>> indexTypes_;
   // To be visited when this tensor is to be indexed. Indexes the underlying
   // af::array, and returns the proxy to be used as a temporary lvalue.
   struct IndexedArrayComponent {
@@ -77,23 +82,33 @@ class ArrayFireTensor : public TensorAdapterBase {
    */
   ArrayFireTensor(
       std::shared_ptr<af::array> handle,
-      std::vector<af::index>&& indices);
+      std::vector<af::index>&& afIndices,
+      std::vector<detail::IndexType>&& indexTypes,
+      unsigned numDims);
 
   /**
    * Construct an ArrayFireTensor from an ArrayFire array handle without copying
    * the handle. Used for creating guaranteed-shallow copies.
    */
-  explicit ArrayFireTensor(std::shared_ptr<af::array> arr);
+  explicit ArrayFireTensor(std::shared_ptr<af::array> arr, unsigned numDims);
 
   /*
    * A Flashlight shape that mirrors ArrayFire dims.
    *
    * NOTE: this shape is only updated on calls to ArrayFireTensor::shape()
-   * so as to satisfy API requirements as per returning a const reference..
+   * so as to satisfy API requirements as per returning a const reference.
    * af::array::dims() should be used for internal computation where
    * shape/dimensions are needed.
    */
   Shape shape_;
+
+  /**
+   * The number of dimensions in this ArrayFire tensor that are "expected" per
+   * interoperability with other tensors. Because ArrayFire doesn't distinguish
+   * between singleton dimensions that are defaults and those that are
+   * explicitly specified, this must be explicitly tracked.
+   */
+  unsigned numDims_{1};
 
  public:
   /**
@@ -109,7 +124,7 @@ class ArrayFireTensor : public TensorAdapterBase {
    * @param[in] array construct a tensor from an ArrayFire array rvalue
    * reference.
    */
-  explicit ArrayFireTensor(af::array&& array);
+  explicit ArrayFireTensor(af::array&& array, unsigned numDims);
 
   /**
    * Default initialization - empty ArrayFire array and empty shape.
@@ -146,6 +161,7 @@ class ArrayFireTensor : public TensorAdapterBase {
   af::array& getHandle();
 
   ~ArrayFireTensor() override = default;
+  unsigned numDims() const;
   // Used with the fl::Tensor copy constructor
   std::unique_ptr<TensorAdapterBase> clone() const override;
   TensorBackendType backendType() const override;

--- a/flashlight/fl/test/tensor/IndexTest.cpp
+++ b/flashlight/fl/test/tensor/IndexTest.cpp
@@ -40,7 +40,7 @@ TEST(IndexTest, Type) {
   using namespace detail;
   ASSERT_EQ(fl::Index(3).type(), IndexType::Literal);
   ASSERT_EQ(fl::Index(fl::range(3)).type(), IndexType::Range);
-  ASSERT_EQ(fl::Index(fl::span).type(), IndexType::Range);
+  ASSERT_EQ(fl::Index(fl::span).type(), IndexType::Span);
   ASSERT_EQ(fl::Index(fl::full({2, 2}, 4)).type(), IndexType::Tensor);
   ASSERT_TRUE(fl::Index(fl::span).isSpan());
 }
@@ -59,13 +59,17 @@ TEST(IndexTest, Shape) {
   ASSERT_EQ(t(2, fl::span).shape(), Shape({4}));
   ASSERT_EQ(t(2).shape(), Shape({4}));
   ASSERT_EQ(t(fl::range(3)).shape(), Shape({3, 4}));
-  ASSERT_EQ(t(fl::range(1, 2)).shape(), Shape({4}));
-  ASSERT_EQ(t(fl::range(1, 2), fl::range(1, 2)).shape(), Shape({1}));
+  ASSERT_EQ(t(fl::range(1, 2)).shape(), Shape({1, 4}));
+  ASSERT_EQ(t(fl::range(1, 2), fl::range(1, 2)).shape(), Shape({1, 1}));
   ASSERT_EQ(t(fl::range(0, fl::end)).shape(), Shape({4, 4}));
   ASSERT_EQ(t(fl::range(0, fl::end, 2)).shape(), Shape({2, 4}));
 
   auto t2 = fl::full({5, 6, 7, 8}, 3.);
   ASSERT_EQ(t2(2, fl::range(2, 4), fl::span, 3).shape(), Shape({2, 7}));
+  ASSERT_EQ(t2(fl::span, 3, fl::span, fl::span).shape(), Shape({5, 7, 8}));
+  ASSERT_EQ(
+      t2(fl::span, fl::range(1, 2), fl::span, fl::span).shape(),
+      Shape({5, 1, 7, 8}));
 }
 
 TEST(IndexTest, IndexAssignment) {
@@ -94,6 +98,37 @@ TEST(IndexTest, IndexAssignment) {
   q(0) = r;
   ASSERT_TRUE(allClose(q(0), r));
   ASSERT_TRUE(allClose(q(fl::range(1, fl::end)), fl::full({3, 4}, 2.)));
+
+  auto k = fl::rand({100, 200});
+  k(3) = fl::full({200}, 0.);
+  ASSERT_TRUE(allClose(k(3), fl::full({200}, 0.)));
+
+  auto x = fl::rand({5, 6, 7, 8});
+  x(3) = fl::full({6, 7, 8}, 0.);
+  ASSERT_TRUE(allClose(x(3), fl::full({6, 7, 8}, 0.)));
+  x(fl::span, fl::span, 2) = fl::full({5, 6, 8}, 3.);
+  ASSERT_TRUE(allClose(x(fl::span, fl::span, 2), fl::full({5, 6, 8}, 3.)));
+  ASSERT_THROW(
+      x(fl::span, fl::span, 4) -= fl::rand({5, 6, 1, 8}),
+      std::invalid_argument);
+
+  x(fl::span, fl::range(1, 3), fl::span) = fl::full({5, 2, 7, 8}, 2.);
+  ASSERT_TRUE(allClose(
+      x(fl::span, fl::range(1, 3), fl::span), fl::full({5, 2, 7, 8}, 2.)));
+
+  x(fl::span, fl::arange({5}), fl::span, fl::arange({5})) =
+      fl::full({5, 5, 7, 5}, 2.);
+  ASSERT_TRUE(allClose(
+      x(fl::span, fl::range(1, 3), fl::span), fl::full({5, 2, 7, 8}, 2.)));
+}
+
+TEST(IndexTest, IndexInPlaceOps) {
+  auto a = fl::full({4, 5, 6}, 0.);
+  auto b = fl::full({5, 6}, 1.);
+  a(2) += b;
+  ASSERT_TRUE(allClose(a(2), b));
+  a(2) -= b;
+  ASSERT_TRUE(allClose(a, fl::full({4, 5, 6}, 0.)));
 }
 
 TEST(IndexTest, TensorIndex) {

--- a/flashlight/fl/test/tensor/ShapeTest.cpp
+++ b/flashlight/fl/test/tensor/ShapeTest.cpp
@@ -12,9 +12,6 @@
 
 #include "flashlight/fl/tensor/Shape.h"
 
-// TODO: move me to an independent AF test suite
-#include "flashlight/fl/tensor/backend/af/Utils.h"
-
 using namespace ::testing;
 using namespace fl;
 
@@ -62,20 +59,4 @@ TEST(ShapeTest, Equality) {
   ASSERT_NE(Shape({5, 2, 3}), Shape({5, 2, 3, 1}));
   ASSERT_EQ(Shape({5, 2, 3, 1}), Shape({5, 2, 3, 1}));
   ASSERT_NE(Shape({5, 2, 1, 1}), Shape({5, 2, 1, 4}));
-}
-
-// TODO: move me to an independent AF test suite
-TEST(ShapeTest, ArrayFireInterop) {
-  auto dimsEq = [](const af::dim4& d, const Shape& s) {
-    return detail::afToFlDims(d) == s;
-  };
-
-  ASSERT_TRUE(dimsEq(af::dim4(), {}));
-  ASSERT_TRUE(dimsEq(af::dim4(3), {3})); // not 3, 1, 1, 1
-  ASSERT_TRUE(dimsEq(af::dim4(3, 2), {3, 2})); // not 3, 2, 1, 1
-  ASSERT_TRUE(dimsEq(af::dim4(3, 1), {3})); // 1 is indistinguishable in AF
-  ASSERT_TRUE(dimsEq(af::dim4(1, 3, 2), {1, 3, 2}));
-  ASSERT_TRUE(dimsEq(af::dim4(1), {1}));
-  ASSERT_TRUE(dimsEq(af::dim4(1, 1, 1), {1}));
-  ASSERT_TRUE(dimsEq(af::dim4(0, 1, 1, 1), {}));
 }


### PR DESCRIPTION
Summary:
Numerous fixes to `ArrayFireTensor` and new tests/subtle behavior to existing indexing ops.

Since ArrayFire tensors always have 4 dims, having a tensor that's `(5, 3, 1, 1)` versus `(5, 3, 1)` *is* semantically meaningful, but these two tensors are indistinguishable from ArrayFire's perspective.
 - Because of this, `ArrayFireTensor` needs to hold on to the number of "true" dimensions of the tensor as a property which it the uses to convert ArrayFire shapes (which always have 4 dims) into Flashlight shapes that may have fewer dims.
- All tensor ops have to be retrofit to properly denote the new number of dimensions of the tensor — also integrate this behavior with `keepDims` semantics (preserving reduced-ver dimensions but making them 1). Fix this everywhere.

Other fixes to indexing include:
1. **Inferring in-place and assignment operator semantics.**. Post-indexing a tensor, in-place modifications should be able to operate with the reduced dimensions, i.e:
```
Tensor a = fl::rand({3, 4, 5});
a(2) = fl::full({4, 5}, 0.);
```
`a(2)` is a temporary array proxy before its upcast into an array, but it should be assignable-to by a tensor with the reduced dims (`a(2)` is a `{4, 5}` tensor, not a `{1, 4, 5}`). The result of `a(2)` is a `{1, 4, 5}` ArrayFire tensor, however. There are two options from here:

1. Modify the result of `a(2)` in place to return a new `{4, 5}` temporary. This is impossible since running `af::moddims` on an `array_proxy` calls `operator array()` which creates a copy and means in-place operations are nullpotent.
2. Modify the operand/rhs to have dimensions which are compatible with the indexed lhs array. This is the function of `remapToIndexedDims`.

**Also:**
- Make `fl::Span` use the actual `fl::Span` index type rather than being cast to an `fl::range`, which makes distinguishing between `span`s and `range`s possible.

Differential Revision: D30176567

