### PR TITLE
Use new CircleCI instance types

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,8 @@ version: 2.1
 
 gpu: &gpu
   machine:
-    image: ubuntu-1604-cuda-11.1:202012-01
-  resource_class: gpu.small
+    image: ubuntu-2004-cuda-11.4:202110-01
+  resource_class: gpu.nvidia.medium
 
 commands:
   ############################### Docker Commands ###############################
@@ -35,7 +35,7 @@ commands:
       - run:
           name: "Start NVIDIA Docker and Copy Flashlight source"
           command: |
-            sudo docker run --runtime=nvidia --rm -itd --ipc=host --name flashlight flml/flashlight:cuda-base-latest
+            sudo docker run --gpus all --rm -itd --ipc=host --name flashlight flml/flashlight:cuda-base-latest
             sudo docker exec -it flashlight bash -c "mkdir /flashlight"
             sudo docker cp . flashlight:/flashlight
   # Default cmake inside docker will be tested with docker build
@@ -394,11 +394,11 @@ jobs:
       - start_nvidia_docker_and_copy_flashlight_source
       - build_flashlight_inside_nvidia_docker:
           fl_backend: "CUDA"
-          fl_build_lib_set:  "ON"
-          fl_build_lib_sequence:  "ON"
-          fl_build_lib_audio:  "ON"
-          fl_build_lib_common:  "ON"
-          fl_build_lib_text:  "ON"
+          fl_build_lib_set: "ON"
+          fl_build_lib_sequence: "ON"
+          fl_build_lib_audio: "ON"
+          fl_build_lib_common: "ON"
+          fl_build_lib_text: "ON"
       - test_flashlight_inside_nvidia_docker:
           test_name: "fl_lib_common"
           fl_test_apex_dir: "flashlight/lib/common/test"
@@ -421,11 +421,11 @@ jobs:
       - build_flashlight_inside_nvidia_docker:
           fl_backend: "CUDA"
           fl_build_fl_core: "ON"
-          fl_build_lib_set:  "ON"
-          fl_build_lib_sequence:  "ON"
-          fl_build_lib_audio:  "ON"
-          fl_build_lib_common:  "ON"
-          fl_build_lib_text:  "ON"
+          fl_build_lib_set: "ON"
+          fl_build_lib_sequence: "ON"
+          fl_build_lib_audio: "ON"
+          fl_build_lib_common: "ON"
+          fl_build_lib_text: "ON"
           fl_build_pkg_runtime: "ON"
           fl_build_pkg_speech: "ON"
           fl_build_pkg_vision: "ON"
@@ -538,11 +538,11 @@ jobs:
       - build_flashlight_inside_nvidia_docker:
           fl_backend: "CUDA"
           fl_build_fl_core: "ON"
-          fl_build_lib_set:  "ON"
-          fl_build_lib_sequence:  "ON"
-          fl_build_lib_audio:  "ON"
-          fl_build_lib_common:  "ON"
-          fl_build_lib_text:  "ON"
+          fl_build_lib_set: "ON"
+          fl_build_lib_sequence: "ON"
+          fl_build_lib_audio: "ON"
+          fl_build_lib_common: "ON"
+          fl_build_lib_text: "ON"
           fl_build_pkg_runtime: "ON"
           fl_build_pkg_speech: "ON"
           fl_build_pkg_vision: "ON"

