### PR TITLE
Add Tensor::flat for 1D indexing

### DIFF
--- a/flashlight/fl/tensor/TensorAdapter.h
+++ b/flashlight/fl/tensor/TensorAdapter.h
@@ -180,6 +180,14 @@ class TensorAdapterBase {
   virtual Tensor flatten() const = 0;
 
   /**
+   * Returns a tensor indexed from this tensor but indexed as a 1D/flattened
+   * tensor.
+   *
+   * @return a 1D version of this tensor 1D-indexed with the given index.
+   */
+  virtual Tensor flat(const Index& idx) const = 0;
+
+  /**
    * Returns a copy of the tensor that is contiguous in memory.
    */
   virtual Tensor asContiguousTensor() = 0;

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -117,6 +117,10 @@ Tensor Tensor::flatten() const {
   return impl_->flatten();
 }
 
+Tensor Tensor::flat(const Index& idx) const {
+  return impl_->flat(idx);
+}
+
 Tensor Tensor::asContiguousTensor() const {
   return impl_->asContiguousTensor();
 }

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -297,9 +297,17 @@ class Tensor {
   /**
    * Returns a representation of the tensor in 1 dimension.
    *
-   * @return a 1D version of this tensor
+   * @return a 1D version of this tensor 1D-indexed with the given index.
    */
   Tensor flatten() const;
+
+  /**
+   * Returns a tensor indexed from this tensor but indexed as a 1D/flattened
+   * tensor.
+   *
+   * @return an indexed, 1D version of this tensor.
+   */
+  Tensor flat(const Index& idx) const;
 
   /**
    * Return a copy (depending on copy-on-write behavior of the underlying

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
@@ -289,6 +289,18 @@ Tensor ArrayFireTensor::flatten() const {
   return toTensor<ArrayFireTensor>(af::flat(getHandle()), /* numDims = */ 1);
 }
 
+Tensor ArrayFireTensor::flat(const Index& idx) const {
+  getHandle(); // if this tensor was a view, run indexing and promote
+  // Return a lazy indexing operation. Indexing with a single index on an
+  // ArrayFire tensor (with a type that is not an af::array) ends up doing
+  // flat indexing, so all index assignment operators will work as they are.
+  return fl::Tensor(std::unique_ptr<ArrayFireTensor>(new ArrayFireTensor(
+      arrayHandle_,
+      {detail::flToAfIndex(idx)},
+      {idx.type()},
+      /* numDims = */ 1)));
+}
+
 Tensor ArrayFireTensor::asContiguousTensor() {
   if (isContiguous()) {
     af::array other = getHandle();

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
@@ -190,6 +190,7 @@ class ArrayFireTensor : public TensorAdapterBase {
   Tensor astype(const dtype type) override;
   Tensor index(const std::vector<Index>& indices) override;
   Tensor flatten() const override;
+  Tensor flat(const Index& idx) const override;
   Tensor asContiguousTensor() override;
   void setContext(void* context) override; // noop
   void* getContext() override; // noop


### PR DESCRIPTION
Summary:
Mirror numpy's [flat](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.flat.html) — return a 1D iterator on a tensor.

The ArrayFire implementation supports in-place operations via lvalue `af::array::array_proxy` objects as before.

Differential Revision: D30453772

