### PR TITLE
Clean up Tensor and Shape stringification

### DIFF
--- a/flashlight/fl/tensor/CMakeLists.txt
+++ b/flashlight/fl/tensor/CMakeLists.txt
@@ -20,7 +20,8 @@ target_sources(
   ${CMAKE_CURRENT_LIST_DIR}/Random.cpp
   ${CMAKE_CURRENT_LIST_DIR}/Shape.cpp
   ${CMAKE_CURRENT_LIST_DIR}/TensorBackend.cpp
-  ${CMAKE_CURRENT_LIST_DIR}/TensorBase.cpp  
+  ${CMAKE_CURRENT_LIST_DIR}/TensorBase.cpp
   ${CMAKE_CURRENT_LIST_DIR}/TensorAdapter.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/TensorExtension.cpp
   ${CMAKE_CURRENT_LIST_DIR}/Types.cpp
 )

--- a/flashlight/fl/tensor/Index.cpp
+++ b/flashlight/fl/tensor/Index.cpp
@@ -9,13 +9,14 @@
 
 namespace fl {
 
-range::range(idx idx) : range(0, idx) {}
+range::range(const idx& i) : range(0, i) {}
 
-range::range(idx start, idx end) : range(start, end, /* stride */ 1) {}
+range::range(const idx& start, const idx& end)
+    : range(start, end, /* stride */ 1) {}
 
-range::range(idx start, idx end, Dim stride)
+range::range(const idx& start, const idx& end, const Dim stride)
     : // fl::end decays to int
-      start_(std::visit([](Dim idx) -> Dim { return idx; }, start)),
+      start_(std::visit([](const Dim idx) -> Dim { return idx; }, start)),
       // fl::end --> -1, else idx as Dim
       end_(
           std::holds_alternative<fl::end_t>(end)

--- a/flashlight/fl/tensor/Index.h
+++ b/flashlight/fl/tensor/Index.h
@@ -44,18 +44,18 @@ class range {
   /**
    * Construct a range with the indices [0, idx) (i.e. [0, idx - 1])
    */
-  explicit range(idx idx);
+  explicit range(const idx& idx);
 
   /**
    * Construct a range with the indices [start, end) (i.e. [start, end - 1])
    */
-  range(idx start, idx end);
+  range(const idx& start, const idx& end);
 
   /**
    * Construct a range with the indices [start, end) (i.e. [start, end - 1])
    * with the given stride.
    */
-  range(idx start, idx end, Dim stride);
+  range(const idx& start, const idx& end, const Dim stride);
 
   Dim start() const;
   Dim end() const;

--- a/flashlight/fl/tensor/Shape.cpp
+++ b/flashlight/fl/tensor/Shape.cpp
@@ -73,15 +73,6 @@ bool Shape::operator!=(const std::initializer_list<Dim>& other) const {
   return !(this->operator==(other));
 }
 
-std::ostream& operator<<(std::ostream& ostr, const Shape& s) {
-  ostr << "(";
-  for (size_t i = 0; i < s.ndim(); ++i) {
-    ostr << s.dim(i) << (i == s.ndim() - 1 ? "" : ", ");
-  }
-  ostr << ")";
-  return ostr;
-}
-
 const std::vector<Dim>& Shape::get() const {
   return dims_;
 }
@@ -89,5 +80,20 @@ const std::vector<Dim>& Shape::get() const {
 std::vector<Dim>& Shape::get() {
   return dims_;
 };
+
+std::string Shape::toString() const {
+  std::stringstream ss;
+  ss << "(";
+  for (size_t i = 0; i < ndim(); ++i) {
+    ss << dim(i) << (i == ndim() - 1 ? "" : ", ");
+  }
+  ss << ")";
+  return ss.str();
+}
+
+std::ostream& operator<<(std::ostream& ostr, const Shape& s) {
+  ostr << s.toString();
+  return ostr;
+}
 
 } // namespace fl

--- a/flashlight/fl/tensor/Shape.cpp
+++ b/flashlight/fl/tensor/Shape.cpp
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <limits>
 #include <numeric>
+#include <sstream>
 #include <stdexcept>
 
 namespace fl {
@@ -18,6 +19,16 @@ Shape::Shape(std::vector<Dim> d) : dims_(std::move(d)) {}
 Shape::Shape(std::initializer_list<Dim> d) : Shape(std::vector<Dim>(d)) {}
 
 const Dim kEmptyShapeNumberOfElements = 1;
+
+void Shape::checkDimsOrThrow(const size_t dim) const {
+  if (dim > ndim() - 1) {
+    std::stringstream ss;
+    ss << "Shape index " << std::to_string(dim)
+       << " out of bounds for shape with " << std::to_string(dims_.size())
+       << " dimensions.";
+    throw std::invalid_argument(ss.str());
+  }
+}
 
 Dim Shape::elements() const {
   if (dims_.size() == 0) {
@@ -31,19 +42,17 @@ size_t Shape::ndim() const {
 }
 
 Dim Shape::dim(const size_t dim) const {
-  if (dim >= dims_.size()) {
-    throw std::invalid_argument(
-        "fl::Shape::dim - passed dimension is larger than "
-        "the number of dimensions in the shape");
-  }
+  checkDimsOrThrow(dim);
   return dims_[dim];
 }
 
 Dim& Shape::operator[](const size_t dim) {
+  checkDimsOrThrow(dim);
   return dims_[dim];
 }
 
 const Dim& Shape::operator[](const size_t dim) const {
+  checkDimsOrThrow(dim);
   return dims_[dim];
 }
 

--- a/flashlight/fl/tensor/Shape.h
+++ b/flashlight/fl/tensor/Shape.h
@@ -113,6 +113,11 @@ class Shape {
    */
   const std::vector<Dim>& get() const;
   std::vector<Dim>& get();
+
+  /**
+   * Returns a string representation of the Shape
+   */
+  std::string toString() const;
 };
 
 /**

--- a/flashlight/fl/tensor/Shape.h
+++ b/flashlight/fl/tensor/Shape.h
@@ -44,6 +44,12 @@ class Shape {
   // {} is a scalar shape.
   std::vector<Dim> dims_;
 
+  /**
+   * Check if a dimension is valid (i.e. in bounds) given the current size of
+   * the shape. If not valid, throws an exception.
+   */
+  void checkDimsOrThrow(const size_t dim) const;
+
  public:
   Shape() = default;
   ~Shape() = default;

--- a/flashlight/fl/tensor/TensorAdapter.h
+++ b/flashlight/fl/tensor/TensorAdapter.h
@@ -213,6 +213,12 @@ class TensorAdapterBase {
   virtual void* getContext() = 0;
 
   /**
+   * Return a string representation of a Tensor. Not intended to be portable
+   * across backends.
+   */
+  virtual std::string toString() = 0;
+
+  /**
    * Write a string representation of a tensor to an output stream.
    */
   virtual std::ostream& operator<<(std::ostream& ostr) = 0;

--- a/flashlight/fl/tensor/TensorBackend.cpp
+++ b/flashlight/fl/tensor/TensorBackend.cpp
@@ -9,6 +9,7 @@
 
 namespace fl {
 namespace detail {
+
 bool areBackendsEqual(const Tensor& a, const Tensor& b) {
   return a.backendType() == b.backendType();
 }

--- a/flashlight/fl/tensor/TensorBackend.h
+++ b/flashlight/fl/tensor/TensorBackend.h
@@ -8,10 +8,13 @@
 #pragma once
 
 #include <memory>
+#include <stdexcept>
 #include <type_traits>
+#include <unordered_map>
 #include <utility>
 
 #include "flashlight/fl/tensor/TensorBase.h"
+#include "flashlight/fl/tensor/TensorExtension.h"
 
 namespace fl {
 
@@ -31,6 +34,7 @@ class TensorBackend {
  public:
   TensorBackend() = default;
   virtual ~TensorBackend() = default;
+  virtual TensorBackendType backendType() const = 0;
 
   /* -------------------------- Compute Functions -------------------------- */
   virtual void sync() = 0;
@@ -232,6 +236,31 @@ class TensorBackend {
 
   /************************** Utils ***************************/
   virtual void print(const Tensor& tensor) = 0;
+
+  /********************* Tensor Extensions **********************/
+  template <typename T>
+  T& getExtension() {
+    static_assert(
+        std::is_base_of<TensorExtensionBase, T>::value,
+        "TensorBackend::getExtension<T>() called with type T "
+        "that is not derived from TensorExtensionBase.");
+
+    TensorExtensionType e = T::getExtensionType();
+
+    // If an extension isn't present, instantiate it via its registered
+    // creation function - only do this once per extension.
+    if (extensions_.find(e) == extensions_.end()) {
+      auto& creationFunc =
+          detail::TensorExtensionRegistrar::getInstance()
+              .getTensorExtensionCreationFunc(this->backendType(), e);
+      extensions_.emplace(e, creationFunc());
+    }
+    return *(static_cast<T*>(extensions_.at(e).get()));
+  }
+
+ protected:
+  std::unordered_map<TensorExtensionType, std::unique_ptr<TensorExtensionBase>>
+      extensions_;
 };
 
 /**

--- a/flashlight/fl/tensor/TensorBackend.h
+++ b/flashlight/fl/tensor/TensorBackend.h
@@ -126,6 +126,12 @@ class TensorBackend {
       const SortMode sortMode) = 0;
   virtual Tensor
   sort(const Tensor& input, const Dim axis, const SortMode sortMode) = 0;
+  virtual void sort(
+      Tensor& values,
+      Tensor& indices,
+      const Tensor& input,
+      const Dim axis,
+      const SortMode sortMode) = 0;
   virtual Tensor
   argsort(const Tensor& input, const Dim axis, const SortMode sortMode) = 0;
 

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -611,6 +611,10 @@ Tensor power(const Tensor& lhs, const double& rhs) {
   return lhs.backend().power(lhs, full(lhs.shape(), rhs));
 }
 
+Tensor power(const double& lhs, const Tensor& rhs) {
+  return rhs.backend().power(full(rhs.shape(), lhs), rhs);
+}
+
 /******************************* BLAS ********************************/
 Tensor matmul(
     const Tensor& lhs,

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -768,4 +768,12 @@ bool allClose(
       absTolerance;
 }
 
+namespace detail {
+
+bool areTensorTypesEqual(const Tensor& a, const Tensor& b) {
+  return a.type() == b.type();
+}
+
+} // namespace detail
+
 } // namespace fl

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -501,13 +501,22 @@ void topk(
     const Tensor& input,
     const unsigned k,
     const Dim axis,
-    const SortMode sortMode) {
+    const SortMode sortMode /* = SortMode::Descending */) {
   FL_TENSOR_BACKENDS_MATCH_CHECK(values, indices, input);
   input.backend().topk(values, indices, input, k, axis, sortMode);
 }
 
 Tensor sort(const Tensor& input, const Dim axis, const SortMode sortMode) {
   return input.backend().sort(input, axis, sortMode);
+}
+
+void sort(
+    Tensor& values,
+    Tensor& indices,
+    const Tensor& input,
+    const Dim axis,
+    const SortMode sortMode /* = SortMode::Descending */) {
+  return values.backend().sort(values, indices, input, axis, sortMode);
 }
 
 Tensor argsort(const Tensor& input, const Dim axis, const SortMode sortMode) {

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -240,6 +240,10 @@ void* Tensor::getContext() const {
   return impl_->getContext();
 }
 
+std::string Tensor::toString() const {
+  return impl_->toString();
+}
+
 std::ostream& Tensor::operator<<(std::ostream& ostr) const {
   return impl_->operator<<(ostr);
 }

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -522,6 +522,15 @@ class Tensor {
   void* getContext() const;
 
   /**
+   * Returns a string representation of a Tensor. NOTE: This is
+   * backend-dependent. See Flashlight's serialization utilities for ways to
+   * serialize Tensors that are portable across Tensor backends.
+   *
+   * @return a string representation of the Tensor.
+   */
+  std::string toString() const;
+
+  /**
    * Write a string representation of a tensor to an output stream.
    */
   std::ostream& operator<<(std::ostream& ostr) const;
@@ -1391,7 +1400,7 @@ Tensor all(
 /**
  * Write a string representation of a tensor to an output stream.
  */
-std::ostream& operator<<(std::ostream& ostr, const Tensor& s);
+std::ostream& operator<<(std::ostream& ostr, const Tensor& t);
 
 /**
  * Print a string representation of a tensor to standard out.

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -1401,4 +1401,27 @@ bool allClose(
     const fl::Tensor& b,
     const double absTolerance = 1e-5);
 
+namespace detail {
+
+bool areTensorTypesEqual(const Tensor& a, const Tensor& b);
+
+template <typename... Args>
+bool areTensorTypesEqual(
+    const Tensor& a,
+    const Tensor& b,
+    const Args&... args) {
+  return areTensorTypesEqual(a, b) && areTensorTypesEqual(a, args...);
+}
+
+} // namespace detail
+
+/**
+ * Checks if a variadic number of Tensors have the same type.
+ */
+#define FL_TENSOR_DTYPES_MATCH_CHECK(...)                                     \
+  if (!detail::areTensorTypesEqual(__VA_ARGS__)) {                            \
+    throw std::invalid_argument(                                              \
+        std::string(__func__) + ": tensors are not all of the same types. "); \
+  }
+
 } // namespace fl

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -411,9 +411,9 @@ class Tensor {
       case dtype::f64:
         return scalar<double>();
       case dtype::s32:
-        return scalar<long>();
+        return scalar<int>();
       case dtype::u32:
-        return scalar<unsigned long>();
+        return scalar<unsigned int>();
       case dtype::b8:
         return scalar<char>();
       case dtype::u8:
@@ -1090,6 +1090,7 @@ Tensor maximum(const double& lhs, const Tensor& rhs);
  */
 Tensor power(const Tensor& lhs, const Tensor& rhs);
 Tensor power(const Tensor& lhs, const double& rhs);
+Tensor power(const double& lhs, const Tensor& rhs);
 
 /******************************* BLAS ********************************/
 

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -966,8 +966,8 @@ enum class SortMode { Descending = 0, Ascending = 1 };
 /**
  * Get the top-k values and indices from a Tensor.
  *
- * @param[in] values
- * @param[in] indices
+ * @param[out] values the sorted tensor
+ * @param[out] indices the indices corresponding to the sorted ordering
  * @param[in] input the input tensor to sort
  * @param[in] k the top number of elements to return
  * @param[in] axis the axis along which to sort.
@@ -989,6 +989,22 @@ void topk(
  * @param[in] sortMode the ordering with which to sort. Defaults to descending
  */
 Tensor sort(
+    const Tensor& input,
+    const Dim axis,
+    const SortMode sortMode = SortMode::Descending);
+
+/**
+ * Sort the values of a tensor, and return the sorted tensor and sorted indices.
+ *
+ * @param[out] values the sorted tensor
+ * @param[out] indices the indices corresponding to the sorted ordering
+ * @param[in] input the input Tensor
+ * @param[in] axis the axis along which to sort
+ * @param[in] sortMode the ordering with which to sort. Defaults to descending
+ */
+void sort(
+    Tensor& values,
+    Tensor& indices,
     const Tensor& input,
     const Dim axis,
     const SortMode sortMode = SortMode::Descending);

--- a/flashlight/fl/tensor/TensorExtension.cpp
+++ b/flashlight/fl/tensor/TensorExtension.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "flashlight/fl/tensor/TensorExtension.h"
+
+#include <stdexcept>
+
+namespace fl {
+namespace detail {
+
+bool TensorExtensionRegistrar::registerTensorExtension(
+    TensorBackendType backend,
+    TensorExtensionType extensionType,
+    TensorExtensionCallback&& creationFunc) {
+  auto& _extensions = (*extensions_
+                            .try_emplace(
+                                backend,
+                                std::unordered_map<
+                                    TensorExtensionType,
+                                    TensorExtensionCallback>())
+                            .first)
+                          .second;
+
+  // Add extension to registry
+  _extensions.try_emplace(extensionType, std::move(creationFunc));
+  return true;
+}
+
+TensorExtensionCallback&
+TensorExtensionRegistrar::getTensorExtensionCreationFunc(
+    TensorBackendType backend,
+    TensorExtensionType extensionType) {
+  if (extensions_.find(backend) == extensions_.end()) {
+    throw std::invalid_argument(
+        "TensorExtensionRegistrar::getTensorExtensionCreationFunc: "
+        "no tensor extensions registered for given backend.");
+  }
+  auto& _extensions = extensions_[backend];
+  if (_extensions.find(extensionType) == _extensions.end()) {
+    throw std::invalid_argument(
+        "TensorExtensionRegistrar::getTensorExtensionCreationFunc: "
+        "given extension type is not registered for this backend.");
+  }
+  return _extensions[extensionType];
+}
+
+TensorExtensionRegistrar& TensorExtensionRegistrar::getInstance() {
+  static TensorExtensionRegistrar instance;
+  return instance;
+}
+
+} // namespace detail
+} // namespace fl

--- a/flashlight/fl/tensor/TensorExtension.h
+++ b/flashlight/fl/tensor/TensorExtension.h
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <type_traits>
+#include <unordered_map>
+
+#include "flashlight/fl/tensor/TensorBase.h"
+
+namespace fl {
+
+/**
+ * A runtime type denoting the tensor extension.
+ */
+enum class TensorExtensionType {
+  Generic, // placeholder
+  Autograd,
+  Vision
+};
+
+// Common base type
+class TensorExtensionBase {
+ public:
+  virtual ~TensorExtensionBase() = default;
+
+  virtual bool isDataTypeSupported(const fl::dtype& dtype) = 0;
+};
+
+namespace detail {
+
+using TensorExtensionCallback =
+    std::function<std::unique_ptr<TensorExtensionBase>()>;
+
+/**
+ * Employ an extensible factory singleton pattern to handle creation callbacks
+ * for creating specific TensorExtension instances.
+ *
+ * Users should not directly use this singleton and should instead
+ */
+class TensorExtensionRegistrar {
+  // Intentionally private. Only one instance should exist/it should be accessed
+  // via getInstance().
+  TensorExtensionRegistrar() = default;
+
+  // TODO(jacobkahn): change this to an array and have indices for extension
+  // types correspond to extension instances
+  std::unordered_map<
+      TensorBackendType,
+      std::unordered_map<TensorExtensionType, TensorExtensionCallback>>
+      extensions_;
+
+ public:
+  bool registerTensorExtension(
+      TensorBackendType backend,
+      TensorExtensionType extensionType,
+      TensorExtensionCallback&& creationFunc);
+
+  static TensorExtensionRegistrar& getInstance();
+  ~TensorExtensionRegistrar() = default;
+
+  template <typename T>
+  bool registerTensorExtension(TensorBackendType backend) {
+    // TODO: use a static T::create instead of a lambda if we can enforce its
+    // declaration and definition on interface functions
+    return this->registerTensorExtension(
+        backend, T::getExtensionType(), []() -> std::unique_ptr<T> {
+          return std::make_unique<T>();
+        });
+  }
+
+  TensorExtensionCallback& getTensorExtensionCreationFunc(
+      TensorBackendType backend,
+      TensorExtensionType extensionType);
+};
+
+} // namespace detail
+
+/**
+ * Register a tensor extension. Template type T is the type of the tensor
+ * extension
+ *
+ * @param[in] backendType the type of ht ebackend to register the extension to.
+ * See TensorBackendType.
+ */
+template <typename T>
+bool registerTensorExtension(TensorBackendType backendType) {
+  return detail::TensorExtensionRegistrar::getInstance()
+      .registerTensorExtension<T>(backendType);
+}
+
+template <typename T>
+class TensorExtension : public TensorExtensionBase {
+ public:
+  static TensorExtensionType getExtensionType() {
+    return T::extensionType;
+  }
+};
+
+/**
+ * Register a tensor extension.
+ *
+ * @param[in] T the class type of the tensor extension
+ * @param[in] backendType the type of ht ebackend to register the extension to.
+ * See TensorBackendType.
+ */
+#define FL_REGISTER_TENSOR_EXTENSION(T, BACKEND_TYPE)                \
+  static_assert(                                                     \
+      std::is_same<decltype(T::registered), bool>::value,            \
+      "Registered Tensor extension does not have static bool field " \
+      "called \"registered\"");                                      \
+  bool T::registered = ::fl::registerTensorExtension<T>(BACKEND_TYPE);
+
+} // namespace fl

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
@@ -17,7 +17,10 @@
 #include <af/random.h>
 
 #include <algorithm>
+#include <cstdlib>
 #include <numeric>
+#include <optional>
+#include <sstream>
 #include <stdexcept>
 
 #include "flashlight/fl/tensor/TensorBase.h"
@@ -27,7 +30,7 @@
 namespace fl {
 namespace {
 
-typedef af::array (*reduceFunc_t)(const af::array&, const int);
+using reduceFunc_t = af::array (*)(const af::array&, const int);
 
 template <typename T = reduceFunc_t>
 af::array afReduceAxes(
@@ -70,6 +73,49 @@ bool isAllAxisReduction(const Tensor& input, const std::vector<int>& axes) {
     }
   }
   return true;
+}
+
+bool canBroadcast(const Shape& lhs, const Shape& rhs) {
+  unsigned nDim = std::max(lhs.ndim(), rhs.ndim());
+
+  for (unsigned i = 0; i < nDim; ++i) {
+    if (i + 1 > lhs.ndim() || i + 1 > rhs.ndim()) {
+      // One Shape has more dimensions than the other - will broadcast to the
+      // smaller tensor
+      continue;
+    }
+    if (lhs[i] != rhs[i] && lhs[i] != 1 && rhs[i] != 1) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// A binary operation on two ArrayFire arrays
+using binaryOpFunc_t =
+    af::array (*)(const af::array& lhs, const af::array& rhs);
+
+Tensor doBinaryOpOrBroadcast(
+    const Tensor& lhs,
+    const Tensor& rhs,
+    binaryOpFunc_t func) {
+  // Dims are the same or scalar <> 1-el tensor - no broadcasting
+  if (lhs.shape() == rhs.shape() || (lhs.size() <= 1 && rhs.size() <= 1)) {
+    return toTensor<ArrayFireTensor>(
+        func(toArray(lhs), toArray(rhs)), lhs.ndim());
+  }
+
+  if (canBroadcast(lhs.shape(), rhs.shape())) {
+    return toTensor<ArrayFireTensor>(
+        af::batchFunc(toArray(lhs), toArray(rhs), func),
+        std::max(lhs.ndim(), rhs.ndim()));
+  } else {
+    std::stringstream ss;
+    ss << "doBinaryOpOrBroadcast: cannot perform operation "
+          "or broadcasting with tensors of shapes "
+       << lhs.shape() << " and " << rhs.shape() << " - dimension mismatch.";
+    throw std::invalid_argument(ss.str());
+  }
 }
 
 } // namespace
@@ -498,19 +544,10 @@ Tensor ArrayFireBackend::argsort(
 
 // Operations on fl::Tensor call the respective operator overloads that are
 // already defined on af::arrays
-#define FL_AF_BINARY_OP_DEF(OP, FUNC)                                          \
-  Tensor ArrayFireBackend::FUNC(const Tensor& lhs, const Tensor& rhs) {        \
-    if (lhs.ndim() != rhs.ndim()) {                                            \
-      std::stringstream ss;                                                    \
-      ss << "ArrayFireTensor arguments to operator " << std::string(#OP)       \
-         << " (" << std::string(#FUNC) << ") "                                 \
-         << "have a differing number of dimensions " << lhs.shape() << " and " \
-         << rhs.shape();                                                       \
-      throw std::invalid_argument(ss.str());                                   \
-    }                                                                          \
-    return toTensor<ArrayFireTensor>(                                          \
-        toArray(lhs) OP toArray(rhs), lhs.ndim());                             \
-  }                                                                            \
+#define FL_AF_BINARY_OP_DEF(OP, FUNC)                                   \
+  Tensor ArrayFireBackend::FUNC(const Tensor& lhs, const Tensor& rhs) { \
+    return doBinaryOpOrBroadcast(lhs, rhs, af::operator OP);            \
+  }                                                                     \
   FL_AF_BINARY_OP_LITERALS_DEF(FUNC, OP);
 
 // Definitions
@@ -539,18 +576,15 @@ FL_AF_BINARY_OP_DEF(>>, rShift);
 #undef FL_AF_BINARY_OP_LITERALS_DEF
 
 Tensor ArrayFireBackend::minimum(const Tensor& lhs, const Tensor& rhs) {
-  return toTensor<ArrayFireTensor>(
-      af::min(toArray(lhs), toArray(rhs)), lhs.ndim());
+  return doBinaryOpOrBroadcast(lhs, rhs, af::min);
 }
 
 Tensor ArrayFireBackend::maximum(const Tensor& lhs, const Tensor& rhs) {
-  return toTensor<ArrayFireTensor>(
-      af::max(toArray(lhs), toArray(rhs)), lhs.ndim());
+  return doBinaryOpOrBroadcast(lhs, rhs, af::max);
 }
 
 Tensor ArrayFireBackend::power(const Tensor& lhs, const Tensor& rhs) {
-  return toTensor<ArrayFireTensor>(
-      af::pow(toArray(lhs), toArray(rhs)), lhs.ndim());
+  return doBinaryOpOrBroadcast(lhs, rhs, af::pow);
 }
 
 /************************** BLAS ***************************/

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
@@ -129,6 +129,10 @@ ArrayFireBackend& ArrayFireBackend::getInstance() {
   return instance;
 }
 
+TensorBackendType ArrayFireBackend::backendType() const {
+  return TensorBackendType::ArrayFire;
+}
+
 /* -------------------------- Compute Functions -------------------------- */
 
 void ArrayFireBackend::sync() {

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
@@ -121,6 +121,12 @@ class ArrayFireBackend : public TensorBackend {
       const SortMode sortMode) override;
   Tensor sort(const Tensor& input, const Dim axis, const SortMode sortMode)
       override;
+  void sort(
+      Tensor& values,
+      Tensor& indices,
+      const Tensor& input,
+      const Dim axis,
+      const SortMode sortMode) override;
   Tensor argsort(const Tensor& input, const Dim axis, const SortMode sortMode)
       override;
 

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
@@ -27,8 +27,8 @@ class ArrayFireBackend : public TensorBackend {
 
  public:
   static ArrayFireBackend& getInstance();
-
   ~ArrayFireBackend() override = default;
+  TensorBackendType backendType() const override;
 
   // No copy or move construction or assignment
   ArrayFireBackend(ArrayFireBackend&&) = delete;

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
@@ -336,8 +336,12 @@ void* ArrayFireTensor::getContext() {
   return nullptr; // noop
 }
 
+std::string ArrayFireTensor::toString() {
+  return std::string(af::toString("ArrayFireTensor", getHandle()));
+}
+
 std::ostream& ArrayFireTensor::operator<<(std::ostream& ostr) {
-  ostr << "ArrayFireTensor " << std::string(af::toString("", getHandle()));
+  ostr << this->toString();
   return ostr;
 }
 

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
@@ -200,6 +200,7 @@ class ArrayFireTensor : public TensorAdapterBase {
   Tensor asContiguousTensor() override;
   void setContext(void* context) override; // noop
   void* getContext() override; // noop
+  std::string toString() override;
   std::ostream& operator<<(std::ostream& ostr) override;
 
   /******************** Assignment Operators ********************/

--- a/flashlight/fl/tensor/backend/af/Utils.cpp
+++ b/flashlight/fl/tensor/backend/af/Utils.cpp
@@ -194,9 +194,6 @@ af::array condenseIndices(
   af::dim4 newDims(1, 1, 1, 1);
   unsigned newDimIdx = 0;
   for (unsigned i = 0; i < AF_MAX_DIMS; ++i) {
-    if (dims[i] == 1 && indexTypes && indexTypes.value().size() > i) {
-    }
-
     // If we're doing an index op (indexTypes is non-empty), then only collapse
     // the dimension if it contains an index literal
     if (dims[i] == 1 && indexTypes && indexTypes.value().size() > i &&

--- a/flashlight/fl/test/tensor/ArrayFireTensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/ArrayFireTensorBaseTest.cpp
@@ -289,16 +289,16 @@ TEST(ArrayFireTensorBaseTest, var) {
   ASSERT_EQ(fl::var(a).scalar<float>(), af::var<float>(toArray(a)));
   ASSERT_TRUE(allClose(
       toArray(fl::var(a, {0})),
-      detail::condenseIndices(af::var(toArray(a), AF_VARIANCE_POPULATION, 0))));
+      detail::condenseIndices(af::var(toArray(a), /* biased = */ false, 0))));
   ASSERT_TRUE(allClose(
       toArray(fl::var(a, {1})),
-      detail::condenseIndices(af::var(toArray(a), AF_VARIANCE_POPULATION, 1))));
+      detail::condenseIndices(af::var(toArray(a), /* biased = */ false, 1))));
   // Make sure multidimension matches computing for all
   ASSERT_FLOAT_EQ(
       toArray(fl::var(a)).scalar<float>(), af::var<float>(toArray(a)));
   ASSERT_FLOAT_EQ(
-      toArray(fl::var(a, {0, 1}, true)).scalar<float>(),
-      af::var<float>(toArray(a), AF_VARIANCE_SAMPLE));
+      toArray(fl::var(a, {0, 1}, /* biased = */ true)).scalar<float>(),
+      af::var<float>(toArray(a), /* biased = */ true));
 }
 
 TEST(ArrayFireTensorBaseTest, std) {

--- a/flashlight/fl/test/tensor/IndexTest.cpp
+++ b/flashlight/fl/test/tensor/IndexTest.cpp
@@ -201,6 +201,11 @@ TEST(IndexTest, flat) {
             .scalar<float>(),
         i + 1 - 10);
   }
+
+  // Range flat assignment
+  auto rA = fl::rand({6});
+  a.flat(fl::range(1, 7)) = rA;
+  ASSERT_TRUE(allClose(rA, a.flatten()(fl::range(1, 7))));
 }
 
 TEST(IndexTest, TensorIndex) {
@@ -223,13 +228,19 @@ TEST(IndexTest, TensorIndex) {
   auto i = fl::arange({10}, 0, fl::dtype::u32);
   auto b = fl::rand({20, 20});
   auto ref = b;
-  ASSERT_TRUE(allClose(b(i), b(fl::range(10), 0)));
+  ASSERT_EQ(b(i).shape(), b(fl::range(10)).shape());
+  ASSERT_TRUE(allClose(b(i), b(fl::range(10))));
 
   b(i) += 3.;
-  ASSERT_TRUE(allClose(b(i), b(fl::range(10), 0)));
+  ASSERT_TRUE(allClose(b(i), b(fl::range(10))));
   ASSERT_TRUE(allClose(b(i), (ref + 3)(i)));
-  b(i) += fl::full({(Dim)i.size()}, 10.);
+  b(i) += fl::full({(Dim)i.size(), b.dim(1)}, 10.);
+  ASSERT_EQ(b(i).shape(), (ref + 13)(i).shape());
   ASSERT_TRUE(allClose(b(i), (ref + 13)(i)));
+
+  // Tensor index a > 1D tensor
+  auto c = fl::rand({10, 10, 10});
+  ASSERT_EQ(c(fl::arange({5})).shape(), Shape({5, 10, 10}));
 }
 
 TEST(IndexTest, ExpressionIndex) {

--- a/flashlight/fl/test/tensor/ShapeTest.cpp
+++ b/flashlight/fl/test/tensor/ShapeTest.cpp
@@ -71,3 +71,18 @@ TEST(ShapeTest, Indexing) {
   ASSERT_EQ(a[3], 2);
   ASSERT_THROW(a[4], std::invalid_argument);
 }
+
+TEST(ShapeTest, string) {
+  auto checkShapeStrEqual = [](const Shape& s, const std::string& str) -> void {
+    auto sStr = s.toString();
+    ASSERT_EQ(sStr, str);
+    std::stringstream ss;
+    ss << sStr;
+    ASSERT_EQ(sStr, ss.str());
+  };
+
+  checkShapeStrEqual(Shape({3, 4, 7, 9}), "(3, 4, 7, 9)");
+  checkShapeStrEqual(Shape({}), "()");
+  checkShapeStrEqual(Shape({0}), "(0)");
+  checkShapeStrEqual(Shape({7, 7, 7, 7, 7, 7, 7}), "(7, 7, 7, 7, 7, 7, 7)");
+}

--- a/flashlight/fl/test/tensor/ShapeTest.cpp
+++ b/flashlight/fl/test/tensor/ShapeTest.cpp
@@ -62,3 +62,12 @@ TEST(ShapeTest, Equality) {
   ASSERT_EQ(Shape({5, 2, 3, 1}), Shape({5, 2, 3, 1}));
   ASSERT_NE(Shape({5, 2, 1, 1}), Shape({5, 2, 1, 4}));
 }
+
+TEST(ShapeTest, Indexing) {
+  auto a = Shape({3, 4, 5, 2});
+  ASSERT_EQ(a[0], 3);
+  ASSERT_EQ(a[1], 4);
+  ASSERT_EQ(a[2], 5);
+  ASSERT_EQ(a[3], 2);
+  ASSERT_THROW(a[4], std::invalid_argument);
+}

--- a/flashlight/fl/test/tensor/TensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/TensorBaseTest.cpp
@@ -67,11 +67,13 @@ TEST(TensorBaseTest, fromScalar) {
   ASSERT_EQ(a.shape(), Shape({}));
 }
 
-TEST(TensorBaseTest, ostream) {
+TEST(TensorBaseTest, string) {
   // Different backends might print tensors differently - check for consistency
   // across two identical tensors
   auto a = fl::full({3, 4, 5}, 6.);
   auto b = fl::full({3, 4, 5}, 6.);
+  ASSERT_EQ(a.toString(), b.toString());
+
   std::stringstream ssa, ssb;
   ssa << a;
   ssb << b;

--- a/flashlight/fl/test/tensor/TensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/TensorBaseTest.cpp
@@ -709,6 +709,14 @@ TEST(TensorBaseTest, sort) {
   ASSERT_TRUE(allClose(sorted, tiled));
 
   ASSERT_TRUE(allClose(a, fl::sort(tiled, 0, SortMode::Ascending)));
+
+  auto b = fl::rand({10});
+  Tensor values, indices;
+  fl::sort(values, indices, b, /* axis = */ 0, SortMode::Descending);
+  ASSERT_TRUE(
+      allClose(values, fl::sort(b, /* axis = */ 0, SortMode::Descending)));
+  ASSERT_TRUE(
+      allClose(fl::argsort(b, /* axis = */ 0, SortMode::Descending), indices));
 }
 
 TEST(TensorBaseTest, argsort) {

--- a/flashlight/fl/test/tensor/TensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/TensorBaseTest.cpp
@@ -735,6 +735,10 @@ TEST(TensorBaseTest, power) {
 TEST(TensorBaseTest, powerDouble) {
   auto a = fl::full({3, 3}, 2.);
   ASSERT_TRUE(allClose(fl::power(a, 3), a * a * a));
+
+  auto b = fl::full({3, 3}, 2.);
+  ASSERT_TRUE(
+      allClose(fl::power(3, a), fl::full(b.shape(), 3 * 3, fl::dtype::f32)));
 }
 
 TEST(TensorBaseTest, floor) {

--- a/flashlight/fl/test/tensor/TensorExtensionTest.cpp
+++ b/flashlight/fl/test/tensor/TensorExtensionTest.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <cmath>
+#include <stdexcept>
+
+#include <gtest/gtest.h>
+
+#include "flashlight/fl/tensor/Index.h"
+#include "flashlight/fl/tensor/Random.h"
+#include "flashlight/fl/tensor/TensorBackend.h"
+#include "flashlight/fl/tensor/TensorBase.h"
+#include "flashlight/fl/tensor/TensorExtension.h"
+
+using namespace ::testing;
+using namespace fl;
+
+// Extension interface
+class TestTensorExtension : public TensorExtension<TestTensorExtension> {
+ public:
+  static constexpr TensorExtensionType extensionType =
+      TensorExtensionType::Generic;
+
+  TestTensorExtension() = default;
+  virtual ~TestTensorExtension() = default;
+
+  virtual Tensor testExtensionFunc(const Tensor& tensor) = 0;
+};
+
+// Specific extension implementation
+class TestArrayFireTensorExtension : public TestTensorExtension {
+ public:
+  static bool registered;
+
+  Tensor testExtensionFunc(const Tensor& tensor) override {
+    return tensor + 1;
+  }
+
+  bool isDataTypeSupported(const fl::dtype&) {
+    return true;
+  }
+};
+
+// Op in API
+Tensor testExtensionFunc(const Tensor& tensor) {
+  return tensor.backend().getExtension<TestTensorExtension>().testExtensionFunc(
+      tensor);
+}
+
+FL_REGISTER_TENSOR_EXTENSION(
+    TestArrayFireTensorExtension,
+    TensorBackendType::ArrayFire);
+
+TEST(TensorExtensionTest, TestExtension) {
+  auto a = fl::rand({4, 5, 6});
+  ASSERT_TRUE(TestArrayFireTensorExtension::registered);
+
+  // TODO: this test only works with the ArrayFire backend - gate accordingly
+  if (Tensor().backendType() != TensorBackendType::ArrayFire) {
+    GTEST_SKIP() << "Flashlight not built with ArrayFire backend.";
+  }
+
+  // TODO: add a fixture to check with available backends
+  // Already registered - returns true
+  ASSERT_TRUE(::fl::registerTensorExtension<TestArrayFireTensorExtension>(
+      TensorBackendType::ArrayFire));
+
+  ASSERT_TRUE(allClose(testExtensionFunc(a), a + 1));
+}


### PR DESCRIPTION
Summary: See title. Add `Tensor::toString()` and `Shape::toString()` explicitly and use in `operator<<` for `ArrayFireTensor`.

Reviewed By: benoitsteiner

Differential Revision: D33159894

