### PR TITLE
Fix KenLM Scoring

### DIFF
--- a/flashlight/lib/text/decoder/lm/KenLM.cpp
+++ b/flashlight/lib/text/decoder/lm/KenLM.cpp
@@ -15,6 +15,9 @@ namespace fl {
 namespace lib {
 namespace text {
 
+// log 10^e
+const float LogTenExp = 0.4342945;
+
 KenLMState::KenLMState() : ken_(std::make_unique<lm::ngram::State>()) {}
 
 KenLM::KenLM(const std::string& path, const Dictionary& usrTknDict) {
@@ -58,7 +61,7 @@ std::pair<LMStatePtr, float> KenLM::score(
   auto inState = std::static_pointer_cast<KenLMState>(state);
   auto outState = inState->child<KenLMState>(usrTokenIdx);
   float score = model_->BaseScore(
-      inState->ken(), usrToLmIdxMap_[usrTokenIdx], outState->ken());
+      inState->ken(), usrToLmIdxMap_[usrTokenIdx], outState->ken()) / LogTenExp;
   return std::make_pair(std::move(outState), score);
 }
 
@@ -66,7 +69,7 @@ std::pair<LMStatePtr, float> KenLM::finish(const LMStatePtr& state) {
   auto inState = std::static_pointer_cast<KenLMState>(state);
   auto outState = inState->child<KenLMState>(-1);
   float score =
-      model_->BaseScore(inState->ken(), vocab_->EndSentence(), outState->ken());
+      model_->BaseScore(inState->ken(), vocab_->EndSentence(), outState->ken()) / LogTenExp;
   return std::make_pair(std::move(outState), score);
 }
 } // namespace text


### PR DESCRIPTION
**Original Issue**:  Different log base for scoring calculation #745 

### Summary

KenLM score may need to rescale.
So, I Apply log formula of the change of base.
log e^Prob = log 10^Prob / log 10^e.

### Test Plan (required) 
Calculate score from inference code directly.

