### PR TITLE
Fix gradient computation for batched matrix multiply

### DIFF
--- a/flashlight/fl/autograd/Functions.cpp
+++ b/flashlight/fl/autograd/Functions.cpp
@@ -712,15 +712,15 @@ Variable matmul(const Variable& lhs, const Variable& rhs) {
       // matmulNT(gradOutput, inputs[1])
       // -- matmulNT([M, K], [N, K])
       // -- matmul([M, K], [K, N]) -- [M, K]
-      inputs[0].addGrad(
-          Variable(matmulNT(gradOutput, inputs[1]).array(), false));
+      auto val = af::matmulNT(gradOutput.array(), inputs[1].array());
+      inputs[0].addGrad(Variable(detail::sumAs(val, inputs[0].dims()), false));
     }
     if (inputs[1].isCalcGrad()) {
       // matmulTN(inputs[0], gradOutput)
       // -- matmulTN([M, N], [M, K])
       // -- matmul([N, M], [M, K]) -- [N, K]
-      inputs[1].addGrad(
-          Variable(matmulTN(inputs[0], gradOutput).array(), false));
+      auto val = af::matmulTN(inputs[0].array(), gradOutput.array());
+      inputs[1].addGrad(Variable(detail::sumAs(val, inputs[1].dims()), false));
     }
   };
   return Variable(result, {lhs, rhs}, gradFunc);
@@ -741,13 +741,14 @@ Variable matmulTN(const Variable& lhs, const Variable& rhs) {
       // matmulNT(inputs[1], gradOutput)
       // -- matmulNT([N, K], [M, K])
       // -- matmul([N, K], [K, M]) -- [N, M]
-      inputs[0].addGrad(
-          Variable(matmulNT(inputs[1], gradOutput).array(), false));
+      auto val = af::matmulNT(inputs[1].array(), gradOutput.array());
+      inputs[0].addGrad(Variable(detail::sumAs(val, inputs[0].dims()), false));
     }
     if (inputs[1].isCalcGrad()) {
       // matmul(inputs[0], gradOutput)
       // -- matmulNT([N, M], [M, K]) -- [N, K]
-      inputs[1].addGrad(Variable(matmul(inputs[0], gradOutput).array(), false));
+      auto val = af::matmul(inputs[0].array(), gradOutput.array());
+      inputs[1].addGrad(Variable(detail::sumAs(val, inputs[1].dims()), false));
     }
   };
   return Variable(result, {lhs, rhs}, gradFunc);
@@ -767,14 +768,15 @@ Variable matmulNT(const Variable& lhs, const Variable& rhs) {
     if (inputs[0].isCalcGrad()) {
       // matmul(gradOutput, inputs[1])
       // -- matmul([M, K], [K, N]) -- [M, N]
-      inputs[0].addGrad(Variable(matmul(gradOutput, inputs[1]).array(), false));
+      auto val = af::matmul(gradOutput.array(), inputs[1].array());
+      inputs[0].addGrad(Variable(detail::sumAs(val, inputs[0].dims()), false));
     }
     if (inputs[1].isCalcGrad()) {
       // matmulTN(gradOutput, inputs[0])
       // -- matmulTN([M, K], [M, N])
       // -- matmul([K, M], [M, N]) -- [K, N]
-      inputs[1].addGrad(
-          Variable(matmulTN(gradOutput, inputs[0]).array(), false));
+      auto val = af::matmulTN(gradOutput.array(), inputs[0].array());
+      inputs[1].addGrad(Variable(detail::sumAs(val, inputs[1].dims()), false));
     }
   };
   return Variable(result, {lhs, rhs}, gradFunc);

--- a/flashlight/fl/test/autograd/AutogradTest.cpp
+++ b/flashlight/fl/test/autograd/AutogradTest.cpp
@@ -1068,6 +1068,73 @@ TEST(AutogradTest, Reorder) {
   ASSERT_TRUE(jacobianTestImpl(func_reorder, in, 1E-3));
 }
 