--- a/flashlight/pkg/text/data/TextDataset.cpp
+++ b/flashlight/pkg/text/data/TextDataset.cpp
@@ -23,15 +23,6 @@ namespace fl {
 namespace pkg {
 namespace text {
 
-namespace {
-
-// Maximum number of tokens to keep in memory for each `TextDataset` instance.
-// Setting the default value to 10,000,000,000 which requires 40GB in memory,
-// since indices are stored as int32.
-constexpr size_t kMaxTokenInBuffer = 10000000000;
-
-} // namespace
-
 TextDataset::TextDataset(
     const std::string& dataDirectory,
     const std::string& filenames,
@@ -41,13 +32,14 @@ TextDataset::TextDataset(
     int64_t tokensPerSample /* = 1024 */,
     int64_t batchSize /* = 1 */,
     const std::string& sampleBreakMode /* = "none" */,
-    bool useDynamicBatching /* = false */)
+    const bool useDynamicBatching /* = false */,
+    const size_t reserveSpaceSize /* = kMaxTokenInBuffer */)
     : pad_(dictionary.getIndex(fl::lib::text::kPadToken)) {
   /* 1. Read data */
   // data_ will have the following layout:
   // <eos> sentence <eos> sentence <eos> ... <eos> sentence <eos>
   data_.clear();
-  data_.reserve(kMaxTokenInBuffer);
+  data_.reserve(reserveSpaceSize);
   const auto eos = dictionary.getIndex(fl::lib::text::kEosToken);
   data_.push_back(eos);
 

--- a/flashlight/pkg/text/data/TextDataset.h
+++ b/flashlight/pkg/text/data/TextDataset.h
@@ -19,6 +19,15 @@ namespace fl {
 namespace pkg {
 namespace text {
 
+namespace {
+
+// Maximum number of tokens to keep in memory for each `TextDataset` instance.
+// Setting the default value to 10,000,000,000 which requires 40GB in memory,
+// since indices are stored as int32.
+constexpr size_t kMaxTokenInBuffer = 10000000000;
+
+} // namespace
+
 /**
  * TextDataset prepares text data for LM training. It returns a single tensor of
  * the indices for a given batched text. The indices are the token ID of each
@@ -59,7 +68,8 @@ class TextDataset : public fl::Dataset {
       int64_t tokensPerSample = 1024,
       int64_t batchSize = 1,
       const std::string& sampleBreakMode = "none",
-      bool useDynamicBatching = false);
+      const bool useDynamicBatching = false,
+      const size_t reserveSpaceSize = kMaxTokenInBuffer);
 
   int64_t size() const override;
 

--- a/flashlight/pkg/text/test/data/TextDatasetTest.cpp
+++ b/flashlight/pkg/text/test/data/TextDatasetTest.cpp
@@ -10,12 +10,12 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include "flashlight/pkg/text/data/TextDataset.h"
 #include "flashlight/fl/common/Init.h"
 #include "flashlight/lib/text/dictionary/Defines.h"
 #include "flashlight/lib/text/dictionary/Dictionary.h"
 #include "flashlight/lib/text/tokenizer/PartialFileReader.h"
 #include "flashlight/lib/text/tokenizer/Tokenizer.h"
+#include "flashlight/pkg/text/data/TextDataset.h"
 
 using fl::lib::pathsConcat;
 using namespace fl::lib;
@@ -59,7 +59,9 @@ TEST(TextDatasetTest, NoneMode) {
       dictionary,
       tokensPerSample,
       batchSize,
-      "none");
+      "none",
+      /* useDynamicBatching = */ false,
+      /* reserveSpaceSize = */ 0);
 
   ASSERT_EQ(dataset.size(), 4);
   for (int i = 0; i < dataset.size(); i++) {
@@ -87,7 +89,9 @@ TEST(TextDatasetTest, EosMode) {
       dictionary,
       tokensPerSample,
       batchSize,
-      "eos");
+      "eos",
+      /* useDynamicBatching = */ false,
+      /* reserveSpaceSize = */ 0);
 
   ASSERT_EQ(dataset.size(), 4);
 
@@ -118,7 +122,8 @@ TEST(TextDatasetTest, EosModeWithDynamicBatching) {
       tokensPerSample,
       1,
       "eos",
-      true);
+      /* useDynamicBatching = */ true,
+      /* reserveSpaceSize = */ 0);
 
   ASSERT_EQ(dataset.size(), 4);
 


### PR DESCRIPTION
See title.

Also add a `useReserveSpace` flag with `TextDataset` which, when set to true (default), allocates 40 GB on the host for text loading. This OOMs on new, smaller CircleCI machines/isn't optimal for people with less memory. Can fix this further in the future.