### PR TITLE
Only build HalideInterface with AF + CUDA

### DIFF
--- a/flashlight/pkg/halide/CMakeLists.txt
+++ b/flashlight/pkg/halide/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.10)
 
-if (NOT FL_USE_CUDA)
+if (NOT (FL_USE_ARRAYFIRE AND FL_ARRAYFIRE_USE_CUDA))
   message(FATAL_ERROR "Flashlight Halide integration "
-    "only available with the CUDA backend for now")
+    "only available with the ArrayFire backend with CUDA for now")
 endif()
 
 add_library(

--- a/flashlight/pkg/halide/HalideInterface.cpp
+++ b/flashlight/pkg/halide/HalideInterface.cpp
@@ -12,6 +12,8 @@
 #include "flashlight/fl/common/backend/cuda/CudaUtils.h"
 #include "flashlight/fl/tensor/Compute.h"
 
+#include <af/cuda.h>
+#include <af/device.h>
 #include <cuda.h> // Driver API needed for CUcontext
 
 std::unordered_map<void*, fl::Tensor> memory;
@@ -68,7 +70,8 @@ std::unordered_map<void*, fl::Tensor> memory;
    CUcontext ctx = 0;
    CUresult res = cuCtxGetCurrent(&ctx);
    if (res != CUDA_SUCCESS) throw std::runtime_error("cuCtxGetCurrent failed");
-   cudaStream_t stream = fl::cuda::getActiveStream();
+   // NOTE All ops are required to run on the default ArrayFire CUDA stream
+   cudaStream_t stream = afcu::getStream(af::getDevice());
    fl::pkg::runtime::detail::UserContext userCtx(deviceId, &ctx, &stream);
    // This symbol is searched for by LLVM on the stack before
    // JMPing to a function pointer
@@ -128,7 +131,8 @@ int halide_cuda_get_stream(
     void* /* user_context */,
     CUcontext /* ctx */,
     CUstream* stream) {
-  *stream = (CUstream)fl::cuda::getActiveStream();
+  // NOTE All ops are required to run on the default ArrayFire CUDA stream
+  *stream = (CUstream)afcu::getStream(af::getDevice());
   return 0;
 }
 

--- a/flashlight/pkg/halide/HalideInterface.h
+++ b/flashlight/pkg/halide/HalideInterface.h
@@ -64,6 +64,10 @@ template <typename T>
 class HalideBufferWrapper {
  public:
   HalideBufferWrapper(Tensor& tensor) {
+    if (tensor.backendType() != TensorBackendType::ArrayFire) {
+      throw std::runtime_error(
+          "[HalideBufferWrapper] Only support Tensor with ArrayFireBackend");
+    }
     devicePtr_ = DevicePtr(tensor);
     halideBuffer_ = Halide::Buffer<T>(flToHalideDims(tensor.shape()));
     // Halide::Buffer::device_detach_native(...) is implicitly called by the
@@ -98,6 +102,10 @@ namespace detail {
  */
 template <typename T>
 Halide::Buffer<T> toHalideBuffer(Tensor& arr) {
+  if (arr.backendType() != TensorBackendType::ArrayFire) {
+    throw std::runtime_error(
+        "[HalideBufferWrapper] Only support Tensor with ArrayFireBackend");
+  }
   // Since the buffer manages the memory, give it a persistent pointer that
   // won't be unlocked or invalidated if the Array falls out of scope.
   void* deviceMem = arr.device<void>();


### PR DESCRIPTION
Summary:
This diff enforces compilation condition of `HalideInterface` to be ArrayFire Backend with CUDA, thereby replacing `fl::cuda::getActiveStream` with lower level AF APIs.

It will help the upcoming integration of runtime abstractions into existing FL codebase (by reducing `fl::cuda::getActiveStream` calls).

Differential Revision: D37288590

