### PR TITLE
Add topk, sort, and argsort; fix Index literal type

### DIFF
--- a/flashlight/fl/tensor/Index.cpp
+++ b/flashlight/fl/tensor/Index.cpp
@@ -13,24 +13,24 @@ range::range(idx idx) : range(0, idx) {}
 
 range::range(idx start, idx end) : range(start, end, /* stride */ 1) {}
 
-range::range(idx start, idx end, int stride)
+range::range(idx start, idx end, Dim stride)
     : // fl::end decays to int
-      start_(std::visit([](int idx) -> int { return idx; }, start)),
-      // fl::end --> -1, else idx as int
+      start_(std::visit([](Dim idx) -> Dim { return idx; }, start)),
+      // fl::end --> -1, else idx as Dim
       end_(
           std::holds_alternative<fl::end_t>(end) ? std::get<fl::end_t>(end)
-                                                 : std::get<int>(end) - 1),
+                                                 : std::get<Dim>(end) - 1),
       stride_(stride) {}
 
-int range::start() const {
+Dim range::start() const {
   return start_;
 }
 
-int range::end() const {
+Dim range::end() const {
   return end_;
 }
 
-int range::stride() const {
+Dim range::stride() const {
   return stride_;
 }
 
@@ -52,7 +52,7 @@ Index::Index(const range& range)
                                         : detail::IndexType::Range),
       index_(range) {}
 
-Index::Index(const int idx) : type_(detail::IndexType::Literal), index_(idx) {}
+Index::Index(const Dim idx) : type_(detail::IndexType::Literal), index_(idx) {}
 
 Index::Index(Index&& other) noexcept
     : type_(other.type_), index_(std::move(other.index_)) {}

--- a/flashlight/fl/tensor/Index.cpp
+++ b/flashlight/fl/tensor/Index.cpp
@@ -47,7 +47,10 @@ Index::Index(const Tensor& tensor)
     : type_(detail::IndexType::Tensor), index_(tensor) {}
 
 Index::Index(const range& range)
-    : type_(detail::IndexType::Range), index_(range) {}
+    : type_(
+          range == fl::range(-1, -1, 0) ? detail::IndexType::Span
+                                        : detail::IndexType::Range),
+      index_(range) {}
 
 Index::Index(const int idx) : type_(detail::IndexType::Literal), index_(idx) {}
 
@@ -59,10 +62,7 @@ detail::IndexType Index::type() const {
 }
 
 bool Index::isSpan() const {
-  if (type_ != detail::IndexType::Range) {
-    return false;
-  }
-  return get<range>() == fl::span;
+  return type_ == detail::IndexType::Span;
 }
 
 } // namespace fl

--- a/flashlight/fl/tensor/Index.h
+++ b/flashlight/fl/tensor/Index.h
@@ -17,7 +17,7 @@ namespace fl {
  * Represents the last index along an axis of a tensor.
  */
 struct end_t {
-  operator int() const {
+  operator Dim() const {
     return -1;
   }
 };
@@ -29,11 +29,11 @@ static const end_t end = end_t();
  * An entity representing a contiguous or strided sequence of indices.
  */
 class range {
-  using idx = std::variant<end_t, int>;
+  using idx = std::variant<end_t, Dim>;
 
-  int start_{0};
-  int end_{fl::end};
-  int stride_{1};
+  Dim start_{0};
+  Dim end_{fl::end};
+  Dim stride_{1};
 
  public:
   /**
@@ -55,11 +55,11 @@ class range {
    * Construct a range with the indices [start, end) (i.e. [start, end - 1])
    * with the given stride.
    */
-  range(idx start, idx end, int stride);
+  range(idx start, idx end, Dim stride);
 
-  int start() const;
-  int end() const;
-  int stride() const;
+  Dim start() const;
+  Dim end() const;
+  Dim stride() const;
   bool operator==(const range& other) const;
   bool operator!=(const range& other) const;
 };
@@ -91,7 +91,7 @@ class Index {
   // The type of indexing operator.
   detail::IndexType type_;
   // Underlying data referred to by the index
-  std::variant<int, range, Tensor> index_;
+  std::variant<Dim, range, Tensor> index_;
 
   // Intentionally private
   Index() = default;
@@ -99,7 +99,7 @@ class Index {
  public:
   /* implicit */ Index(const Tensor& tensor);
   /* implicit */ Index(const range& range);
-  /* implicit */ Index(const int idx);
+  /* implicit */ Index(const Dim idx);
 
   /**
    * Default copy assignment operator.

--- a/flashlight/fl/tensor/TensorAdapter.h
+++ b/flashlight/fl/tensor/TensorAdapter.h
@@ -165,6 +165,11 @@ class TensorAdapterBase {
   virtual Tensor flatten() const = 0;
 
   /**
+   * Returns a copy of the tensor that is contiguous in memory.
+   */
+  virtual Tensor asContiguousTensor() = 0;
+
+  /**
    * Sets arbitrary data on a tensor. May be a no-op for some backends.
    */
   virtual void setContext(void* context) = 0;

--- a/flashlight/fl/tensor/TensorBackend.h
+++ b/flashlight/fl/tensor/TensorBackend.h
@@ -110,6 +110,17 @@ class TensorBackend {
   virtual Tensor triu(const Tensor& tensor) = 0;
   virtual Tensor
   where(const Tensor& condition, const Tensor& x, const Tensor& y) = 0;
+  virtual void topk(
+      Tensor& values,
+      Tensor& indices,
+      const Tensor& input,
+      const unsigned k,
+      const Dim axis,
+      const SortMode sortMode) = 0;
+  virtual Tensor
+  sort(const Tensor& input, const Dim axis, const SortMode sortMode) = 0;
+  virtual Tensor
+  argsort(const Tensor& input, const Dim axis, const SortMode sortMode) = 0;
 
   /************************** Binary Operators ***************************/
 #define FL_BINARY_OP_TYPE_DECL(FUNC, TYPE)            \

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -98,6 +98,10 @@ Tensor Tensor::flatten() const {
   return impl_->flatten();
 }
 
+Tensor Tensor::asContiguousTensor() const {
+  return impl_->asContiguousTensor();
+}
+
 TensorBackendType Tensor::backendType() const {
   return impl_->backendType();
 }

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -40,6 +40,21 @@ Tensor::Tensor(
     MemoryLocation memoryLocation)
     : impl_(detail::getDefaultAdapter(shape, type, ptr, memoryLocation)) {}
 
+Tensor::Tensor(
+    const Dim nRows,
+    const Dim nCols,
+    const Tensor& values,
+    const Tensor& rowIdx,
+    const Tensor& colIdx,
+    StorageType storageType)
+    : impl_(detail::getDefaultAdapter(
+          nRows,
+          nCols,
+          values,
+          rowIdx,
+          colIdx,
+          storageType)) {}
+
 Tensor::Tensor(const Shape& shape, fl::dtype type /* = fl::dtype::f32 */)
     : impl_(detail::getDefaultAdapter(shape, type)) {}
 
@@ -84,6 +99,10 @@ size_t Tensor::bytes() const {
 
 dtype Tensor::type() const {
   return impl_->type();
+}
+
+bool Tensor::isSparse() const {
+  return impl_->isSparse();
 }
 
 Tensor Tensor::astype(const dtype type) const {

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -129,40 +129,40 @@ TensorBackend& Tensor::backend() const {
   return impl_->backend();
 }
 
-#define FL_CREATE_MEMORY_OPS(TYPE)                          \
-  template <>                                               \
-  TYPE Tensor::scalar() const {                             \
-    if (type() != dtype_traits<TYPE>::fl_type) {            \
-      throw std::invalid_argument(                          \
-          "Tensor::scalar: requested type doesn't match "   \
-          "tensor type, which is " +                        \
-          std::string(dtype_traits<TYPE>::getName()));      \
-    }                                                       \
-    TYPE out;                                               \
-    impl_->scalar(&out);                                    \
-    return out;                                             \
-  }                                                         \
-                                                            \
-  template <>                                               \
-  TYPE* Tensor::device() const {                            \
-    TYPE* out;                                              \
-    void** addr = reinterpret_cast<void**>(&out);           \
-    impl_->device(addr);                                    \
-    return out;                                             \
-  }                                                         \
-                                                            \
-  template <>                                               \
-  TYPE* Tensor::host() const {                              \
-    TYPE* out = reinterpret_cast<TYPE*>(new char[bytes()]); \
-    void** addr = reinterpret_cast<void**>(&out);           \
-    impl_->host(addr);                                      \
-    return out;                                             \
-  }                                                         \
-                                                            \
-  template <>                                               \
-  void Tensor::host(TYPE* ptr) const {                      \
-    void** addr = reinterpret_cast<void**>(&ptr);           \
-    impl_->host(addr);                                      \
+#define FL_CREATE_MEMORY_OPS(TYPE)                                          \
+  template <>                                                               \
+  TYPE Tensor::scalar() const {                                             \
+    if (type() != dtype_traits<TYPE>::fl_type) {                            \
+      throw std::invalid_argument(                                          \
+          "Tensor::scalar: requested type of " +                            \
+          std::string(dtype_traits<TYPE>::getName()) +                      \
+          " doesn't match tensor type, which is " + dtypeToString(type())); \
+    }                                                                       \
+    TYPE out;                                                               \
+    impl_->scalar(&out);                                                    \
+    return out;                                                             \
+  }                                                                         \
+                                                                            \
+  template <>                                                               \
+  TYPE* Tensor::device() const {                                            \
+    TYPE* out;                                                              \
+    void** addr = reinterpret_cast<void**>(&out);                           \
+    impl_->device(addr);                                                    \
+    return out;                                                             \
+  }                                                                         \
+                                                                            \
+  template <>                                                               \
+  TYPE* Tensor::host() const {                                              \
+    TYPE* out = reinterpret_cast<TYPE*>(new char[bytes()]);                 \
+    void** addr = reinterpret_cast<void**>(&out);                           \
+    impl_->host(addr);                                                      \
+    return out;                                                             \
+  }                                                                         \
+                                                                            \
+  template <>                                                               \
+  void Tensor::host(TYPE* ptr) const {                                      \
+    void** addr = reinterpret_cast<void**>(&ptr);                           \
+    impl_->host(addr);                                                      \
   }
 FL_CREATE_MEMORY_OPS(int);
 FL_CREATE_MEMORY_OPS(unsigned);
@@ -487,6 +487,25 @@ Tensor where(const Tensor& condition, const double& x, const Tensor& y) {
   FL_TENSOR_BACKENDS_MATCH_CHECK(condition, y);
   return condition.backend().where(
       condition, fl::full(condition.shape(), x, y.type()), y);
+}
+
+void topk(
+    Tensor& values,
+    Tensor& indices,
+    const Tensor& input,
+    const unsigned k,
+    const Dim axis,
+    const SortMode sortMode) {
+  FL_TENSOR_BACKENDS_MATCH_CHECK(values, indices, input);
+  input.backend().topk(values, indices, input, k, axis, sortMode);
+}
+
+Tensor sort(const Tensor& input, const Dim axis, const SortMode sortMode) {
+  return input.backend().sort(input, axis, sortMode);
+}
+
+Tensor argsort(const Tensor& input, const Dim axis, const SortMode sortMode) {
+  return input.backend().argsort(input, axis, sortMode);
 }
 
 /************************** Binary Operators ***************************/

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -70,7 +70,7 @@ Dim Tensor::dim(const size_t dim) const {
   return shape().dim(dim);
 }
 
-unsigned Tensor::ndim() const {
+size_t Tensor::ndim() const {
   return shape().ndim();
 }
 

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -193,7 +193,7 @@ class Tensor {
    *
    * @return the number of dimensions
    */
-  unsigned ndim() const;
+  size_t ndim() const;
 
   /**
    * Returns true if the tensor has zero elements, else false.

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -265,6 +265,14 @@ class Tensor {
   Tensor flatten() const;
 
   /**
+   * Return a copy (depending on copy-on-write behavior of the underlying
+   * implementation) of this tensor that is contigous in memory.
+   *
+   * @return an identical tensor that is contiguous in memory
+   */
+  Tensor asContiguousTensor() const;
+
+  /**
    * Gets the backend enum from the underlying TensorAdapter.
    *
    * @return the backend in question

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -41,6 +41,11 @@ enum class Location { Host, Device };
 using MemoryLocation = Location;
 
 /**
+ * Tensor storage types.
+ */
+enum class StorageType { Dense = 0, CSR = 1, CSC = 2, COO = 3 };
+
+/**
  * A Tensor on which computation can be performed.
  *
  * Underlying implementations of tensor operations are implemented via types
@@ -119,6 +124,26 @@ class Tensor {
   explicit Tensor(fl::dtype type);
 
   /**
+   * Construct a sparse tensor.
+   *
+   * @param[in] nRows the number of rows of the tensor
+   * @param[in] nCols the number of columns of the tensor
+   * @param[in] value the values associated with the tensor
+   * @param[in] rowIdx the row indices of the sparse array
+   * @param[in] colIdx the the column indices of the sparse array
+   * @param[in] storageType the storage type of the underlying tensor
+   *
+   * TODO(jacobkahn): expand this API with getters, isSparse() as needed, etc.
+   */
+  Tensor(
+      const Dim nRows,
+      const Dim nCols,
+      const Tensor& values,
+      const Tensor& rowIdx,
+      const Tensor& colIdx,
+      StorageType storageType);
+
+  /**
    * Create a tensor from a vector of values.
    *
    * @param[in] s the shape of the resulting tensor.
@@ -128,6 +153,11 @@ class Tensor {
   template <typename T>
   static Tensor fromVector(Shape s, std::vector<T> v) {
     return Tensor(s, fl::dtype_traits<T>::fl_type, v.data(), Location::Host);
+  }
+
+  template <typename T>
+  static Tensor fromVector(Shape s, std::vector<T> v, dtype type) {
+    return Tensor(s, type, v.data(), Location::Host);
   }
 
   template <typename T>
@@ -215,6 +245,13 @@ class Tensor {
    * @return the dtype of the tensor
    */
   dtype type() const;
+
+  /**
+   * Returns whether or not the tensor is sparse.
+   *
+   * @return true if the tensor is a sparse tensor, else false
+   */
+  bool isSparse() const;
 
   /**
    * Get this tensor's strides - the number of elements/coefficients to step

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -815,6 +815,53 @@ Tensor where(const Tensor& condition, const Tensor& x, const Tensor& y);
 Tensor where(const Tensor& condition, const Tensor& x, const double& y);
 Tensor where(const Tensor& condition, const double& x, const Tensor& y);
 
+/**
+ * Sorting mode for sorting-related functions.
+ */
+enum class SortMode { Descending = 0, Ascending = 1 };
+
+/**
+ * Get the top-k values and indices from a Tensor.
+ *
+ * @param[in] values
+ * @param[in] indices
+ * @param[in] input the input tensor to sort
+ * @param[in] k the top number of elements to return
+ * @param[in] axis the axis along which to sort.
+ * @param[in] sortMode the ordering with which to sort. Defaults to descending.
+ */
+void topk(
+    Tensor& values,
+    Tensor& indices,
+    const Tensor& input,
+    const unsigned k,
+    const Dim axis,
+    const SortMode sortMode = SortMode::Descending);
+
+/**
+ * Sort the values of a tensor, and return the sorted tensor.
+ *
+ * @param[in] input the input Tensor
+ * @param[in] axis the axis along which to sort
+ * @param[in] sortMode the ordering with which to sort. Defaults to descending
+ */
+Tensor sort(
+    const Tensor& input,
+    const Dim axis,
+    const SortMode sortMode = SortMode::Descending);
+
+/**
+ * Sort the values of a tensor and return the sorted indices.
+ *
+ * @param[in] input the input Tensor
+ * @param[in] axis the axis along which to sort
+ * @param[in] sortMode the ordering with which to sort. Defaults to descending
+ */
+Tensor argsort(
+    const Tensor& input,
+    const Dim axis,
+    const SortMode sortMode = SortMode::Descending);
+
 /************************** Binary Operators ***************************/
 #define FL_BINARY_OP_LITERAL_TYPE_DECL(OP, FUNC, TYPE) \
   Tensor FUNC(TYPE lhs, const Tensor& rhs);            \

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
@@ -358,6 +358,62 @@ Tensor ArrayFireBackend::where(
   return orig;
 }
 
+void ArrayFireBackend::topk(
+    Tensor& values,
+    Tensor& indices,
+    const Tensor& input,
+    const unsigned k,
+    const Dim axis,
+    const SortMode sortMode) {
+  if (axis != 0) {
+    throw std::invalid_argument(
+        "ArrayFireTensor topk: operation only supported along zero axis.");
+  }
+  af::array valuesArr, indicesArr;
+  af::topk(
+      valuesArr,
+      indicesArr,
+      toArray(input),
+      k,
+      axis,
+      detail::flToAfSortMode(sortMode));
+
+  values = toTensor<ArrayFireTensor>(std::move(valuesArr), input.ndim());
+  indices = toTensor<ArrayFireTensor>(std::move(indicesArr), input.ndim());
+}
+
+Tensor ArrayFireBackend::sort(
+    const Tensor& input,
+    const Dim axis,
+    const SortMode sortMode) {
+  if (sortMode != SortMode::Descending && sortMode != SortMode::Ascending) {
+    throw std::invalid_argument(
+        "Cannot sort ArrayFire tensor with given SortMode: "
+        "only Descending and Ascending supported.");
+  }
+
+  af::array values, indices;
+  af::sort(
+      values, indices, toArray(input), axis, sortMode == SortMode::Ascending);
+  return toTensor<ArrayFireTensor>(std::move(values), input.ndim());
+}
+
+Tensor ArrayFireBackend::argsort(
+    const Tensor& input,
+    const Dim axis,
+    const SortMode sortMode) {
+  if (sortMode != SortMode::Descending && sortMode != SortMode::Ascending) {
+    throw std::invalid_argument(
+        "Cannot sort ArrayFire tensor with given SortMode: "
+        "only Descending and Ascending supported.");
+  }
+
+  af::array values, indices;
+  af::sort(
+      values, indices, toArray(input), axis, sortMode == SortMode::Ascending);
+  return toTensor<ArrayFireTensor>(std::move(indices), input.ndim());
+}
+
 /************************** Binary Operators ***************************/
 // For ArrayFire, af::array already implements overloads for all needed
 // operators -- use these by default.

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
@@ -41,6 +41,14 @@ af::array afReduceAxes(
   return fl::detail::condenseIndices(arr, keepDims);
 }
 
+unsigned getReducedNumDims(unsigned inSize, unsigned axisSize, bool keepDims) {
+  if (keepDims) {
+    return inSize;
+  } else {
+    return inSize - axisSize;
+  }
+}
+
 } // namespace
 
 ArrayFireBackend::ArrayFireBackend() {
@@ -82,22 +90,26 @@ void ArrayFireBackend::setSeed(int seed) {
 
 Tensor ArrayFireBackend::randn(const Shape& shape, dtype type) {
   return toTensor<ArrayFireTensor>(
-      af::randn(detail::flToAfDims(shape), detail::flToAfType(type)));
+      af::randn(detail::flToAfDims(shape), detail::flToAfType(type)),
+      shape.ndim());
 }
 
 Tensor ArrayFireBackend::rand(const Shape& shape, dtype type) {
   return toTensor<ArrayFireTensor>(
-      af::randu(detail::flToAfDims(shape), detail::flToAfType(type)));
+      af::randu(detail::flToAfDims(shape), detail::flToAfType(type)),
+      shape.ndim());
 }
 
 /* --------------------------- Tensor Operators --------------------------- */
 
 /******************** Tensor Creation Functions ********************/
-#define AF_BACKEND_FULL_FUN_DEF(TYPE)                                \
-  Tensor ArrayFireBackend::full(                                     \
-      const Shape& dims, TYPE value, const dtype type) {             \
-    return toTensor<ArrayFireTensor>(af::constant(                   \
-        value, detail::flToAfDims(dims), detail::flToAfType(type))); \
+#define AF_BACKEND_FULL_FUN_DEF(TYPE)                                    \
+  Tensor ArrayFireBackend::full(                                         \
+      const Shape& shape, TYPE value, const dtype type) {                \
+    return toTensor<ArrayFireTensor>(                                    \
+        af::constant(                                                    \
+            value, detail::flToAfDims(shape), detail::flToAfType(type)), \
+        shape.ndim());                                                   \
   }
 AF_BACKEND_FULL_FUN_DEF(const double&);
 AF_BACKEND_FULL_FUN_DEF(const float&);
@@ -115,7 +127,7 @@ AF_BACKEND_FULL_FUN_DEF(const unsigned short&);
 
 Tensor ArrayFireBackend::identity(const Dim dim, const dtype type) {
   return toTensor<ArrayFireTensor>(
-      af::identity({dim, dim}, detail::flToAfType(type)));
+      af::identity({dim, dim}, detail::flToAfType(type)), /* numDims = */ 2);
 }
 
 Tensor ArrayFireBackend::arange(
@@ -123,37 +135,41 @@ Tensor ArrayFireBackend::arange(
     const Dim seqDim,
     const dtype type) {
   return toTensor<ArrayFireTensor>(
-      af::range(detail::flToAfDims(shape), seqDim, detail::flToAfType(type)));
+      af::range(detail::flToAfDims(shape), seqDim, detail::flToAfType(type)),
+      shape.ndim());
 }
 
 Tensor ArrayFireBackend::iota(
     const Shape& dims,
     const Shape& tileDims,
     const dtype type) {
-  return toTensor<ArrayFireTensor>(af::iota(
-      detail::flToAfDims(dims),
-      detail::flToAfDims(tileDims),
-      detail::flToAfType(type)));
+  return toTensor<ArrayFireTensor>(
+      af::iota(
+          detail::flToAfDims(dims),
+          detail::flToAfDims(tileDims),
+          detail::flToAfType(type)),
+      // TODO: check
+      tileDims.ndim());
 }
 
 /************************ Shaping and Indexing *************************/
 Tensor ArrayFireBackend::reshape(const Tensor& tensor, const Shape& shape) {
   return toTensor<ArrayFireTensor>(
-      af::moddims(toArray(tensor), detail::flToAfDims(shape)));
+      af::moddims(toArray(tensor), detail::flToAfDims(shape)), shape.ndim());
 }
 
 Tensor ArrayFireBackend::transpose(
     const Tensor& tensor,
     const Shape& dims /* = {} */) {
-  if (tensor.shape().ndim() == 2 &&
-      (dims.ndim() == 0 || dims == Shape({1, 0}))) {
+  if (tensor.ndim() == 2 && (dims.ndim() == 0 || dims == Shape({1, 0}))) {
     // fastpath for matrices
     return toTensor<ArrayFireTensor>(
-        detail::condenseIndices(af::transpose(toArray(tensor))));
+        detail::condenseIndices(af::transpose(toArray(tensor))), tensor.ndim());
   } else if (dims.ndim() == 0) {
     // flip all dimensions
     return toTensor<ArrayFireTensor>(
-        detail::condenseIndices(af::reorder(toArray(tensor), 3, 2, 1, 0)));
+        detail::condenseIndices(af::reorder(toArray(tensor), 3, 2, 1, 0)),
+        tensor.ndim());
   } else {
     if (dims.ndim() > AF_MAX_DIMS) {
       throw std::invalid_argument(
@@ -166,23 +182,33 @@ Tensor ArrayFireBackend::transpose(
     for (size_t i = 0; i < dims.ndim(); ++i) {
       d[i] = dims[i];
     }
-    return toTensor<ArrayFireTensor>(detail::condenseIndices(
-        af::reorder(toArray(tensor), d[0], d[1], d[2], d[3])));
+    return toTensor<ArrayFireTensor>(
+        detail::condenseIndices(
+            af::reorder(toArray(tensor), d[0], d[1], d[2], d[3])),
+        tensor.ndim());
   }
 }
 
 Tensor ArrayFireBackend::tile(const Tensor& tensor, const Shape& shape) {
   return toTensor<ArrayFireTensor>(
-      af::tile(toArray(tensor), detail::flToAfDims(shape)));
+      af::tile(toArray(tensor), detail::flToAfDims(shape)),
+      // TODO: check
+      std::max(tensor.ndim(), shape.ndim()));
 }
 
 Tensor ArrayFireBackend::concatenate(
     const std::vector<Tensor>& tensors,
     unsigned axis) {
+  // TODO: write this in a custom way with index assignment so as to avoid this
+  // limitation
   if (tensors.size() > 10) {
     throw std::invalid_argument(
         "ArrayFire concatenate doesn't support > 10 tensors");
   }
+  if (tensors.size() == 0) {
+    return toTensor<ArrayFireTensor>(ArrayFireTensor()); // empty tensor
+  }
+
   std::vector<af_array> arrs(tensors.size());
   std::transform(
       tensors.begin(), tensors.end(), arrs.begin(), [](const Tensor& t) {
@@ -190,11 +216,19 @@ Tensor ArrayFireBackend::concatenate(
       });
   af_array handle = nullptr;
   AF_CHECK(af_join_many(&handle, axis, tensors.size(), arrs.data()));
-  return toTensor<ArrayFireTensor>(af::array(handle));
+
+  unsigned numDims = tensors[0].ndim();
+  if (axis > numDims - 1) {
+    numDims = axis + 1;
+  }
+
+  // All tensors have the same numdims
+  return toTensor<ArrayFireTensor>(af::array(handle), numDims);
 }
 
 Tensor ArrayFireBackend::nonzero(const Tensor& tensor) {
-  return toTensor<ArrayFireTensor>(af::where(toArray(tensor)));
+  return toTensor<ArrayFireTensor>(
+      af::where(toArray(tensor)), /* numDims = */ 1);
 }
 
 Tensor ArrayFireBackend::pad(
@@ -215,66 +249,72 @@ Tensor ArrayFireBackend::pad(
     endPadding[i] = second;
   }
 
-  return toTensor<ArrayFireTensor>(af::pad(
-      toArray(input), beginPadding, endPadding, detail::flToAfPadType(type)));
+  return toTensor<ArrayFireTensor>(
+      af::pad(
+          toArray(input),
+          beginPadding,
+          endPadding,
+          detail::flToAfPadType(type)),
+      /* numDims = */ // TODO: check
+      std::max(input.ndim(), padWidths.size()));
 }
 
 /************************** Unary Operators ***************************/
 
 Tensor ArrayFireBackend::exp(const Tensor& tensor) {
-  return toTensor<ArrayFireTensor>(af::exp(toArray(tensor)));
+  return toTensor<ArrayFireTensor>(af::exp(toArray(tensor)), tensor.ndim());
 }
 
 Tensor ArrayFireBackend::log(const Tensor& tensor) {
-  return toTensor<ArrayFireTensor>(af::log(toArray(tensor)));
+  return toTensor<ArrayFireTensor>(af::log(toArray(tensor)), tensor.ndim());
 }
 
 Tensor ArrayFireBackend::negative(const Tensor& tensor) {
-  return toTensor<ArrayFireTensor>(-toArray(tensor));
+  return toTensor<ArrayFireTensor>(-toArray(tensor), tensor.ndim());
 }
 
 Tensor ArrayFireBackend::logicalNot(const Tensor& tensor) {
-  return toTensor<ArrayFireTensor>(!toArray(tensor));
+  return toTensor<ArrayFireTensor>(!toArray(tensor), tensor.ndim());
 }
 
 Tensor ArrayFireBackend::log1p(const Tensor& tensor) {
-  return toTensor<ArrayFireTensor>(af::log1p(toArray(tensor)));
+  return toTensor<ArrayFireTensor>(af::log1p(toArray(tensor)), tensor.ndim());
 }
 
 Tensor ArrayFireBackend::sin(const Tensor& tensor) {
-  return toTensor<ArrayFireTensor>(af::sin(toArray(tensor)));
+  return toTensor<ArrayFireTensor>(af::sin(toArray(tensor)), tensor.ndim());
 }
 
 Tensor ArrayFireBackend::cos(const Tensor& tensor) {
-  return toTensor<ArrayFireTensor>(af::cos(toArray(tensor)));
+  return toTensor<ArrayFireTensor>(af::cos(toArray(tensor)), tensor.ndim());
 }
 
 Tensor ArrayFireBackend::sqrt(const Tensor& tensor) {
-  return toTensor<ArrayFireTensor>(af::sqrt(toArray(tensor)));
+  return toTensor<ArrayFireTensor>(af::sqrt(toArray(tensor)), tensor.ndim());
 }
 
 Tensor ArrayFireBackend::tanh(const Tensor& tensor) {
-  return toTensor<ArrayFireTensor>(af::tanh(toArray(tensor)));
+  return toTensor<ArrayFireTensor>(af::tanh(toArray(tensor)), tensor.ndim());
 }
 
 Tensor ArrayFireBackend::floor(const Tensor& tensor) {
-  return toTensor<ArrayFireTensor>(af::floor(toArray(tensor)));
+  return toTensor<ArrayFireTensor>(af::floor(toArray(tensor)), tensor.ndim());
 }
 
 Tensor ArrayFireBackend::ceil(const Tensor& tensor) {
-  return toTensor<ArrayFireTensor>(af::ceil(toArray(tensor)));
+  return toTensor<ArrayFireTensor>(af::ceil(toArray(tensor)), tensor.ndim());
 }
 
 Tensor ArrayFireBackend::absolute(const Tensor& tensor) {
-  return toTensor<ArrayFireTensor>(af::abs(toArray(tensor)));
+  return toTensor<ArrayFireTensor>(af::abs(toArray(tensor)), tensor.ndim());
 }
 
 Tensor ArrayFireBackend::sigmoid(const Tensor& tensor) {
-  return toTensor<ArrayFireTensor>(af::sigmoid(toArray(tensor)));
+  return toTensor<ArrayFireTensor>(af::sigmoid(toArray(tensor)), tensor.ndim());
 }
 
 Tensor ArrayFireBackend::erf(const Tensor& tensor) {
-  return toTensor<ArrayFireTensor>(af::erf(toArray(tensor)));
+  return toTensor<ArrayFireTensor>(af::erf(toArray(tensor)), tensor.ndim());
 }
 
 Tensor ArrayFireBackend::clip(
@@ -282,31 +322,31 @@ Tensor ArrayFireBackend::clip(
     const Tensor& low,
     const Tensor& high) {
   return toTensor<ArrayFireTensor>(
-      af::clamp(toArray(tensor), toArray(low), toArray(high)));
+      af::clamp(toArray(tensor), toArray(low), toArray(high)), tensor.ndim());
 }
 
 Tensor ArrayFireBackend::isnan(const Tensor& tensor) {
-  return toTensor<ArrayFireTensor>(af::isNaN(toArray(tensor)));
+  return toTensor<ArrayFireTensor>(af::isNaN(toArray(tensor)), tensor.ndim());
 }
 
 Tensor ArrayFireBackend::isinf(const Tensor& tensor) {
-  return toTensor<ArrayFireTensor>(af::isInf(toArray(tensor)));
+  return toTensor<ArrayFireTensor>(af::isInf(toArray(tensor)), tensor.ndim());
 }
 
 Tensor ArrayFireBackend::sign(const Tensor& tensor) {
   auto wSigned = 1 - 2 * af::sign(toArray(tensor));
   wSigned(toArray(tensor) == 0) = 0;
-  return toTensor<ArrayFireTensor>(std::move(wSigned));
+  return toTensor<ArrayFireTensor>(std::move(wSigned), tensor.ndim());
 }
 
 Tensor ArrayFireBackend::tril(const Tensor& tensor) {
   return toTensor<ArrayFireTensor>(
-      af::lower(toArray(tensor), /* is_unit_diag = */ false));
+      af::lower(toArray(tensor), /* is_unit_diag = */ false), tensor.ndim());
 }
 
 Tensor ArrayFireBackend::triu(const Tensor& tensor) {
   return toTensor<ArrayFireTensor>(
-      af::upper(toArray(tensor), /* is_unit_diag = */ false));
+      af::upper(toArray(tensor), /* is_unit_diag = */ false), tensor.ndim());
 }
 
 Tensor ArrayFireBackend::where(
@@ -321,12 +361,12 @@ Tensor ArrayFireBackend::where(
 /************************** Binary Operators ***************************/
 // For ArrayFire, af::array already implements overloads for all needed
 // operators -- use these by default.
-#define FL_AF_BINARY_OP_TYPE_DEF(FUNC, OP, TYPE)             \
-  Tensor ArrayFireBackend::FUNC(const Tensor& a, TYPE rhs) { \
-    return toTensor<ArrayFireTensor>(toArray(a) OP rhs);     \
-  }                                                          \
-  Tensor ArrayFireBackend::FUNC(TYPE lhs, const Tensor& a) { \
-    return toTensor<ArrayFireTensor>(lhs OP toArray(a));     \
+#define FL_AF_BINARY_OP_TYPE_DEF(FUNC, OP, TYPE)                   \
+  Tensor ArrayFireBackend::FUNC(const Tensor& a, TYPE rhs) {       \
+    return toTensor<ArrayFireTensor>(toArray(a) OP rhs, a.ndim()); \
+  }                                                                \
+  Tensor ArrayFireBackend::FUNC(TYPE lhs, const Tensor& a) {       \
+    return toTensor<ArrayFireTensor>(lhs OP toArray(a), a.ndim()); \
   }
 
 #define FL_AF_BINARY_OP_LITERALS_DEF(FUNC, OP)                   \
@@ -346,10 +386,17 @@ Tensor ArrayFireBackend::where(
 
 // Operations on fl::Tensor call the respective operator overloads that are
 // already defined on af::arrays
-#define FL_AF_BINARY_OP_DEF(OP, FUNC)                                   \
-  Tensor ArrayFireBackend::FUNC(const Tensor& lhs, const Tensor& rhs) { \
-    return toTensor<ArrayFireTensor>(toArray(lhs) OP toArray(rhs));     \
-  }                                                                     \
+#define FL_AF_BINARY_OP_DEF(OP, FUNC)                                          \
+  Tensor ArrayFireBackend::FUNC(const Tensor& lhs, const Tensor& rhs) {        \
+    if (lhs.ndim() != rhs.ndim()) {                                            \
+      throw std::invalid_argument(                                             \
+          "ArrayFireTensor arguments to operator " + std::string(#OP) + " (" + \
+          std::string(#FUNC) + ") " +                                          \
+          "have a differing number of dimensions.");                           \
+    }                                                                          \
+    return toTensor<ArrayFireTensor>(                                          \
+        toArray(lhs) OP toArray(rhs), lhs.ndim());                             \
+  }                                                                            \
   FL_AF_BINARY_OP_LITERALS_DEF(FUNC, OP);
 
 // Definitions
@@ -378,29 +425,34 @@ FL_AF_BINARY_OP_DEF(>>, rShift);
 #undef FL_AF_BINARY_OP_LITERALS_DEF
 
 Tensor ArrayFireBackend::minimum(const Tensor& lhs, const Tensor& rhs) {
-  return toTensor<ArrayFireTensor>(af::min(toArray(lhs), toArray(rhs)));
+  return toTensor<ArrayFireTensor>(
+      af::min(toArray(lhs), toArray(rhs)), lhs.ndim());
 }
 
 Tensor ArrayFireBackend::maximum(const Tensor& lhs, const Tensor& rhs) {
-  return toTensor<ArrayFireTensor>(af::max(toArray(lhs), toArray(rhs)));
+  return toTensor<ArrayFireTensor>(
+      af::max(toArray(lhs), toArray(rhs)), lhs.ndim());
 }
 
 Tensor ArrayFireBackend::power(const Tensor& lhs, const Tensor& rhs) {
-  return toTensor<ArrayFireTensor>(af::pow(toArray(lhs), toArray(rhs)));
+  return toTensor<ArrayFireTensor>(
+      af::pow(toArray(lhs), toArray(rhs)), lhs.ndim());
 }
 
-/************************** Matrix Multiply ***************************/
+/************************** BLAS ***************************/
 
 Tensor ArrayFireBackend::matmul(
     const Tensor& lhs,
     const Tensor& rhs,
     MatrixProperty lhsProp,
     MatrixProperty rhsProp) {
-  return toTensor<ArrayFireTensor>(af::matmul(
-      toArray(lhs),
-      toArray(rhs),
-      detail::flToAfMatrixProperty(lhsProp),
-      detail::flToAfMatrixProperty(rhsProp)));
+  return toTensor<ArrayFireTensor>(
+      af::matmul(
+          toArray(lhs),
+          toArray(rhs),
+          detail::flToAfMatrixProperty(lhsProp),
+          detail::flToAfMatrixProperty(rhsProp)),
+      /* numDims = */ std::max(lhs.ndim(), rhs.ndim()));
 }
 
 /************************** Reductions ***************************/
@@ -410,7 +462,8 @@ Tensor ArrayFireBackend::amin(
     const std::vector<int>& axes,
     bool keepDims) {
   return toTensor<ArrayFireTensor>(
-      afReduceAxes(toArray(input), axes, af::min, keepDims));
+      afReduceAxes(toArray(input), axes, af::min, keepDims),
+      getReducedNumDims(input.ndim(), axes.size(), keepDims));
 }
 
 // TODO: consolidate with above
@@ -423,7 +476,8 @@ Tensor ArrayFireBackend::amax(
     const std::vector<int>& axes,
     bool keepDims) {
   return toTensor<ArrayFireTensor>(
-      afReduceAxes(toArray(input), axes, af::max, keepDims));
+      afReduceAxes(toArray(input), axes, af::max, keepDims),
+      getReducedNumDims(input.ndim(), axes.size(), keepDims));
 }
 
 // TODO: consolidate with above
@@ -436,7 +490,8 @@ Tensor ArrayFireBackend::sum(
     const std::vector<int>& axes,
     bool keepDims) {
   return toTensor<ArrayFireTensor>(
-      afReduceAxes(toArray(input), axes, af::sum, keepDims));
+      afReduceAxes(toArray(input), axes, af::sum, keepDims),
+      getReducedNumDims(input.ndim(), axes.size(), keepDims));
 }
 
 // TODO: consolidate with above
@@ -450,7 +505,8 @@ Tensor ArrayFireBackend::mean(
     bool keepDims) {
   return toTensor<ArrayFireTensor>(
       afReduceAxes<af::array(const af::array&, const dim_t)>(
-          toArray(input), axes, af::mean, keepDims));
+          toArray(input), axes, af::mean, keepDims),
+      getReducedNumDims(input.ndim(), axes.size(), keepDims));
 }
 
 // TODO: consolidate with above
@@ -464,7 +520,8 @@ Tensor ArrayFireBackend::median(
     bool keepDims) {
   return toTensor<ArrayFireTensor>(
       afReduceAxes<af::array(const af::array&, const dim_t)>(
-          toArray(input), axes, af::median, keepDims));
+          toArray(input), axes, af::median, keepDims),
+      getReducedNumDims(input.ndim(), axes.size(), keepDims));
 }
 
 // TODO: consolidate with above
@@ -477,13 +534,17 @@ Tensor ArrayFireBackend::var(
     const std::vector<int>& axes,
     const bool bias,
     bool keepDims) {
-  // Use arrayfire default for one dimension which may be optimized
+  // Use ArrayFire default for one dimension which may be optimized
   auto& arr = toArray(input);
   if (axes.size() == 1) {
-    return toTensor<ArrayFireTensor>(detail::condenseIndices(
-        af::var(
-            arr, bias ? AF_VARIANCE_SAMPLE : AF_VARIANCE_POPULATION, axes[0]),
-        keepDims));
+    return toTensor<ArrayFireTensor>(
+        detail::condenseIndices(
+            af::var(
+                arr,
+                bias ? AF_VARIANCE_SAMPLE : AF_VARIANCE_POPULATION,
+                axes[0]),
+            keepDims),
+        /* numDims = */ input.ndim() - 1);
   }
   auto meanArr = mean(input, axes, /* keepDims = */ false);
   // TODO Replace when we have batchFunc for fl::Tensor
@@ -501,7 +562,9 @@ Tensor ArrayFireBackend::var(
   }
 
   x = x / denominator;
-  return toTensor<ArrayFireTensor>(detail::condenseIndices(x, keepDims));
+  return toTensor<ArrayFireTensor>(
+      detail::condenseIndices(x, keepDims),
+      getReducedNumDims(input.ndim(), axes.size(), keepDims));
 }
 
 // TODO: consolidate with above
@@ -515,7 +578,9 @@ Tensor ArrayFireBackend::std(
     bool keepDims) {
   if (axes.size() == 1) {
     // Use arrayfire default for one dimension which may be optimized
-    return toTensor<ArrayFireTensor>(af::stdev(toArray(input), axes[0]));
+    // TODO: update this? stddev is deprecated.
+    return toTensor<ArrayFireTensor>(
+        af::stdev(toArray(input), axes[0]), /* numDims = */ input.ndim() - 1);
   }
   return this->sqrt(this->var(input, axes, /* bias = */ false, keepDims));
 }
@@ -529,19 +594,24 @@ Tensor ArrayFireBackend::countNonzero(
     const std::vector<int>& axes,
     bool keepDims) {
   auto& arr = toArray(input);
+  unsigned numDims;
   af::array out;
   if (axes.size() == 0) {
     out = af::sum(af::count(arr));
+    numDims = 1;
   } else if (axes.size() == 1) {
     out = af::count(arr, axes.front());
+    numDims = getReducedNumDims(input.ndim(), axes.size(), keepDims);
   } else {
     out = afReduceAxes(
         af::count(arr, axes.front()),
         std::vector<int>(axes.begin() + 1, axes.end()),
         af::sum,
         keepDims);
+    numDims = getReducedNumDims(input.ndim(), axes.size(), keepDims);
   }
-  return toTensor<ArrayFireTensor>(detail::condenseIndices(out, keepDims));
+  return toTensor<ArrayFireTensor>(
+      detail::condenseIndices(out, keepDims), numDims);
 }
 
 Tensor ArrayFireBackend::any(
@@ -549,7 +619,8 @@ Tensor ArrayFireBackend::any(
     const std::vector<int>& axes,
     bool keepDims) {
   return toTensor<ArrayFireTensor>(
-      afReduceAxes(toArray(input), axes, af::anyTrue, keepDims));
+      afReduceAxes(toArray(input), axes, af::anyTrue, keepDims),
+      getReducedNumDims(input.ndim(), axes.size(), keepDims));
 }
 
 bool ArrayFireBackend::any(const Tensor& input) {
@@ -561,7 +632,8 @@ Tensor ArrayFireBackend::all(
     const std::vector<int>& axes,
     bool keepDims) {
   return toTensor<ArrayFireTensor>(
-      afReduceAxes(toArray(input), axes, af::allTrue, keepDims));
+      afReduceAxes(toArray(input), axes, af::allTrue, keepDims),
+      getReducedNumDims(input.ndim(), axes.size(), keepDims));
 }
 
 bool ArrayFireBackend::all(const Tensor& input) {

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
@@ -109,6 +109,17 @@ class ArrayFireBackend : public TensorBackend {
   Tensor triu(const Tensor& tensor) override;
   Tensor where(const Tensor& condition, const Tensor& x, const Tensor& y)
       override;
+  void topk(
+      Tensor& values,
+      Tensor& indices,
+      const Tensor& input,
+      const unsigned k,
+      const Dim axis,
+      const SortMode sortMode) override;
+  Tensor sort(const Tensor& input, const Dim axis, const SortMode sortMode)
+      override;
+  Tensor argsort(const Tensor& input, const Dim axis, const SortMode sortMode)
+      override;
 
   /************************** Binary Operators ***************************/
 #define FL_AF_BINARY_OP_TYPE_DECL(FUNC, TYPE)      \

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
@@ -262,6 +262,18 @@ Tensor ArrayFireTensor::flatten() const {
   return toTensor<ArrayFireTensor>(af::flat(getHandle()), /* numDims = */ 1);
 }
 
+Tensor ArrayFireTensor::asContiguousTensor() {
+  if (isContiguous()) {
+    af::array other = getHandle();
+    return toTensor<ArrayFireTensor>(std::move(other), numDims());
+  }
+
+  const af::array& array = getHandle();
+  auto linearArray = af::array(array.dims(), array.type());
+  af::copy(linearArray, array, af::span);
+  return toTensor<ArrayFireTensor>(std::move(linearArray), numDims());
+}
+
 void ArrayFireTensor::setContext(void* context) {} // noop
 
 void* ArrayFireTensor::getContext() {

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
@@ -180,6 +180,7 @@ class ArrayFireTensor : public TensorAdapterBase {
   Tensor astype(const dtype type) override;
   Tensor index(const std::vector<Index>& indices) override;
   Tensor flatten() const override;
+  Tensor asContiguousTensor() override;
   void setContext(void* context) override; // noop
   void* getContext() override; // noop
 

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
@@ -145,6 +145,14 @@ class ArrayFireTensor : public TensorAdapterBase {
       void* ptr,
       Location memoryLocation);
 
+  ArrayFireTensor(
+      const Dim nRows,
+      const Dim nCols,
+      const Tensor& values,
+      const Tensor& rowIdx,
+      const Tensor& colIdx,
+      StorageType storageType);
+
   /**
    * Gets an ArrayFire Array from this impl.
    *
@@ -170,6 +178,8 @@ class ArrayFireTensor : public TensorAdapterBase {
   Tensor shallowCopy() override;
   const Shape& shape() override;
   dtype type() override;
+  bool isSparse() override;
+  af::dtype afHandleType(); // for internal use only
   Location location() override;
   void scalar(void* out) override;
   void device(void** out) override;

--- a/flashlight/fl/tensor/backend/af/Utils.cpp
+++ b/flashlight/fl/tensor/backend/af/Utils.cpp
@@ -62,6 +62,23 @@ af_mat_prop flToAfMatrixProperty(MatrixProperty property) {
   }
 }
 
+af_storage flToAfStorageType(StorageType storageType) {
+  switch (storageType) {
+    case StorageType::Dense:
+      return AF_STORAGE_DENSE;
+    case StorageType::CSR:
+      return AF_STORAGE_CSR;
+    case StorageType::CSC:
+      return AF_STORAGE_CSC;
+    case StorageType::COO:
+      return AF_STORAGE_COO;
+    default:
+      throw std::invalid_argument(
+          "flToAfStorageType: Flashlight storage type "
+          "doesn't have an ArrayFire analog");
+  }
+}
+
 af::dim4 flToAfDims(const Shape& shape) {
   if (shape.ndim() > 4) {
     throw std::invalid_argument(

--- a/flashlight/fl/tensor/backend/af/Utils.cpp
+++ b/flashlight/fl/tensor/backend/af/Utils.cpp
@@ -79,6 +79,18 @@ af_storage flToAfStorageType(StorageType storageType) {
   }
 }
 
+af_topk_function flToAfSortMode(SortMode sortMode) {
+  switch (sortMode) {
+    case SortMode::Descending:
+      return AF_TOPK_MAX;
+    case SortMode::Ascending:
+      return AF_TOPK_MIN;
+    default:
+      throw std::invalid_argument(
+          "flToAfSortMode: sort mode with no ArrayFire analog specified");
+  }
+}
+
 af::dim4 flToAfDims(const Shape& shape) {
   if (shape.ndim() > 4) {
     throw std::invalid_argument(
@@ -138,7 +150,7 @@ af::index flToAfIndex(const fl::Index& idx) {
     case IndexType::Range:
       return af::index(flRangeToAfSeq(idx.get<range>()));
     case IndexType::Literal:
-      return af::index(idx.get<int>());
+      return af::index(idx.get<Dim>());
     default:
       throw std::invalid_argument(
           "flToAfIndex: fl::Index has unknown or invalid type.");

--- a/flashlight/fl/tensor/backend/af/Utils.h
+++ b/flashlight/fl/tensor/backend/af/Utils.h
@@ -37,6 +37,11 @@ fl::dtype afToFlType(af::dtype type);
 af_mat_prop flToAfMatrixProperty(MatrixProperty property);
 
 /**
+ * Convert a Flashlight tensor storage type into an ArrayFire storage type.
+ */
+af_storage flToAfStorageType(StorageType storageType);
+
+/**
  * Convert an fl::Shape into an ArrayFire af::dim4
  */
 af::dim4 flToAfDims(const Shape& shape);

--- a/flashlight/fl/tensor/backend/af/Utils.h
+++ b/flashlight/fl/tensor/backend/af/Utils.h
@@ -42,6 +42,11 @@ af_mat_prop flToAfMatrixProperty(MatrixProperty property);
 af_storage flToAfStorageType(StorageType storageType);
 
 /**
+ * Convert a Flashlight tensor sort mode into an ArrayFire topk sort mode.
+ */
+af_topk_function flToAfSortMode(SortMode sortMode);
+
+/**
  * Convert an fl::Shape into an ArrayFire af::dim4
  */
 af::dim4 flToAfDims(const Shape& shape);

--- a/flashlight/fl/tensor/backend/af/Utils.h
+++ b/flashlight/fl/tensor/backend/af/Utils.h
@@ -11,15 +11,14 @@
 #include <af/index.h>
 #include <af/seq.h>
 
+#include <vector>
+
+#include "flashlight/fl/tensor/Index.h"
 #include "flashlight/fl/tensor/Shape.h"
 #include "flashlight/fl/tensor/TensorBase.h"
 #include "flashlight/fl/tensor/Types.h"
 
 namespace fl {
-
-class Index; // see Index.h
-class range; // see Index.h
-
 namespace detail {
 
 /**
@@ -45,12 +44,12 @@ af::dim4 flToAfDims(const Shape& shape);
 /**
  * Convert an ArrayFire af::dim4 into an fl::Shape
  */
-Shape afToFlDims(const af::dim4& d);
+Shape afToFlDims(const af::dim4& d, const unsigned numDims);
 
 /**
  * Convert an ArrayFire af::dim4 into an fl::Shape, in-place
  */
-void afToFlDims(const af::dim4& d, Shape& s);
+void afToFlDims(const af::dim4& d, const unsigned numDims, Shape& s);
 
 /**
  * Convert an fl::range into an af::seq.
@@ -61,6 +60,8 @@ af::seq flRangeToAfSeq(const fl::range& range);
  * Convert an fl::Index into an af::index.
  */
 af::index flToAfIndex(const fl::Index& idx);
+
+std::vector<af::index> flToAfIndices(const std::vector<fl::Index>& flIndices);
 
 /**
  * Strip leading 1 indices from an ArrayFire dim4.
@@ -76,7 +77,10 @@ af::dim4 condenseDims(const af::dim4& dims);
  *
  * If keepDims is true, this is a noop, and the array is returned as is.
  */
-af::array condenseIndices(const af::array& arr, bool keepDims = false);
+af::array condenseIndices(
+    const af::array& arr,
+    bool keepDims = false,
+    const std::optional<std::vector<detail::IndexType>>& indexTypes = {});
 
 /**
  * Convert a Flashlight Location into an ArrayFire location (host or device).

--- a/flashlight/fl/test/tensor/IndexTest.cpp
+++ b/flashlight/fl/test/tensor/IndexTest.cpp
@@ -40,7 +40,7 @@ TEST(IndexTest, Type) {
   using namespace detail;
   ASSERT_EQ(fl::Index(3).type(), IndexType::Literal);
   ASSERT_EQ(fl::Index(fl::range(3)).type(), IndexType::Range);
-  ASSERT_EQ(fl::Index(fl::span).type(), IndexType::Range);
+  ASSERT_EQ(fl::Index(fl::span).type(), IndexType::Span);
   ASSERT_EQ(fl::Index(fl::full({2, 2}, 4)).type(), IndexType::Tensor);
   ASSERT_TRUE(fl::Index(fl::span).isSpan());
 }
@@ -59,13 +59,17 @@ TEST(IndexTest, Shape) {
   ASSERT_EQ(t(2, fl::span).shape(), Shape({4}));
   ASSERT_EQ(t(2).shape(), Shape({4}));
   ASSERT_EQ(t(fl::range(3)).shape(), Shape({3, 4}));
-  ASSERT_EQ(t(fl::range(1, 2)).shape(), Shape({4}));
-  ASSERT_EQ(t(fl::range(1, 2), fl::range(1, 2)).shape(), Shape({1}));
+  ASSERT_EQ(t(fl::range(1, 2)).shape(), Shape({1, 4}));
+  ASSERT_EQ(t(fl::range(1, 2), fl::range(1, 2)).shape(), Shape({1, 1}));
   ASSERT_EQ(t(fl::range(0, fl::end)).shape(), Shape({4, 4}));
   ASSERT_EQ(t(fl::range(0, fl::end, 2)).shape(), Shape({2, 4}));
 
   auto t2 = fl::full({5, 6, 7, 8}, 3.);
   ASSERT_EQ(t2(2, fl::range(2, 4), fl::span, 3).shape(), Shape({2, 7}));
+  ASSERT_EQ(t2(fl::span, 3, fl::span, fl::span).shape(), Shape({5, 7, 8}));
+  ASSERT_EQ(
+      t2(fl::span, fl::range(1, 2), fl::span, fl::span).shape(),
+      Shape({5, 1, 7, 8}));
 }
 
 TEST(IndexTest, IndexAssignment) {
@@ -94,6 +98,56 @@ TEST(IndexTest, IndexAssignment) {
   q(0) = r;
   ASSERT_TRUE(allClose(q(0), r));
   ASSERT_TRUE(allClose(q(fl::range(1, fl::end)), fl::full({3, 4}, 2.)));
+
+  auto k = fl::rand({100, 200});
+  k(3) = fl::full({200}, 0.);
+  ASSERT_TRUE(allClose(k(3), fl::full({200}, 0.)));
+
+  // Weak ref
+  auto g = fl::rand({3, 4, 5});
+  auto gC = g.copy();
+  auto gI = g(fl::span, fl::range(0, 3));
+  g(fl::span, fl::range(0, 3)) += 3;
+  gI -= 3;
+  ASSERT_TRUE(allClose(gC(fl::span, fl::range(0, 3)), gI));
+
+  auto x = fl::rand({5, 6, 7, 8});
+  x(3) = fl::full({6, 7, 8}, 0.);
+  ASSERT_TRUE(allClose(x(3), fl::full({6, 7, 8}, 0.)));
+  x(fl::span, fl::span, 2) = fl::full({5, 6, 8}, 3.);
+  ASSERT_TRUE(allClose(x(fl::span, fl::span, 2), fl::full({5, 6, 8}, 3.)));
+  ASSERT_THROW(
+      x(fl::span, fl::span, 4) -= fl::rand({5, 6, 1, 8}),
+      std::invalid_argument);
+
+  x(fl::span, fl::range(1, 3), fl::span) = fl::full({5, 2, 7, 8}, 2.);
+  ASSERT_TRUE(allClose(
+      x(fl::span, fl::range(1, 3), fl::span), fl::full({5, 2, 7, 8}, 2.)));
+
+  x(fl::span, fl::arange({5}), fl::span, fl::arange({5})) =
+      fl::full({5, 5, 7, 5}, 2.);
+  ASSERT_TRUE(allClose(
+      x(fl::span, fl::range(1, 3), fl::span), fl::full({5, 2, 7, 8}, 2.)));
+}
+
+TEST(IndexTest, IndexInPlaceOps) {
+  auto a = fl::full({4, 5, 6}, 0.);
+  auto b = fl::full({5, 6}, 1.);
+  a(2) += b;
+  ASSERT_TRUE(allClose(a(2), b));
+  a(2) -= b;
+  ASSERT_TRUE(allClose(a, fl::full({4, 5, 6}, 0.)));
+
+  auto f = fl::full({1, 3, 3}, 4.);
+  auto d = fl::full({3}, 6.);
+  f({0, 1}) += d;
+  ASSERT_TRUE(allClose(f({0, 1}), d + 4.));
+
+  // Integral type
+  auto s = fl::full({4, 5, 6}, 5, fl::dtype::s32);
+  auto sA = fl::full({6}, 3, fl::dtype::s32);
+  s(0, 1) += sA;
+  ASSERT_TRUE(allClose(s(0, 1), sA + 5));
 }
 
 TEST(IndexTest, TensorIndex) {
@@ -111,9 +165,23 @@ TEST(IndexTest, TensorIndex) {
 
   a(indices) = 5.;
   ASSERT_TRUE(allClose(a(indices), fl::full({size}, 5.)));
+
+  // Out of range indices
+  auto i = fl::arange({10}, 0, fl::dtype::u32);
+  auto b = fl::rand({20, 20});
+  auto ref = b;
+  ASSERT_TRUE(allClose(b(i), b(fl::range(10), 0)));
+
+  b(i) += 3.;
+  ASSERT_TRUE(allClose(b(i), b(fl::range(10), 0)));
+  ASSERT_TRUE(allClose(b(i), (ref + 3)(i)));
+  b(i) += fl::full({(Dim)i.size()}, 10.);
+  ASSERT_TRUE(allClose(b(i), (ref + 13)(i)));
 }
 
 TEST(IndexTest, ExpressionIndex) {
   auto a = Tensor::fromVector<int>({2, 5}, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
   ASSERT_TRUE(allClose(a(a < 5), Tensor::fromVector<int>({0, 1, 2, 3, 4})));
+  ASSERT_TRUE(
+      allClose(a(a < 7), Tensor::fromVector<int>({0, 1, 2, 3, 4, 5, 6})));
 }

--- a/flashlight/fl/test/tensor/ShapeTest.cpp
+++ b/flashlight/fl/test/tensor/ShapeTest.cpp
@@ -12,9 +12,6 @@
 
 #include "flashlight/fl/tensor/Shape.h"
 
-// TODO: move me to an independent AF test suite
-#include "flashlight/fl/tensor/backend/af/Utils.h"
-
 using namespace ::testing;
 using namespace fl;
 
@@ -62,20 +59,4 @@ TEST(ShapeTest, Equality) {
   ASSERT_NE(Shape({5, 2, 3}), Shape({5, 2, 3, 1}));
   ASSERT_EQ(Shape({5, 2, 3, 1}), Shape({5, 2, 3, 1}));
   ASSERT_NE(Shape({5, 2, 1, 1}), Shape({5, 2, 1, 4}));
-}
-
-// TODO: move me to an independent AF test suite
-TEST(ShapeTest, ArrayFireInterop) {
-  auto dimsEq = [](const af::dim4& d, const Shape& s) {
-    return detail::afToFlDims(d) == s;
-  };
-
-  ASSERT_TRUE(dimsEq(af::dim4(), {}));
-  ASSERT_TRUE(dimsEq(af::dim4(3), {3})); // not 3, 1, 1, 1
-  ASSERT_TRUE(dimsEq(af::dim4(3, 2), {3, 2})); // not 3, 2, 1, 1
-  ASSERT_TRUE(dimsEq(af::dim4(3, 1), {3})); // 1 is indistinguishable in AF
-  ASSERT_TRUE(dimsEq(af::dim4(1, 3, 2), {1, 3, 2}));
-  ASSERT_TRUE(dimsEq(af::dim4(1), {1}));
-  ASSERT_TRUE(dimsEq(af::dim4(1, 1, 1), {1}));
-  ASSERT_TRUE(dimsEq(af::dim4(0, 1, 1, 1), {}));
 }

--- a/flashlight/fl/test/tensor/TensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/TensorBaseTest.cpp
@@ -418,6 +418,24 @@ TEST(TensorBaseTest, strides) {
   ASSERT_EQ(t.strides(), Shape({1, 10}));
 }
 
+TEST(TensorBaseTest, asContiguousTensor) {
+  auto t = fl::rand({5, 6, 7, 8});
+  auto indexed =
+      t(fl::range(1, 4, 2),
+        fl::range(0, 6, 2),
+        fl::range(0, 6, 3),
+        fl::range(0, 5, 3));
+
+  auto contiguous = indexed.asContiguousTensor();
+  std::vector<Dim> strides;
+  unsigned stride = 1;
+  for (unsigned i = 0; i < contiguous.ndim(); ++i) {
+    strides.push_back(stride);
+    stride *= contiguous.dim(i);
+  }
+  ASSERT_EQ(contiguous.strides(), Shape(strides));
+}
+
 TEST(TensorBaseTest, host) {
   auto a = fl::rand({10, 10});
 

--- a/flashlight/fl/test/tensor/TensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/TensorBaseTest.cpp
@@ -46,6 +46,7 @@ TEST(TensorBaseTest, Metadata) {
 
   Tensor e;
   ASSERT_TRUE(e.isEmpty());
+  ASSERT_FALSE(e.isSparse());
 }
 
 TEST(TensorBaseTest, BinaryOperators) {


### PR DESCRIPTION
Summary:
Add topk, [`sort`](https://numpy.org/doc/stable/reference/generated/numpy.sort.html) and [`argsort`](https://numpy.org/doc/stable/reference/generated/numpy.sort.html).

Also change the type of Index integer literals to be a `Dim` (`long long`) so as to support using `unsigned`/most integral types without type narrowing issues.

Differential Revision: D30182922

