### PR TITLE
Fix arith ops for broadcasting tests, make AF type maps static

### DIFF
--- a/flashlight/fl/tensor/backend/af/Utils.cpp
+++ b/flashlight/fl/tensor/backend/af/Utils.cpp
@@ -16,37 +16,37 @@
 namespace fl {
 namespace detail {
 
-const std::unordered_map<fl::dtype, af::dtype> kFlashlightTypeToArrayFire = {
-    {fl::dtype::f16, af::dtype::f16},
-    {fl::dtype::f32, af::dtype::f32},
-    {fl::dtype::f64, af::dtype::f64},
-    {fl::dtype::b8, af::dtype::b8},
-    {fl::dtype::s16, af::dtype::s16},
-    {fl::dtype::s32, af::dtype::s32},
-    {fl::dtype::s64, af::dtype::s64},
-    {fl::dtype::u8, af::dtype::u8},
-    {fl::dtype::u16, af::dtype::u16},
-    {fl::dtype::u32, af::dtype::u32},
-    {fl::dtype::u64, af::dtype::u64}};
-
-const std::unordered_map<af::dtype, fl::dtype> kArrayFireTypeToFlashlight = {
-    {af::dtype::f16, fl::dtype::f16},
-    {af::dtype::f32, fl::dtype::f32},
-    {af::dtype::f64, fl::dtype::f64},
-    {af::dtype::b8, fl::dtype::b8},
-    {af::dtype::s16, fl::dtype::s16},
-    {af::dtype::s32, fl::dtype::s32},
-    {af::dtype::s64, fl::dtype::s64},
-    {af::dtype::u8, fl::dtype::u8},
-    {af::dtype::u16, fl::dtype::u16},
-    {af::dtype::u32, fl::dtype::u32},
-    {af::dtype::u64, fl::dtype::u64}};
-
 af::dtype flToAfType(fl::dtype type) {
+  static const std::unordered_map<fl::dtype, af::dtype>
+      kFlashlightTypeToArrayFire = {
+          {fl::dtype::f16, af::dtype::f16},
+          {fl::dtype::f32, af::dtype::f32},
+          {fl::dtype::f64, af::dtype::f64},
+          {fl::dtype::b8, af::dtype::b8},
+          {fl::dtype::s16, af::dtype::s16},
+          {fl::dtype::s32, af::dtype::s32},
+          {fl::dtype::s64, af::dtype::s64},
+          {fl::dtype::u8, af::dtype::u8},
+          {fl::dtype::u16, af::dtype::u16},
+          {fl::dtype::u32, af::dtype::u32},
+          {fl::dtype::u64, af::dtype::u64}};
   return kFlashlightTypeToArrayFire.at(type);
 }
 
 fl::dtype afToFlType(af::dtype type) {
+  static const std::unordered_map<af::dtype, fl::dtype>
+      kArrayFireTypeToFlashlight = {
+          {af::dtype::f16, fl::dtype::f16},
+          {af::dtype::f32, fl::dtype::f32},
+          {af::dtype::f64, fl::dtype::f64},
+          {af::dtype::b8, fl::dtype::b8},
+          {af::dtype::s16, fl::dtype::s16},
+          {af::dtype::s32, fl::dtype::s32},
+          {af::dtype::s64, fl::dtype::s64},
+          {af::dtype::u8, fl::dtype::u8},
+          {af::dtype::u16, fl::dtype::u16},
+          {af::dtype::u32, fl::dtype::u32},
+          {af::dtype::u64, fl::dtype::u64}};
   return kArrayFireTypeToFlashlight.at(type);
 }
 

--- a/flashlight/fl/test/tensor/TensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/TensorBaseTest.cpp
@@ -458,8 +458,8 @@ TEST(TensorBaseTest, broadcasting) {
 
   for (auto funcp : functions) {
     for (auto& shapeData : shapes) {
-      auto lhs = (fl::rand(shapeData.lhs) * 10).astype(fl::dtype::s32);
-      auto rhs = (fl::rand(shapeData.rhs) * 10).astype(fl::dtype::s32);
+      auto lhs = ((fl::rand(shapeData.lhs) + 1) * 10).astype(fl::dtype::s32);
+      auto rhs = ((fl::rand(shapeData.rhs) + 1) * 10).astype(fl::dtype::s32);
 
       auto [actualOut, expectedOut] = doBinaryOp(
           lhs,


### PR DESCRIPTION
Summary:
- Fix a static init fiasco -- found this in CPU tests where we don't have huge NVIDIA drive init overhead
- Fix arith errors with `% 0` -- ensure broadcast test input tensors can't have zeros

Differential Revision: D33977793

