### PR TITLE
Various AF + Tensor abstraction changes and fixes

### DIFF
--- a/flashlight/fl/tensor/TensorAdapter.h
+++ b/flashlight/fl/tensor/TensorAdapter.h
@@ -137,7 +137,7 @@ class TensorAdapterBase {
    * Populates a pointer with a pointer value in memory pointing to a host
    * buffer containing tensor data.
    */
-  virtual void host(void** out) = 0;
+  virtual void host(void* out) = 0;
 
   /**
    * Unlocks any device memory associated with the tensor that was acquired with

--- a/flashlight/fl/tensor/TensorBackend.h
+++ b/flashlight/fl/tensor/TensorBackend.h
@@ -75,7 +75,7 @@ class TensorBackend {
   virtual Tensor reshape(const Tensor& tensor, const Shape& shape) = 0;
   virtual Tensor transpose(
       const Tensor& tensor,
-      const Shape& dims /* = {} */) = 0;
+      const Shape& axes /* = {} */) = 0;
   virtual Tensor tile(const Tensor& tensor, const Shape& shape) = 0;
   virtual Tensor concatenate(
       const std::vector<Tensor>& tensors,

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -158,15 +158,13 @@ TensorBackend& Tensor::backend() const {
   template <>                                                               \
   TYPE* Tensor::host() const {                                              \
     TYPE* out = reinterpret_cast<TYPE*>(new char[bytes()]);                 \
-    void** addr = reinterpret_cast<void**>(&out);                           \
-    impl_->host(addr);                                                      \
+    impl_->host(out);                                                       \
     return out;                                                             \
   }                                                                         \
                                                                             \
   template <>                                                               \
   void Tensor::host(TYPE* ptr) const {                                      \
-    void** addr = reinterpret_cast<void**>(&ptr);                           \
-    impl_->host(addr);                                                      \
+    impl_->host(ptr);                                                       \
   }
 FL_CREATE_MEMORY_OPS(int);
 FL_CREATE_MEMORY_OPS(unsigned);
@@ -191,13 +189,13 @@ void* Tensor::device() const {
 template <>
 void* Tensor::host() const {
   void* out = reinterpret_cast<void*>(new char[bytes()]);
-  impl_->host(&out);
+  impl_->host(out);
   return out;
 }
 
 template <>
 void Tensor::host(void* ptr) const {
-  impl_->host(&ptr);
+  impl_->host(ptr);
 }
 #undef FL_CREATE_MEMORY_OPS
 
@@ -350,8 +348,8 @@ Tensor reshape(const Tensor& tensor, const Shape& shape) {
   return tensor.backend().reshape(tensor, shape);
 }
 
-Tensor transpose(const Tensor& tensor, const Shape& dims /* = {} */) {
-  return tensor.backend().transpose(tensor, dims);
+Tensor transpose(const Tensor& tensor, const Shape& axes /* = {} */) {
+  return tensor.backend().transpose(tensor, axes);
 }
 
 Tensor tile(const Tensor& tensor, const Shape& shape) {

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -184,6 +184,21 @@ class Tensor {
   }
 
   /**
+   * Create a tensor from an existing byte buffer given a type.
+   *
+   * @param[in] s the shape of the resulting tensor.
+   * @param[in] t the type of the underlying tensor
+   * @param[in] ptr the buffer of bytes containing the data
+   * @param[in] memoryLocation the location in memory where the input buffer
+   * with which to create the tensor resides.
+   * @return a tensor with values and shape as given.
+   */
+  static Tensor
+  fromBuffer(Shape s, fl::dtype t, uint8_t* ptr, Location memoryLocation) {
+    return Tensor(s, t, ptr, memoryLocation);
+  }
+
+  /**
    * Deep-copies the tensor, including underlying data.
    */
   Tensor copy() const;
@@ -377,7 +392,8 @@ class Tensor {
    * host. If the tensor is located on a device, makes a copy of device memory
    * and returns a buffer on the host containing the relevant memory.
    *
-   * @return the requested pointer on the host.
+   * @param[in] ptr a pointer to the region of memory to populate with tensor
+   * values
    */
   template <typename T>
   void host(T* ptr) const;
@@ -555,11 +571,12 @@ Tensor reshape(const Tensor& tensor, const Shape& shape);
  * a tensor.
  *
  * @param[in] tensor the tensor to transpose
- * @param[in] dims (optional) the permuted indices of the tensor the kth access
- * of the output tensor will correspond to dims[k] in the input tensor
+ * @param[in] axes (optional) the permuted indices of the tensor the kth access
+ * of the output tensor will correspond to dims[k] in the input tensor. If this
+ * argument is not passed, the axes of the input tensor will be reversed.
  * @return the permuted tensor
  */
-Tensor transpose(const Tensor& tensor, const Shape& dims = {});
+Tensor transpose(const Tensor& tensor, const Shape& axes = {});
 
 /**
  * Repeat the contents of a tensor a given number of times along specified

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
@@ -75,7 +75,7 @@ class ArrayFireBackend : public TensorBackend {
 
   /************************ Shaping and Indexing *************************/
   Tensor reshape(const Tensor& tensor, const Shape& shape) override;
-  Tensor transpose(const Tensor& tensor, const Shape& dims /* = {} */) override;
+  Tensor transpose(const Tensor& tensor, const Shape& axes /* = {} */) override;
   Tensor tile(const Tensor& tensor, const Shape& shape) override;
   Tensor concatenate(const std::vector<Tensor>& tensors, unsigned axis)
       override;

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
@@ -206,8 +206,8 @@ void ArrayFireTensor::device(void** out) {
   AF_CHECK(af_get_device_ptr(out, getHandle().get()));
 }
 
-void ArrayFireTensor::host(void** out) {
-  AF_CHECK(af_get_data_ptr(*out, getHandle().get()));
+void ArrayFireTensor::host(void* out) {
+  AF_CHECK(af_get_data_ptr(out, getHandle().get()));
 }
 
 void ArrayFireTensor::unlock() {

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
@@ -183,7 +183,7 @@ class ArrayFireTensor : public TensorAdapterBase {
   Location location() override;
   void scalar(void* out) override;
   void device(void** out) override;
-  void host(void** out) override;
+  void host(void* out) override;
   void unlock() override;
   bool isLocked() override;
   bool isContiguous() override;

--- a/flashlight/fl/test/tensor/ArrayFireTensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/ArrayFireTensorBaseTest.cpp
@@ -43,7 +43,9 @@ bool allClose(
 
 } // namespace
 
-TEST(ShapeTest, ArrayFireInterop) {
+namespace fl {
+
+TEST(ArrayFireTensorBaseTest, ArrayFireShapeInterop) {
   auto dimsEq = [](const af::dim4& d, const Shape& s) {
     return detail::afToFlDims(d, s.ndim()) == s;
   };
@@ -59,6 +61,8 @@ TEST(ShapeTest, ArrayFireInterop) {
   ASSERT_TRUE(dimsEq(af::dim4(1, 1, 1), {1}));
   ASSERT_TRUE(dimsEq(af::dim4(0, 1, 1, 1), {}));
 }
+
+} // namespace fl
 
 TEST(ArrayFireTensorBaseTest, AfRefCountBasic) {
   // Sanity check that af::arrays moved into fl::Tensors don't have their
@@ -326,7 +330,8 @@ TEST(ArrayFireTensorBaseTest, transpose) {
 
   auto b = fl::rand({3, 5, 4, 8});
   ASSERT_TRUE(allClose(
-      toArray(fl::transpose(b, {2, 0, 1})), af::reorder(toArray(b), 2, 0, 1)));
+      toArray(fl::transpose(b, {2, 0, 1, 3})),
+      af::reorder(toArray(b), 2, 0, 1, 3)));
 }
 
 TEST(ArrayFireTensorBaseTest, concatenate) {

--- a/flashlight/fl/test/tensor/TensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/TensorBaseTest.cpp
@@ -153,8 +153,22 @@ TEST(TensorBaseTest, transpose) {
   ASSERT_TRUE(
       allClose(fl::transpose(fl::full({3, 4}, 3.)), fl::full({4, 3}, 3.)));
   ASSERT_TRUE(allClose(
-      fl::transpose(fl::full({4, 5, 6, 7}, 3.), {2, 0, 1}),
+      fl::transpose(fl::full({4, 5, 6, 7}, 3.), {2, 0, 1, 3}),
       fl::full({6, 4, 5, 7}, 3.)));
+  ASSERT_THROW(fl::transpose(fl::rand({3, 4, 5}), {0, 1}), std::exception);
+  ASSERT_THROW(
+      fl::transpose(fl::rand({2, 4, 6, 8}), {1, 0, 2}), std::exception);
+  ASSERT_THROW(
+      fl::transpose(fl::rand({2, 4, 6, 8}), {1, 0, 2, 4}), std::exception);
+
+  auto a = fl::rand({4});
+  ASSERT_TRUE(allClose(fl::transpose(a), a));
+
+  ASSERT_EQ(fl::transpose(fl::rand({5, 6, 1, 7})).shape(), Shape({7, 1, 6, 5}));
+  ASSERT_EQ(fl::transpose(fl::rand({1, 1})).shape(), Shape({1, 1}));
+  ASSERT_EQ(
+      fl::transpose(fl::rand({7, 2, 1, 3}), {0, 2, 1, 3}).shape(),
+      Shape({7, 1, 2, 3}));
 }
 
 TEST(TensorBaseTest, tile) {
@@ -636,6 +650,40 @@ TEST(TensorBaseTest, matmul) {
       fl::matmul(fl::transpose(a), b, fl::MatrixProperty::Transpose), ref));
 }
 
+TEST(TensorBaseTest, matmulShapes) {
+  ASSERT_EQ(fl::matmul(fl::rand({10}), fl::rand({10})).shape(), Shape({1}));
+  ASSERT_EQ(
+      fl::matmul(fl::rand({10}), fl::rand({10}), fl::MatrixProperty::Transpose)
+          .shape(),
+      Shape({1}));
+  ASSERT_EQ(
+      fl::matmul(
+          fl::rand({10}),
+          fl::rand({10}),
+          fl::MatrixProperty::Transpose,
+          fl::MatrixProperty::Transpose)
+          .shape(),
+      Shape({1}));
+  ASSERT_EQ(
+      fl::matmul(
+          fl::rand({10}),
+          fl::rand({10}),
+          fl::MatrixProperty::None,
+          fl::MatrixProperty::Transpose)
+          .shape(),
+      Shape({1}));
+  ASSERT_EQ(fl::matmul(fl::rand({1, 10}), fl::rand({10})).shape(), Shape({1}));
+  ASSERT_EQ(fl::matmul(fl::rand({1}), fl::rand({1, 10})).shape(), Shape({10}));
+  ASSERT_EQ(
+      fl::matmul(fl::rand({10}), fl::rand({10}), fl::MatrixProperty::Transpose)
+          .shape(),
+      Shape({1}));
+  ASSERT_EQ(fl::matmul(fl::rand({3, 4}), fl::rand({4})).shape(), Shape({3}));
+  ASSERT_EQ(fl::matmul(fl::rand({5}), fl::rand({5, 7})).shape(), Shape({7}));
+  ASSERT_THROW(fl::matmul(fl::rand({1}), fl::rand({10})), std::exception);
+  ASSERT_THROW(fl::matmul(fl::rand({3}), fl::rand({5, 7})), std::exception);
+}
+
 TEST(TensorBaseTest, sum) {
   auto t = fl::full({3, 4, 5, 6}, 1.0);
   ASSERT_TRUE(allClose(fl::sum(t, {0}), fl::full({4, 5, 6}, 3.0)));
@@ -726,6 +774,7 @@ TEST(TensorBaseTest, iota) {
       fl::iota({5, 3}, {1, 2}),
       fl::tile(fl::reshape(fl::arange({15}), {5, 3}), {1, 2})));
   ASSERT_EQ(fl::iota({2, 2}, {2, 2}, fl::dtype::f64).type(), fl::dtype::f64);
+  ASSERT_EQ(fl::iota({1, 10}, {5}).shape(), Shape({5, 10}));
 }
 
 TEST(TensorBaseTest, pad) {


### PR DESCRIPTION
Summary:
Several important tweaks to expected behavior (with tests enforcing it):
- Transposing 1D tensors results in 1D tensors (axis reversal of a 1D tensor is idempotent)
- Enforce the number of reordered dims passed to transpose is equal to the dimension of the tensor ([per numpy](https://numpy.org/doc/stable/reference/generated/numpy.transpose.html))
- Fix `numDims` for ArrayFire tensors created using iota
- Fix matmul behavior in a variety of ways:
  - Make transpose ops on 1D inputs via matmul idempotent
  - Proactively append and prepend a singleton dimension to 1D tensors on the rhs and lhs, respectively to make dimensions match better for 1D inputs
  - Handle vector x matrix case better (always returns a 1D tensor)
- Fix some UB with `fl::Tensor::host` and have it operate on `void*` rather than `void**`
- Add a `Tensor::fromBuffer` overload that takes a `uint8_t*` and a tensor type to facilitate reading serialized bytestreams of tensors

Differential Revision: D30712412

