### PR TITLE
Fix Tensor constant types to be more float-friendly

### DIFF
--- a/flashlight/fl/tensor/TensorAdapter.h
+++ b/flashlight/fl/tensor/TensorAdapter.h
@@ -180,6 +180,14 @@ class TensorAdapterBase {
   virtual Tensor flatten() const = 0;
 
   /**
+   * Returns a tensor indexed from this tensor but indexed as a 1D/flattened
+   * tensor.
+   *
+   * @return a 1D version of this tensor 1D-indexed with the given index.
+   */
+  virtual Tensor flat(const Index& idx) const = 0;
+
+  /**
    * Returns a copy of the tensor that is contiguous in memory.
    */
   virtual Tensor asContiguousTensor() = 0;

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -117,6 +117,10 @@ Tensor Tensor::flatten() const {
   return impl_->flatten();
 }
 
+Tensor Tensor::flat(const Index& idx) const {
+  return impl_->flat(idx);
+}
+
 Tensor Tensor::asContiguousTensor() const {
   return impl_->asContiguousTensor();
 }

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -297,9 +297,17 @@ class Tensor {
   /**
    * Returns a representation of the tensor in 1 dimension.
    *
-   * @return a 1D version of this tensor
+   * @return a 1D version of this tensor 1D-indexed with the given index.
    */
   Tensor flatten() const;
+
+  /**
+   * Returns a tensor indexed from this tensor but indexed as a 1D/flattened
+   * tensor.
+   *
+   * @return an indexed, 1D version of this tensor.
+   */
+  Tensor flat(const Index& idx) const;
 
   /**
    * Return a copy (depending on copy-on-write behavior of the underlying

--- a/flashlight/fl/tensor/Types.h
+++ b/flashlight/fl/tensor/Types.h
@@ -59,10 +59,10 @@ struct dtype_traits;
 
 FL_TYPE_TRAIT(float, dtype::f32, dtype::f32, "float");
 FL_TYPE_TRAIT(double, dtype::f64, dtype::f32, "double");
-FL_TYPE_TRAIT(int, dtype::s32, dtype::s32, "int");
-FL_TYPE_TRAIT(unsigned, dtype::u32, dtype::u32, "unsigned int");
-FL_TYPE_TRAIT(char, dtype::s32, dtype::s32, "char");
-FL_TYPE_TRAIT(unsigned char, dtype::u8, dtype::u32, "unsigned char");
+FL_TYPE_TRAIT(int, dtype::s32, dtype::f32, "int");
+FL_TYPE_TRAIT(unsigned, dtype::u32, dtype::f32, "unsigned int");
+FL_TYPE_TRAIT(char, dtype::s32, dtype::f32, "char");
+FL_TYPE_TRAIT(unsigned char, dtype::u8, dtype::f32, "unsigned char");
 FL_TYPE_TRAIT(long, dtype::s32, dtype::s32, "long int");
 FL_TYPE_TRAIT(unsigned long, dtype::u32, dtype::u32, "unsigned long");
 FL_TYPE_TRAIT(long long, dtype::s64, dtype::s64, "long long");

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
@@ -289,6 +289,18 @@ Tensor ArrayFireTensor::flatten() const {
   return toTensor<ArrayFireTensor>(af::flat(getHandle()), /* numDims = */ 1);
 }
 
+Tensor ArrayFireTensor::flat(const Index& idx) const {
+  getHandle(); // if this tensor was a view, run indexing and promote
+  // Return a lazy indexing operation. Indexing with a single index on an
+  // ArrayFire tensor (with a type that is not an af::array) ends up doing
+  // flat indexing, so all index assignment operators will work as they are.
+  return fl::Tensor(std::unique_ptr<ArrayFireTensor>(new ArrayFireTensor(
+      arrayHandle_,
+      {detail::flToAfIndex(idx)},
+      {idx.type()},
+      /* numDims = */ 1)));
+}
+
 Tensor ArrayFireTensor::asContiguousTensor() {
   if (isContiguous()) {
     af::array other = getHandle();

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
@@ -190,6 +190,7 @@ class ArrayFireTensor : public TensorAdapterBase {
   Tensor astype(const dtype type) override;
   Tensor index(const std::vector<Index>& indices) override;
   Tensor flatten() const override;
+  Tensor flat(const Index& idx) const override;
   Tensor asContiguousTensor() override;
   void setContext(void* context) override; // noop
   void* getContext() override; // noop

--- a/flashlight/fl/test/tensor/IndexTest.cpp
+++ b/flashlight/fl/test/tensor/IndexTest.cpp
@@ -79,7 +79,7 @@ TEST(IndexTest, IndexAssignment) {
   t(fl::span, fl::range(2, fl::end)) += 1;
   t(fl::span, fl::span) *= 7;
   t /= 7;
-  ASSERT_TRUE(allClose(t, fl::full({4, 4}, 1)));
+  ASSERT_TRUE(allClose(t, fl::full({4, 4}, 1, fl::dtype::s32)));
 
   auto a = fl::full({6, 6}, 0.);
   a(3, 4) = 4.;

--- a/flashlight/fl/test/tensor/TensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/TensorBaseTest.cpp
@@ -607,10 +607,11 @@ TEST(TensorBaseTest, all) {
 
 TEST(TensorBaseTest, arange) {
   // Range/step overload
-  ASSERT_TRUE(
-      allClose(fl::arange(2, 10, 2), Tensor::fromVector<int>({2, 4, 6, 8})));
-  ASSERT_TRUE(
-      allClose(fl::arange(0, 6), Tensor::fromVector<int>({0, 1, 2, 3, 4, 5})));
+  ASSERT_TRUE(allClose(
+      fl::arange(2, 10, 2, fl::dtype::s32),
+      Tensor::fromVector<int>({2, 4, 6, 8})));
+  ASSERT_TRUE(allClose(
+      fl::arange(0, 6), Tensor::fromVector<float>({0, 1, 2, 3, 4, 5})));
   ASSERT_TRUE(allClose(
       fl::arange(0., 1.22, 0.25),
       Tensor::fromVector<float>({0., 0.25, 0.5, 0.75})));


### PR DESCRIPTION
Summary: Change Tensor trait ctypes to defer to floats when many integral literal values are provided - `int`, `unsigned`, `char`, and `unsigned char` literals now result in `f32` type tensors.

Differential Revision: D30516047

