### PR TITLE
Fix FFTW thread safety issue

### DIFF
--- a/flashlight/lib/audio/feature/PowerSpectrum.h
+++ b/flashlight/lib/audio/feature/PowerSpectrum.h
@@ -61,6 +61,7 @@ class PowerSpectrum {
   std::unique_ptr<fftw_plan> fftPlan_; // fftw_plan is an opque pointer type
   std::vector<double> inFftBuf_, outFftBuf_;
   std::mutex fftMutex_;
+  static std::mutex fftPlanMutex_;
 };
 } // namespace audio
 } // namespace lib


### PR DESCRIPTION
Summary:
Creating a plan in FFTW is not thread safe. This was causing a lot of memory corruption. Adds locks around plan creation in `PowerSpectrum`.

To ensure this adds no overhead, only construct single instances of a `PowerSpectrum` (or derived types) per thread and repeatedly use the same plan — threads can use the same plan per https://www.fftw.org/fftw3_doc/Thread-safety.html.

Differential Revision: D35798346

