### PR TITLE
(breaking) Have host-side primitive type reductions return Tensors

### DIFF
--- a/flashlight/fl/autograd/Functions.cpp
+++ b/flashlight/fl/autograd/Functions.cpp
@@ -712,15 +712,15 @@ Variable matmul(const Variable& lhs, const Variable& rhs) {
       // matmulNT(gradOutput, inputs[1])
       // -- matmulNT([M, K], [N, K])
       // -- matmul([M, K], [K, N]) -- [M, K]
-      inputs[0].addGrad(
-          Variable(matmulNT(gradOutput, inputs[1]).array(), false));
+      auto val = af::matmulNT(gradOutput.array(), inputs[1].array());
+      inputs[0].addGrad(Variable(detail::sumAs(val, inputs[0].dims()), false));
     }
     if (inputs[1].isCalcGrad()) {
       // matmulTN(inputs[0], gradOutput)
       // -- matmulTN([M, N], [M, K])
       // -- matmul([N, M], [M, K]) -- [N, K]
-      inputs[1].addGrad(
-          Variable(matmulTN(inputs[0], gradOutput).array(), false));
+      auto val = af::matmulTN(inputs[0].array(), gradOutput.array());
+      inputs[1].addGrad(Variable(detail::sumAs(val, inputs[1].dims()), false));
     }
   };
   return Variable(result, {lhs, rhs}, gradFunc);
@@ -741,13 +741,14 @@ Variable matmulTN(const Variable& lhs, const Variable& rhs) {
       // matmulNT(inputs[1], gradOutput)
       // -- matmulNT([N, K], [M, K])
       // -- matmul([N, K], [K, M]) -- [N, M]
-      inputs[0].addGrad(
-          Variable(matmulNT(inputs[1], gradOutput).array(), false));
+      auto val = af::matmulNT(inputs[1].array(), gradOutput.array());
+      inputs[0].addGrad(Variable(detail::sumAs(val, inputs[0].dims()), false));
     }
     if (inputs[1].isCalcGrad()) {
       // matmul(inputs[0], gradOutput)
       // -- matmulNT([N, M], [M, K]) -- [N, K]
-      inputs[1].addGrad(Variable(matmul(inputs[0], gradOutput).array(), false));
+      auto val = af::matmul(inputs[0].array(), gradOutput.array());
+      inputs[1].addGrad(Variable(detail::sumAs(val, inputs[1].dims()), false));
     }
   };
   return Variable(result, {lhs, rhs}, gradFunc);
@@ -767,14 +768,15 @@ Variable matmulNT(const Variable& lhs, const Variable& rhs) {
     if (inputs[0].isCalcGrad()) {
       // matmul(gradOutput, inputs[1])
       // -- matmul([M, K], [K, N]) -- [M, N]
-      inputs[0].addGrad(Variable(matmul(gradOutput, inputs[1]).array(), false));
+      auto val = af::matmul(gradOutput.array(), inputs[1].array());
+      inputs[0].addGrad(Variable(detail::sumAs(val, inputs[0].dims()), false));
     }
     if (inputs[1].isCalcGrad()) {
       // matmulTN(gradOutput, inputs[0])
       // -- matmulTN([M, K], [M, N])
       // -- matmul([K, M], [M, N]) -- [K, N]
-      inputs[1].addGrad(
-          Variable(matmulTN(gradOutput, inputs[0]).array(), false));
+      auto val = af::matmulTN(gradOutput.array(), inputs[0].array());
+      inputs[1].addGrad(Variable(detail::sumAs(val, inputs[1].dims()), false));
     }
   };
   return Variable(result, {lhs, rhs}, gradFunc);

--- a/flashlight/fl/tensor/Types.h
+++ b/flashlight/fl/tensor/Types.h
@@ -61,7 +61,7 @@ FL_TYPE_TRAIT(float, dtype::f32, dtype::f32, "float");
 FL_TYPE_TRAIT(double, dtype::f64, dtype::f32, "double");
 FL_TYPE_TRAIT(int, dtype::s32, dtype::s32, "int");
 FL_TYPE_TRAIT(unsigned, dtype::u32, dtype::u32, "unsigned int");
