### PR TITLE
Convert fl core to use std::filesystem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ wheels/
 *.la
 *.a
 *.lib
+
+# Dev environment
+.vscode

--- a/flashlight/fl/distributed/FileStore.h
+++ b/flashlight/fl/distributed/FileStore.h
@@ -11,6 +11,8 @@
 #include <string>
 #include <vector>
 
+#include "flashlight/fl/common/Filesystem.h"
+
 namespace fl {
 
 namespace detail {
@@ -21,18 +23,18 @@ class FileStore {
  public:
   static constexpr std::chrono::milliseconds kDefaultTimeout =
       std::chrono::seconds(60 * 2);
-  explicit FileStore(const std::string& path) : basePath_(path) {}
+  explicit FileStore(const fs::path& path) : basePath_(path) {}
   std::vector<char> get(const std::string& key);
   void set(const std::string& key, const std::vector<char>& data);
   void clear(const std::string& key);
 
  private:
-  std::string basePath_;
+  fs::path basePath_;
 
   void wait(const std::string& key);
   bool check(const std::string& key);
-  std::string objectPath(const std::string& name);
-  std::string tmpPath(const std::string& name);
+  fs::path objectPath(const std::string& name);
+  fs::path tmpPath(const std::string& name);
 };
 } // namespace detail
 

--- a/flashlight/fl/test/optim/OptimBenchmark.cpp
+++ b/flashlight/fl/test/optim/OptimBenchmark.cpp
@@ -13,7 +13,6 @@
 #include "flashlight/fl/optim/optim.h"
 #include "flashlight/fl/tensor/Compute.h"
 #include "flashlight/fl/tensor/Random.h"
-#include "flashlight/lib/common/System.h"
 
 using namespace fl;
 


### PR DESCRIPTION
Summary: See title — bottom of a stack to remove `fl_lib_common` as part of moving `fl_lib_text` into https://github.com/flashlight/text per usage in torchaudio/torchtext

Differential Revision: D36643168

