### PR TITLE
Use more conservative setDevice in BenchmarkASG/CTC

### DIFF
--- a/flashlight/pkg/speech/test/criterion/BenchmarkASG.cpp
+++ b/flashlight/pkg/speech/test/criterion/BenchmarkASG.cpp
@@ -18,7 +18,7 @@ using namespace fl;
 using namespace fl::pkg::speech;
 
 int main() {
-  fl::setDevice(1);
+  fl::setDevice(0);
   fl::init();
 
   int N = 30, T = 487, L = 34, B = 20;

--- a/flashlight/pkg/speech/test/criterion/BenchmarkCTC.cpp
+++ b/flashlight/pkg/speech/test/criterion/BenchmarkCTC.cpp
@@ -19,7 +19,7 @@ using namespace fl;
 using namespace fl::pkg::speech;
 
 int main() {
-  fl::setDevice(1);
+  fl::setDevice(0);
   fl::init();
 
   auto ctc = ConnectionistTemporalClassificationCriterion();


### PR DESCRIPTION
Summary: `fl::setDevice(1)` assumes we have >= 2 devices. `fl::setDevice(0)` is a safer alternative.

Reviewed By: bwasti

Differential Revision: D37201054

