### PR TITLE
Fix flat indexing with leading singleton dims, don't use AF handles for concat

### DIFF
--- a/flashlight/fl/tensor/TensorBackend.h
+++ b/flashlight/fl/tensor/TensorBackend.h
@@ -86,7 +86,7 @@ class TensorBackend {
   virtual Tensor tile(const Tensor& tensor, const Shape& shape) = 0;
   virtual Tensor concatenate(
       const std::vector<Tensor>& tensors,
-      unsigned axis) = 0;
+      const unsigned axis) = 0;
   virtual Tensor nonzero(const Tensor& tensor) = 0;
   virtual Tensor pad(
       const Tensor& input,

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -364,13 +364,13 @@ Tensor tile(const Tensor& tensor, const Shape& shape) {
   return tensor.backend().tile(tensor, shape);
 }
 
-Tensor concatenate(const std::vector<Tensor>& tensors, unsigned axis) {
+Tensor concatenate(const std::vector<Tensor>& tensors, const unsigned axis) {
   if (tensors.empty()) {
     throw std::invalid_argument("concatenate: called on empty set of tensors");
   }
 
   // Check all backends match
-  TensorBackendType b = tensors.front().backendType();
+  const TensorBackendType b = tensors.front().backendType();
   const bool matches =
       std::all_of(tensors.begin(), tensors.end(), [b](const Tensor& t) {
         return t.backendType() == b;

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -700,7 +700,7 @@ Tensor tile(const Tensor& tensor, const Shape& shape);
  * @param[in] tensors a vector of tensors to concatenate
  * @return a concatenated tensor
  */
-Tensor concatenate(const std::vector<Tensor>& tensors, unsigned axis = 0);
+Tensor concatenate(const std::vector<Tensor>& tensors, const unsigned axis = 0);
 
 /**
  * Join or concatenate tensors together along a particular axis.

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
@@ -80,7 +80,7 @@ class ArrayFireBackend : public TensorBackend {
   Tensor reshape(const Tensor& tensor, const Shape& shape) override;
   Tensor transpose(const Tensor& tensor, const Shape& axes /* = {} */) override;
   Tensor tile(const Tensor& tensor, const Shape& shape) override;
-  Tensor concatenate(const std::vector<Tensor>& tensors, unsigned axis)
+  Tensor concatenate(const std::vector<Tensor>& tensors, const unsigned axis)
       override;
   Tensor nonzero(const Tensor& tensor) override;
   Tensor pad(

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
@@ -53,7 +53,9 @@ class ArrayFireTensor : public TensorAdapterBase {
   // To be visited when this tensor is to be indexed. Indexes the underlying
   // af::array, and returns the proxy to be used as a temporary lvalue.
   struct IndexedArrayComponent {
+    explicit IndexedArrayComponent(const bool _isFlat = false);
     af::array::array_proxy get(const ArrayFireTensor& inst);
+    bool isFlat;
   };
   // To be visited when this tensor is holding an array without needing
   // indexing. Passthrough - returns the array directly.
@@ -79,12 +81,16 @@ class ArrayFireTensor : public TensorAdapterBase {
    *
    * @param[in] handle a pointer to the ArrayFire array
    * @param[in] indices a vector of ArrayFire indices to lazily index.
+   * @param[in] indexTypes a vector of index types to lazily index. Needed to
+   * determine singleton dimension condensation
+   * @param[in] isFlat if the indexing op is flat (condense all dims)
    */
   ArrayFireTensor(
       std::shared_ptr<af::array> handle,
       std::vector<af::index>&& afIndices,
       std::vector<detail::IndexType>&& indexTypes,
-      unsigned numDims);
+      const unsigned numDims,
+      const bool isFlat);
 
   /**
    * Construct an ArrayFireTensor from an ArrayFire array handle without copying

--- a/flashlight/fl/tensor/backend/af/Utils.cpp
+++ b/flashlight/fl/tensor/backend/af/Utils.cpp
@@ -178,9 +178,9 @@ af::dim4 condenseDims(const af::dim4& dims) {
 
 af::array condenseIndices(
     const af::array& arr,
-    bool keepDims /* = false */,
-    const std::optional<std::vector<detail::IndexType>>&
-        indexTypes /* = {} */) {
+    const bool keepDims /* = false */,
+    const std::optional<std::vector<detail::IndexType>>& indexTypes /* = {} */,
+    const bool isFlat /* = false */) {
   // Fast path - return the Array as is if keepDims - don't consolidate
   if (keepDims) {
     return arr;
@@ -195,9 +195,10 @@ af::array condenseIndices(
   unsigned newDimIdx = 0;
   for (unsigned i = 0; i < AF_MAX_DIMS; ++i) {
     // If we're doing an index op (indexTypes is non-empty), then only collapse
-    // the dimension if it contains an index literal
+    // the dimension if it contains an index literal and we aren't doing flat
+    // indexing (which collapses all dims)
     if (dims[i] == 1 && indexTypes && indexTypes.value().size() > i &&
-        indexTypes.value()[i] != detail::IndexType::Literal) {
+        indexTypes.value()[i] != detail::IndexType::Literal && !isFlat) {
       newDims[newDimIdx] = 1;
       newDimIdx++;
     } else if (dims[i] != 1) {

--- a/flashlight/fl/tensor/backend/af/Utils.h
+++ b/flashlight/fl/tensor/backend/af/Utils.h
@@ -89,8 +89,9 @@ af::dim4 condenseDims(const af::dim4& dims);
  */
 af::array condenseIndices(
     const af::array& arr,
-    bool keepDims = false,
-    const std::optional<std::vector<detail::IndexType>>& indexTypes = {});
+    const bool keepDims = false,
+    const std::optional<std::vector<detail::IndexType>>& indexTypes = {},
+    const bool isFlat = false);
 
 /**
  * Convert a Flashlight Location into an ArrayFire location (host or device).

--- a/flashlight/fl/test/tensor/IndexTest.cpp
+++ b/flashlight/fl/test/tensor/IndexTest.cpp
@@ -206,6 +206,12 @@ TEST(IndexTest, flat) {
   auto rA = fl::rand({6});
   a.flat(fl::range(1, 7)) = rA;
   ASSERT_TRUE(allClose(rA, a.flatten()(fl::range(1, 7))));
+
+  // With leading singleton dims
+  auto b = fl::rand({1, 1, 10});
+  ASSERT_EQ(b.flat(fl::range(3)).shape(), Shape({3}));
+  b.flat(fl::range(3)) = fl::full({3}, 6.);
+  ASSERT_TRUE(allClose(b.flatten()(fl::range(3)), fl::full({3}, 6.)));
 }
 
 TEST(IndexTest, TensorIndex) {

--- a/flashlight/fl/test/tensor/TensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/TensorBaseTest.cpp
@@ -231,6 +231,30 @@ TEST(TensorBaseTest, concatenate) {
       allClose(fl::concatenate(0, a, b, c), fl::concatenate({a, b, c})));
   auto out = fl::concatenate(0, a, b, c);
   ASSERT_EQ(out.shape(), Shape({9, 3}));
+
+  // Empty tenors
+  ASSERT_EQ(fl::concatenate(0, Tensor(), Tensor()).shape(), Shape({0}));
+  ASSERT_EQ(fl::concatenate(2, Tensor(), Tensor()).shape(), Shape({0, 1, 1}));
+  ASSERT_EQ(
+      fl::concatenate(1, fl::rand({5, 5}), Tensor()).shape(), Shape({5, 5}));
+
+  // More tensors
+  // TODO{fl::Tensor}{concat} just concat everything once we enforce
+  // arbitrarily-many tensors
+  const float val = 3.;
+  const int axis = 0;
+  auto t = fl::concatenate(
+      axis,
+      fl::full({4, 2}, val),
+      fl::full({4, 2}, val),
+      fl::full({4, 2}, val),
+      fl::concatenate(
+          axis,
+          fl::full({4, 2}, val),
+          fl::full({4, 2}, val),
+          fl::full({4, 2}, val)));
+  ASSERT_EQ(t.shape(), Shape({24, 2}));
+  ASSERT_TRUE(allClose(t, fl::full({24, 2}, val)));
 }
 
 TEST(TensorBaseTest, nonzero) {
@@ -1277,6 +1301,12 @@ TEST(TensorBaseTest, pad) {
   auto symmetricPadded = fl::pad(t, {{1, 1}, {2, 2}}, PadType::Symmetric);
   ASSERT_TRUE(allClose(
       symmetricPadded,
+      // TODO{fl::Tensor}{concat} just concat everything once we enforce
+      // arbitrarily-many tensors
       fl::concatenate(
-          1, vTiled1, vTiled0, vTiled0, vTiled1, vTiled1, vTiled0)));
+          1,
+          vTiled1,
+          vTiled0,
+          vTiled0,
+          fl::concatenate(1, vTiled1, vTiled1, vTiled0))));
 }


### PR DESCRIPTION
Summary:
Flat indexing behavior was broken for tensors with leading singleton dims because dimensions wouldn't be collapsed when doing lazy flat indexing. Because there's no way to know whether or not flat indexing was requested a posteriori (once you only have an `fl::Index` and an `IndexType`), store a flag on `IndexedArrayComponent` to indicate this, which will always result in a total dim collapse to a 1D tensor. Add tests checking this case.

Second -- using `af_join_many` with Array handles failed for cases with empty `af::array`s, which broke some subtle autograd things (RNN weight reordering with oneDNN). Swap to use `af::join` which properly handles empty tensors, and add tests.

Differential Revision: D33768148

