### PR TITLE
Add Tensor roll operator

### DIFF
--- a/flashlight/fl/tensor/TensorBackend.h
+++ b/flashlight/fl/tensor/TensorBackend.h
@@ -112,6 +112,8 @@ class TensorBackend {
   virtual Tensor flip(const Tensor& tensor, const unsigned dim) = 0;
   virtual Tensor
   clip(const Tensor& tensor, const Tensor& low, const Tensor& high) = 0;
+  virtual Tensor
+  roll(const Tensor& tensor, const int shift, const unsigned axis) = 0;
   virtual Tensor isnan(const Tensor& tensor) = 0;
   virtual Tensor isinf(const Tensor& tensor) = 0;
   virtual Tensor sign(const Tensor& tensor) = 0;

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -478,6 +478,10 @@ Tensor clip(const Tensor& tensor, const double& low, const double& high) {
   return clip(tensor, full(tensor.shape(), low), full(tensor.shape(), high));
 }
 
+Tensor roll(const Tensor& tensor, const int shift, const unsigned axis) {
+  return tensor.backend().roll(tensor, shift, axis);
+}
+
 Tensor isnan(const Tensor& tensor) {
   return tensor.backend().isnan(tensor);
 }

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -907,6 +907,19 @@ Tensor clip(const Tensor& tensor, const double& low, const Tensor& high);
 Tensor clip(const Tensor& tensor, const double& low, const double& high);
 
 /**
+ * Rolls (or shifts) a tensor by a certain amount along a given axis, moving
+ * elements that would be shifted out of bounds the beginning of the axis in a
+ * circular fashion.
+ *
+ * @param[in] tensor the tensor to roll shift
+ * @param[in] shift the amount by which to shift
+ * @param[in] axis the axis along which to perform the shift
+ * @return a tensor with values shifted by the given amount in a circular
+ * fashion
+ */
+Tensor roll(const Tensor& tensor, const int shift, const unsigned axis);
+
+/**
  * Returns a boolean tensor which is true where the input tensor was NaN, and
  * false otherwise.
  *

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.cpp
@@ -456,6 +456,21 @@ Tensor ArrayFireBackend::clip(
       af::clamp(toArray(tensor), toArray(low), toArray(high)), tensor.ndim());
 }
 
+Tensor ArrayFireBackend::roll(
+    const Tensor& tensor,
+    const int shift,
+    const unsigned axis) {
+  if (axis > AF_MAX_DIMS) {
+    throw std::invalid_argument(
+        "ArrayFireBackend::roll - given axis > 3 - unsupported");
+  }
+  std::vector<Dim> shifts(AF_MAX_DIMS, 0);
+  shifts[axis] = shift;
+  return toTensor<ArrayFireTensor>(
+      af::shift(toArray(tensor), shifts[0], shifts[1], shifts[2], shifts[3]),
+      tensor.ndim());
+}
+
 Tensor ArrayFireBackend::isnan(const Tensor& tensor) {
   return toTensor<ArrayFireTensor>(af::isNaN(toArray(tensor)), tensor.ndim());
 }

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
@@ -107,6 +107,8 @@ class ArrayFireBackend : public TensorBackend {
   Tensor flip(const Tensor& tensor, const unsigned dim) override;
   Tensor clip(const Tensor& tensor, const Tensor& low, const Tensor& high)
       override;
+  Tensor roll(const Tensor& tensor, const int shift, const unsigned axis)
+      override;
   Tensor isnan(const Tensor& tensor) override;
   Tensor isinf(const Tensor& tensor) override;
   Tensor sign(const Tensor& tensor) override;

--- a/flashlight/fl/tensor/backend/af/Utils.cpp
+++ b/flashlight/fl/tensor/backend/af/Utils.cpp
@@ -16,37 +16,37 @@
 namespace fl {
 namespace detail {
 
-const std::unordered_map<fl::dtype, af::dtype> kFlashlightTypeToArrayFire = {
-    {fl::dtype::f16, af::dtype::f16},
-    {fl::dtype::f32, af::dtype::f32},
-    {fl::dtype::f64, af::dtype::f64},
-    {fl::dtype::b8, af::dtype::b8},
-    {fl::dtype::s16, af::dtype::s16},
-    {fl::dtype::s32, af::dtype::s32},
-    {fl::dtype::s64, af::dtype::s64},
-    {fl::dtype::u8, af::dtype::u8},
-    {fl::dtype::u16, af::dtype::u16},
-    {fl::dtype::u32, af::dtype::u32},
-    {fl::dtype::u64, af::dtype::u64}};
-
-const std::unordered_map<af::dtype, fl::dtype> kArrayFireTypeToFlashlight = {
-    {af::dtype::f16, fl::dtype::f16},
-    {af::dtype::f32, fl::dtype::f32},
-    {af::dtype::f64, fl::dtype::f64},
-    {af::dtype::b8, fl::dtype::b8},
-    {af::dtype::s16, fl::dtype::s16},
-    {af::dtype::s32, fl::dtype::s32},
-    {af::dtype::s64, fl::dtype::s64},
-    {af::dtype::u8, fl::dtype::u8},
-    {af::dtype::u16, fl::dtype::u16},
-    {af::dtype::u32, fl::dtype::u32},
-    {af::dtype::u64, fl::dtype::u64}};
-
 af::dtype flToAfType(fl::dtype type) {
+  static const std::unordered_map<fl::dtype, af::dtype>
+      kFlashlightTypeToArrayFire = {
+          {fl::dtype::f16, af::dtype::f16},
+          {fl::dtype::f32, af::dtype::f32},
+          {fl::dtype::f64, af::dtype::f64},
+          {fl::dtype::b8, af::dtype::b8},
+          {fl::dtype::s16, af::dtype::s16},
+          {fl::dtype::s32, af::dtype::s32},
+          {fl::dtype::s64, af::dtype::s64},
+          {fl::dtype::u8, af::dtype::u8},
+          {fl::dtype::u16, af::dtype::u16},
+          {fl::dtype::u32, af::dtype::u32},
+          {fl::dtype::u64, af::dtype::u64}};
   return kFlashlightTypeToArrayFire.at(type);
 }
 
 fl::dtype afToFlType(af::dtype type) {
+  static const std::unordered_map<af::dtype, fl::dtype>
+      kArrayFireTypeToFlashlight = {
+          {af::dtype::f16, fl::dtype::f16},
+          {af::dtype::f32, fl::dtype::f32},
+          {af::dtype::f64, fl::dtype::f64},
+          {af::dtype::b8, fl::dtype::b8},
+          {af::dtype::s16, fl::dtype::s16},
+          {af::dtype::s32, fl::dtype::s32},
+          {af::dtype::s64, fl::dtype::s64},
+          {af::dtype::u8, fl::dtype::u8},
+          {af::dtype::u16, fl::dtype::u16},
+          {af::dtype::u32, fl::dtype::u32},
+          {af::dtype::u64, fl::dtype::u64}};
   return kArrayFireTypeToFlashlight.at(type);
 }
 

--- a/flashlight/fl/test/tensor/TensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/TensorBaseTest.cpp
@@ -458,8 +458,8 @@ TEST(TensorBaseTest, broadcasting) {
 
   for (auto funcp : functions) {
     for (auto& shapeData : shapes) {
-      auto lhs = (fl::rand(shapeData.lhs) * 10).astype(fl::dtype::s32);
-      auto rhs = (fl::rand(shapeData.rhs) * 10).astype(fl::dtype::s32);
+      auto lhs = ((fl::rand(shapeData.lhs) + 1) * 10).astype(fl::dtype::s32);
+      auto rhs = ((fl::rand(shapeData.rhs) + 1) * 10).astype(fl::dtype::s32);
 
       auto [actualOut, expectedOut] = doBinaryOp(
           lhs,

--- a/flashlight/fl/test/tensor/TensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/TensorBaseTest.cpp
@@ -598,6 +598,20 @@ TEST(TensorBaseTest, clip) {
   ASSERT_TRUE(allClose(fl::clip(fl::full({3, 3}, 4.), l, h), high));
 }
 
+TEST(TensorBaseTest, roll) {
+  auto t = fl::full({5, 5}, 4.);
+  ASSERT_TRUE(allClose(t, fl::roll(t, /* shift = */ 3, /* axis = */ 1)));
+
+  Shape dims({4, 5});
+  auto r = fl::arange(dims);
+  auto result = fl::roll(r, /* shift = */ 1, /* axis = */ 0);
+  ASSERT_EQ(r.shape(), result.shape());
+  ASSERT_TRUE(allClose(result(0), fl::full({dims[1]}, dims[0] - 1, r.type())));
+  ASSERT_TRUE(allClose(
+      result(fl::range(1, fl::end)),
+      fl::arange({dims[0] - 1, dims[1]}, /* seqDim = */ 0, r.type())));
+}
+
 TEST(TensorBaseTest, isnan) {
   Shape s = {3, 3};
   ASSERT_TRUE(allClose(


### PR DESCRIPTION
Summary: Add an operator similar to [numpy's `roll`](https://numpy.org/doc/stable/reference/generated/numpy.roll.html) using `af::shift` internally. Needed for a few special speech loss things that are currently downstream.

Differential Revision: D34215079

