### PR TITLE
Tensor ostream operator<<

### DIFF
--- a/flashlight/fl/tensor/TensorAdapter.h
+++ b/flashlight/fl/tensor/TensorAdapter.h
@@ -180,6 +180,14 @@ class TensorAdapterBase {
   virtual Tensor flatten() const = 0;
 
   /**
+   * Returns a tensor indexed from this tensor but indexed as a 1D/flattened
+   * tensor.
+   *
+   * @return a 1D version of this tensor 1D-indexed with the given index.
+   */
+  virtual Tensor flat(const Index& idx) const = 0;
+
+  /**
    * Returns a copy of the tensor that is contiguous in memory.
    */
   virtual Tensor asContiguousTensor() = 0;

--- a/flashlight/fl/tensor/TensorAdapter.h
+++ b/flashlight/fl/tensor/TensorAdapter.h
@@ -204,6 +204,11 @@ class TensorAdapterBase {
    */
   virtual void* getContext() = 0;
 
+  /**
+   * Write a string representation of a tensor to an output stream.
+   */
+  virtual std::ostream& operator<<(std::ostream& ostr) = 0;
+
   /******************** Assignment Operators ********************/
 #define ASSIGN_OP_TYPE(OP, TYPE) virtual void OP(const TYPE& val) = 0;
 #define ASSIGN_OP(OP)                 \

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -221,6 +221,10 @@ void* Tensor::getContext() const {
   return impl_->getContext();
 }
 
+std::ostream& Tensor::operator<<(std::ostream& ostr) const {
+  return impl_->operator<<(ostr);
+}
+
 // Generate template specializations for functions that return types
 #define EXPAND_MACRO_FUNCTION_TYPE(FUN, TYPE)             \
   template <>                                             \
@@ -711,6 +715,11 @@ T amax(const Tensor& input) {
 }
 
 /************************** Utilities ***************************/
+
+std::ostream& operator<<(std::ostream& ostr, const Tensor& t) {
+  t.operator<<(ostr);
+  return ostr;
+}
 
 void print(const Tensor& tensor) {
   tensor.backend().print(tensor);

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -117,6 +117,10 @@ Tensor Tensor::flatten() const {
   return impl_->flatten();
 }
 
+Tensor Tensor::flat(const Index& idx) const {
+  return impl_->flat(idx);
+}
+
 Tensor Tensor::asContiguousTensor() const {
   return impl_->asContiguousTensor();
 }

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -426,6 +426,11 @@ class Tensor {
    */
   void* getContext() const;
 
+  /**
+   * Write a string representation of a tensor to an output stream.
+   */
+  std::ostream& operator<<(std::ostream& ostr) const;
+
   /******************** Assignment Operators ********************/
 #define ASSIGN_OP(OP)                    \
   Tensor& OP(const Tensor& val);         \
@@ -1190,6 +1195,11 @@ all(const Tensor& input, const std::vector<int>& axes, bool keepDims = false);
 bool all(const Tensor& input);
 
 /************************** Utilities ***************************/
+
+/**
+ * Write a string representation of a tensor to an output stream.
+ */
+std::ostream& operator<<(std::ostream& ostr, const Tensor& s);
 
 /**
  * Print a string representation of a tensor to standard out.

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -297,9 +297,17 @@ class Tensor {
   /**
    * Returns a representation of the tensor in 1 dimension.
    *
-   * @return a 1D version of this tensor
+   * @return a 1D version of this tensor 1D-indexed with the given index.
    */
   Tensor flatten() const;
+
+  /**
+   * Returns a tensor indexed from this tensor but indexed as a 1D/flattened
+   * tensor.
+   *
+   * @return an indexed, 1D version of this tensor.
+   */
+  Tensor flat(const Index& idx) const;
 
   /**
    * Return a copy (depending on copy-on-write behavior of the underlying

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
@@ -153,7 +153,6 @@ Tensor ArrayFireTensor::copy() {
 
 Tensor ArrayFireTensor::shallowCopy() {
   getHandle(); // if this tensor was a view, run indexing and promote
-
   return Tensor(std::unique_ptr<ArrayFireTensor>(
       new ArrayFireTensor(arrayHandle_, numDims())));
 }
@@ -317,6 +316,11 @@ void ArrayFireTensor::setContext(void* context) {} // noop
 
 void* ArrayFireTensor::getContext() {
   return nullptr; // noop
+}
+
+std::ostream& ArrayFireTensor::operator<<(std::ostream& ostr) {
+  ostr << "ArrayFireTensor " << std::string(af::toString("", getHandle()));
+  return ostr;
 }
 
 /******************** Assignment Operators ********************/

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
@@ -289,6 +289,18 @@ Tensor ArrayFireTensor::flatten() const {
   return toTensor<ArrayFireTensor>(af::flat(getHandle()), /* numDims = */ 1);
 }
 
+Tensor ArrayFireTensor::flat(const Index& idx) const {
+  getHandle(); // if this tensor was a view, run indexing and promote
+  // Return a lazy indexing operation. Indexing with a single index on an
+  // ArrayFire tensor (with a type that is not an af::array) ends up doing
+  // flat indexing, so all index assignment operators will work as they are.
+  return fl::Tensor(std::unique_ptr<ArrayFireTensor>(new ArrayFireTensor(
+      arrayHandle_,
+      {detail::flToAfIndex(idx)},
+      {idx.type()},
+      /* numDims = */ 1)));
+}
+
 Tensor ArrayFireTensor::asContiguousTensor() {
   if (isContiguous()) {
     af::array other = getHandle();

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
@@ -190,6 +190,7 @@ class ArrayFireTensor : public TensorAdapterBase {
   Tensor astype(const dtype type) override;
   Tensor index(const std::vector<Index>& indices) override;
   Tensor flatten() const override;
+  Tensor flat(const Index& idx) const override;
   Tensor asContiguousTensor() override;
   void setContext(void* context) override; // noop
   void* getContext() override; // noop

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
@@ -194,6 +194,7 @@ class ArrayFireTensor : public TensorAdapterBase {
   Tensor asContiguousTensor() override;
   void setContext(void* context) override; // noop
   void* getContext() override; // noop
+  std::ostream& operator<<(std::ostream& ostr) override;
 
   /******************** Assignment Operators ********************/
 #define ASSIGN_OP_TYPE(OP, TYPE) void OP(const TYPE& val) override;

--- a/flashlight/fl/test/tensor/TensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/TensorBaseTest.cpp
@@ -49,6 +49,17 @@ TEST(TensorBaseTest, Metadata) {
   ASSERT_FALSE(e.isSparse());
 }
 
+TEST(TensorBaseTest, ostream) {
+  // Different backends might print tensors differently - check for consistency
+  // across two identical tensors
+  auto a = fl::full({3, 4, 5}, 6.);
+  auto b = fl::full({3, 4, 5}, 6.);
+  std::stringstream ssa, ssb;
+  ssa << a;
+  ssb << b;
+  ASSERT_EQ(ssa.str(), ssb.str());
+}
+
 TEST(TensorBaseTest, BinaryOperators) {
   // TODO:{fl::Tensor}{testing} expand this test/add a million fixtures, etc
   auto a = fl::full({2, 2}, 1);


### PR DESCRIPTION
Summary: Add an ostream `operator<<` that takes a tensor to make it possible to write to arbitrary out streams.

Differential Revision: D30519109

