### PR TITLE
Remove outdated and redundant includes in HalideInterface

### DIFF
--- a/flashlight/pkg/halide/HalideInterface.cpp
+++ b/flashlight/pkg/halide/HalideInterface.cpp
@@ -9,9 +9,9 @@
 
 #include <unordered_map>
 
-#include "flashlight/fl/common/backend/cuda/CudaUtils.h"
 #include "flashlight/fl/tensor/Compute.h"
 
+#include <cublas_v2.h> // this must proceed `af/cuda.h` for some reason
 #include <af/cuda.h>
 #include <af/device.h>
 #include <cuda.h> // Driver API needed for CUcontext

--- a/flashlight/pkg/halide/HalideInterface.h
+++ b/flashlight/pkg/halide/HalideInterface.h
@@ -10,9 +10,6 @@
 #include <stdexcept>
 #include <vector>
 
-#include <cuda.h>
-#include <cuda_runtime.h>
-
 #include <Halide.h>
 #include <HalideBuffer.h>
 #include <HalideRuntime.h>


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.** Changes *must* be discussed.

**Original Issue**: [corresponding issue on Github]

*Note:* You can add `closes #[issue number]` to automatically close the issue that this PR resolves when it is merged.

### Summary
Fix HalideInterface build failure by removing outdated and redundant includes.

### Test Plan (required)
make test