+TEST(AutogradTest, matmul) {
+  unsigned M = 10;
+  unsigned K = 12;
+  unsigned N = 14;
+  unsigned b2 = 2;
+  unsigned b3 = 4;
+  auto mk = af::dim4({M, K});
+  auto mkb2 = af::dim4({M, K, b2}); // 1 batch dim
+  auto mkb2b3 = af::dim4({M, K, b2, b3}); // 2 batch dims
+  auto kn = af::dim4({K, N});
+  auto knb2 = af::dim4({K, N, b2}); // 1 batch dim
+  auto knb2b3 = af::dim4({K, N, b2, b3}); // 2 batch dims
+
+  // lhs, rhs
+  std::vector<std::pair<af::dim4, af::dim4>> inputs = {
+      {mk, kn},
+      {mk, knb2},
+      {mk, knb2b3},
+      {mkb2, kn},
+      {mkb2, knb2},
+      {mkb2b3, kn},
+      {mkb2b3, knb2b3}};
+
+  auto trFirstTwoDims = [](const af::dim4& in) -> af::dim4 {
+    af::dim4 out = in;
+    auto out1 = out[1];
+    out[1] = out[0];
+    out[0] = out1;
+    return out;
+  };
+
+  for (auto& pair : inputs) {
+    auto& aShape = pair.first;
+    auto& bShape = pair.second;
+
+    auto a = Variable(af::randu(aShape, af::dtype::f64) * 2 - 1, true);
+    auto b = Variable(af::randu(bShape, af::dtype::f64) * 2 - 1, true);
+
+    auto aT = Variable(af::randu(trFirstTwoDims(aShape), af::dtype::f64), true);
+    auto bT = Variable(af::randu(trFirstTwoDims(bShape), af::dtype::f64), true);
+
+    // matmul
+    auto funcMatmulLhs = [&](Variable& input) { return matmul(input, b); };
+    ASSERT_TRUE(jacobianTestImpl(funcMatmulLhs, a, 1E-6))
+        << "matmul lhs gradient: lhs " << a.dims() << " rhs " << b.dims();
+    auto funcMatmulRhs = [&](Variable& input) { return matmul(a, input); };
+    ASSERT_TRUE(jacobianTestImpl(funcMatmulRhs, b, 1E-6))
+        << "matmul rhs gradient: lhs " << a.dims() << " rhs " << b.dims();
+
+    // matmulTN
+    auto funcMatmulTNLhs = [&](Variable& input) { return matmulTN(input, b); };
+    ASSERT_TRUE(jacobianTestImpl(funcMatmulTNLhs, aT, 1E-6))
+        << "matmulTN lhs gradient: lhs " << a.dims() << " rhs " << b.dims();
+    auto funcMatmulTNRhs = [&](Variable& input) { return matmulTN(aT, input); };
+    ASSERT_TRUE(jacobianTestImpl(funcMatmulTNRhs, b, 1E-6))
+        << "matmulTN rhs gradient: lhs " << a.dims() << " rhs " << b.dims();
+
+    // matmulNT
+    auto funcMatmulNTLhs = [&](Variable& input) { return matmulNT(input, bT); };
+    ASSERT_TRUE(jacobianTestImpl(funcMatmulNTLhs, a, 1E-6))
+        << "matmulTN lhs gradient: lhs " << a.dims() << " rhs " << b.dims();
+    auto funcMatmulNTRhs = [&](Variable& input) { return matmulNT(a, input); };
+    ASSERT_TRUE(jacobianTestImpl(funcMatmulNTRhs, bT, 1E-6))
+        << "matmulTN rhs gradient: lhs " << a.dims() << " rhs " << b.dims();
+  }
+}
+
 TEST(AutogradTest, Glu) {
   auto in = Variable(af::randu(3, 4, 5, af::dtype::f64), true);
   auto func_glu = [&](Variable& input) { return gatedlinearunit(input, 1); };


### PR DESCRIPTION
Summary:
Gradients for batched matmul are of incorrect shapes — fixes the issue. What's happening here:

Consider `matmul(lhs, rhs)` where `lhs = Shape(10, 12)` and `rhs = Shape(12, 14, 2)`. The result is of shape `(10, 14, 2)`:

wlog, the gradient of the lhs is `matmul(gradOutput, rhs^T)` (`^T` --> transpose) which is `(10, 14, 2) x (12, 14, 2)^T --> (10, 14, 2) x (14, 12, 2) --> (10, 12, 2)`

Before, we were adding a gradient of size `(10, 12, 2)` to a tensor of size `(10, 12)`, which is incorrect. Since batched matmul simulates a tile operation in the batch dimension(s), the gradient for a non-batched input should be the sum over the tiled batch dimensions --> `sum((10, 12, 2), dim=2)` gives the correct output

Differential Revision: D31966446

