### PR TITLE
Fix breakage from S262969 per default args

### DIFF
--- a/flashlight/fl/test/memory/MemoryFrameworkTest.cpp
+++ b/flashlight/fl/test/memory/MemoryFrameworkTest.cpp
@@ -240,7 +240,7 @@ class MockTestMemoryManager : public TestMemoryManager {
   MOCK_METHOD(size_t, allocated, (void*));
   MOCK_METHOD(void, unlock, (void*, bool));
   MOCK_METHOD(void, signalMemoryCleanup, ());
-  MOCK_METHOD(void, printInfo, (const char*, const int));
+  MOCK_METHOD(void, printInfo, (const char*, const int, std::ostream*));
   MOCK_METHOD(void, userLock, (const void*));
   MOCK_METHOD(void, userUnlock, (const void*));
   MOCK_METHOD(bool, isUserLocked, (const void*));

--- a/flashlight/fl/test/tensor/ShapeTest.cpp
+++ b/flashlight/fl/test/tensor/ShapeTest.cpp
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <arrayfire.h>
 #include <gtest/gtest.h>
 
 #include <stdexcept>


### PR DESCRIPTION
Summary: D34622171 switches to gmock 1.10 --- use `MOCK_METHOD` and add defaulted args as explicit in Mock signatures.

Differential Revision: D34799321