-FL_TYPE_TRAIT(char, dtype::s32, dtype::s32, "char");
+FL_TYPE_TRAIT(char, dtype::b8, dtype::s32, "char");
 FL_TYPE_TRAIT(unsigned char, dtype::u8, dtype::u32, "unsigned char");
 FL_TYPE_TRAIT(long, dtype::s32, dtype::s32, "long int");
 FL_TYPE_TRAIT(unsigned long, dtype::u32, dtype::u32, "unsigned long");

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
@@ -180,10 +180,8 @@ class ArrayFireBackend : public TensorBackend {
   /************************** Reductions ***************************/
   Tensor amin(const Tensor& input, const std::vector<int>& axes, bool keepDims)
       override;
-  double amin(const Tensor& input) override; // TODO: consolidate w/ above
   Tensor amax(const Tensor& input, const std::vector<int>& axes, bool keepDims)
       override;
-  double amax(const Tensor& input) override; // TODO: consolidate w/ above
   void min(
       Tensor& values,
       Tensor& indices,
@@ -198,37 +196,34 @@ class ArrayFireBackend : public TensorBackend {
       bool keepDims) override;
   Tensor sum(const Tensor& input, const std::vector<int>& axes, bool keepDims)
       override;
-  double sum(const Tensor& input) override; // TODO: consolidate w/ above
   Tensor argmax(const Tensor& input, unsigned axis, bool keepDims) override;
   Tensor argmin(const Tensor& input, unsigned axis, bool keepDims) override;
   Tensor mean(const Tensor& input, const std::vector<int>& axes, bool keepDims)
       override;
-  double mean(const Tensor& input) override; // TODO: consolidate w/ above
   Tensor median(
       const Tensor& input,
       const std::vector<int>& axes,
       bool keepDims) override;
-  double median(const Tensor& input) override; // TODO: consolidate w/ above
   Tensor var(
       const Tensor& input,
       const std::vector<int>& axes,
       const bool bias,
       bool keepDims) override;
-  double var(const Tensor& input, const bool bias)
-      override; // TODO: consolidate w/ above
   Tensor std(const Tensor& input, const std::vector<int>& axes, bool keepDims)
       override;
-  double norm(const Tensor& input) override;
+  Tensor norm(
+      const Tensor& input,
+      const std::vector<int>& axes,
+      double p,
+      bool keepDims) override;
   Tensor countNonzero(
       const Tensor& input,
       const std::vector<int>& axes,
       bool keepDims) override;
   Tensor any(const Tensor& input, const std::vector<int>& axes, bool keepDims)
       override;
-  bool any(const Tensor& input) override;
   Tensor all(const Tensor& input, const std::vector<int>& axes, bool keepDims)
       override;
-  bool all(const Tensor& input) override;
 
   /************************** Utils ***************************/
   void print(const Tensor& tensor) override;

--- a/flashlight/fl/test/autograd/AutogradTest.cpp
+++ b/flashlight/fl/test/autograd/AutogradTest.cpp
@@ -1068,6 +1068,73 @@ TEST(AutogradTest, Reorder) {
   ASSERT_TRUE(jacobianTestImpl(func_reorder, in, 1E-3));
 }
 
+TEST(AutogradTest, matmul) {
+  unsigned M = 10;
+  unsigned K = 12;
+  unsigned N = 14;
+  unsigned b2 = 2;
+  unsigned b3 = 4;
+  auto mk = af::dim4({M, K});
+  auto mkb2 = af::dim4({M, K, b2}); // 1 batch dim
+  auto mkb2b3 = af::dim4({M, K, b2, b3}); // 2 batch dims
+  auto kn = af::dim4({K, N});
+  auto knb2 = af::dim4({K, N, b2}); // 1 batch dim
+  auto knb2b3 = af::dim4({K, N, b2, b3}); // 2 batch dims
+
+  // lhs, rhs
+  std::vector<std::pair<af::dim4, af::dim4>> inputs = {
+      {mk, kn},
+      {mk, knb2},
+      {mk, knb2b3},
+      {mkb2, kn},
+      {mkb2, knb2},
+      {mkb2b3, kn},
+      {mkb2b3, knb2b3}};
+
+  auto trFirstTwoDims = [](const af::dim4& in) -> af::dim4 {
+    af::dim4 out = in;
+    auto out1 = out[1];
+    out[1] = out[0];
+    out[0] = out1;
+    return out;
+  };
+
+  for (auto& pair : inputs) {
+    auto& aShape = pair.first;
+    auto& bShape = pair.second;
+
+    auto a = Variable(af::randu(aShape, af::dtype::f64) * 2 - 1, true);
+    auto b = Variable(af::randu(bShape, af::dtype::f64) * 2 - 1, true);
+
+    auto aT = Variable(af::randu(trFirstTwoDims(aShape), af::dtype::f64), true);
+    auto bT = Variable(af::randu(trFirstTwoDims(bShape), af::dtype::f64), true);
+
+    // matmul
+    auto funcMatmulLhs = [&](Variable& input) { return matmul(input, b); };
+    ASSERT_TRUE(jacobianTestImpl(funcMatmulLhs, a, 1E-6))
+        << "matmul lhs gradient: lhs " << a.dims() << " rhs " << b.dims();
+    auto funcMatmulRhs = [&](Variable& input) { return matmul(a, input); };
+    ASSERT_TRUE(jacobianTestImpl(funcMatmulRhs, b, 1E-6))
+        << "matmul rhs gradient: lhs " << a.dims() << " rhs " << b.dims();
+
+    // matmulTN
+    auto funcMatmulTNLhs = [&](Variable& input) { return matmulTN(input, b); };
+    ASSERT_TRUE(jacobianTestImpl(funcMatmulTNLhs, aT, 1E-6))
+        << "matmulTN lhs gradient: lhs " << a.dims() << " rhs " << b.dims();
+    auto funcMatmulTNRhs = [&](Variable& input) { return matmulTN(aT, input); };
+    ASSERT_TRUE(jacobianTestImpl(funcMatmulTNRhs, b, 1E-6))
+        << "matmulTN rhs gradient: lhs " << a.dims() << " rhs " << b.dims();
+
+    // matmulNT
+    auto funcMatmulNTLhs = [&](Variable& input) { return matmulNT(input, bT); };
+    ASSERT_TRUE(jacobianTestImpl(funcMatmulNTLhs, a, 1E-6))
+        << "matmulTN lhs gradient: lhs " << a.dims() << " rhs " << b.dims();
+    auto funcMatmulNTRhs = [&](Variable& input) { return matmulNT(a, input); };
+    ASSERT_TRUE(jacobianTestImpl(funcMatmulNTRhs, bT, 1E-6))
+        << "matmulTN rhs gradient: lhs " << a.dims() << " rhs " << b.dims();
+  }
+}
+
 TEST(AutogradTest, Glu) {
   auto in = Variable(af::randu(3, 4, 5, af::dtype::f64), true);
   auto func_glu = [&](Variable& input) { return gatedlinearunit(input, 1); };

--- a/flashlight/fl/test/tensor/ArrayFireTensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/ArrayFireTensorBaseTest.cpp
@@ -189,7 +189,7 @@ TEST(ArrayFireTensorBaseTest, rand) {
 
 TEST(ArrayFireTensorBaseTest, amin) {
   auto a = fl::rand({3, 3});
-  ASSERT_EQ(fl::amin<float>(a), af::min<float>(toArray(a)));
+  ASSERT_EQ(fl::amin(a).scalar<float>(), af::min<float>(toArray(a)));
   ASSERT_TRUE(allClose(
       toArray(fl::amin(a, {0})),
       fl::detail::condenseIndices(af::min(toArray(a), 0))));
@@ -197,7 +197,7 @@ TEST(ArrayFireTensorBaseTest, amin) {
 
 TEST(ArrayFireTensorBaseTest, amax) {
   auto a = fl::rand({3, 3});
-  ASSERT_EQ(fl::amax<float>(a), af::max<float>(toArray(a)));
+  ASSERT_EQ(fl::amax(a).scalar<float>(), af::max<float>(toArray(a)));
   ASSERT_TRUE(allClose(
       toArray(fl::amax(a, {0})),
       fl::detail::condenseIndices(af::max(toArray(a), 0))));
@@ -205,13 +205,13 @@ TEST(ArrayFireTensorBaseTest, amax) {
 
 TEST(ArrayFireTensorBaseTest, sum) {
   auto a = fl::rand({3, 3});
-  ASSERT_EQ(fl::sum<float>(a), af::sum<float>(toArray(a)));
+  ASSERT_EQ(fl::sum(a).scalar<float>(), af::sum<float>(toArray(a)));
   ASSERT_TRUE(allClose(
       toArray(fl::sum(a, {0})),
       fl::detail::condenseIndices(af::sum(toArray(a), 0))));
 
   auto b = fl::rand({5, 6, 7, 8});
-  ASSERT_EQ(fl::sum<float>(b), af::sum<float>(toArray(b)));
+  ASSERT_NEAR(fl::sum(b).scalar<float>(), af::sum<float>(toArray(b)), 1e-3);
   ASSERT_TRUE(allClose(
       toArray(fl::sum(b, {1, 2})),
       fl::detail::condenseIndices(af::sum(af::sum(toArray(b), 1), 2))));
@@ -264,7 +264,7 @@ TEST(ArrayFireTensorBaseTest, erf) {
 
 TEST(ArrayFireTensorBaseTest, mean) {
   auto a = fl::rand({3, 50});
-  ASSERT_EQ(fl::mean<float>(a), af::mean<float>(toArray(a)));
+  ASSERT_NEAR(fl::mean(a).scalar<float>(), af::mean<float>(toArray(a)), 1e-4);
   ASSERT_TRUE(allClose(
       toArray(fl::mean(a, {0})),
       detail::condenseIndices(af::mean(toArray(a), 0))));
@@ -272,7 +272,8 @@ TEST(ArrayFireTensorBaseTest, mean) {
 
 TEST(ArrayFireTensorBaseTest, median) {
   auto a = fl::rand({3, 50});
-  ASSERT_EQ(fl::median<float>(a), af::median<float>(toArray(a)));
+  ASSERT_NEAR(
+      fl::median(a).scalar<float>(), af::median<float>(toArray(a)), 1e-3);
   ASSERT_TRUE(allClose(
       toArray(fl::median(a, {0})),
       detail::condenseIndices(af::median(toArray(a), 0))));
@@ -280,17 +281,16 @@ TEST(ArrayFireTensorBaseTest, median) {
 
 TEST(ArrayFireTensorBaseTest, var) {
   auto a = fl::rand({3, 3});
-  ASSERT_EQ(fl::var<float>(a), af::var<float>(toArray(a)));
+  ASSERT_EQ(fl::var(a).scalar<float>(), af::var<float>(toArray(a)));
   ASSERT_TRUE(allClose(
       toArray(fl::var(a, {0})),
       detail::condenseIndices(af::var(toArray(a), AF_VARIANCE_POPULATION, 0))));
   ASSERT_TRUE(allClose(
-      toArray(fl::var(a, {1}, false)),
+      toArray(fl::var(a, {1})),
       detail::condenseIndices(af::var(toArray(a), AF_VARIANCE_POPULATION, 1))));
   // Make sure multidimension matches computing for all
   ASSERT_FLOAT_EQ(
-      toArray(fl::var(a, {0, 1}, false)).scalar<float>(),
-      af::var<float>(toArray(a)));
+      toArray(fl::var(a)).scalar<float>(), af::var<float>(toArray(a)));
   ASSERT_FLOAT_EQ(
       toArray(fl::var(a, {0, 1}, true)).scalar<float>(),
       af::var<float>(toArray(a), AF_VARIANCE_SAMPLE));
@@ -298,8 +298,12 @@ TEST(ArrayFireTensorBaseTest, var) {
 
 TEST(ArrayFireTensorBaseTest, std) {
   auto a = fl::rand({3, 3});
-  ASSERT_TRUE(allClose(toArray(fl::std(a, {0})), af::stdev(toArray(a), 0)));
-  ASSERT_TRUE(allClose(toArray(fl::std(a, {1})), af::stdev(toArray(a), 1)));
+  ASSERT_TRUE(allClose(
+      toArray(fl::std(a, {0}, /* keepDims = */ true)),
+      af::stdev(toArray(a), 0)));
+  ASSERT_TRUE(allClose(
+      toArray(fl::std(a, {1}, /* keepDims = */ true)),
+      af::stdev(toArray(a), 1)));
   // Make sure multidimension matches computing for all
   ASSERT_FLOAT_EQ(
       toArray(fl::std(a, {0, 1})).scalar<float>(),
@@ -308,7 +312,7 @@ TEST(ArrayFireTensorBaseTest, std) {
 
 TEST(ArrayFireTensorBaseTest, norm) {
   auto a = fl::rand({3, 3});
-  ASSERT_EQ(fl::norm(a), af::norm(toArray(a)));
+  ASSERT_NEAR(fl::norm(a).scalar<float>(), af::norm(toArray(a)), 1e-4);
 }
 
 TEST(ArrayFireTensorBaseTest, tile) {


### PR DESCRIPTION
Summary:
Reductions that return host-side primitive types are super bad for accelerator backends with async execution models because they require syncs and materialization. Remove these from the API entirely — this leaves no functions that return host side primitive types — everything returns a Tensor.

ArrayFire will be adding support for reduction specializations for arrays (e.g. `af::sum<af::array>`) which will use the same efficient and accurate `reduce_all` kernels. For now, stay with either per-axis reductions, like `af::sum(af::sum(af::sum(af::sum(...))))` (which isn't JITted super well but will still be fine) or materialize a value on the host then transfer it back to the device.

Differential Revision: D31718115

