### PR TITLE
Let device take shared ownership of the streams on it

### DIFF
--- a/flashlight/fl/runtime/Device.cpp
+++ b/flashlight/fl/runtime/Device.cpp
@@ -5,9 +5,42 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <algorithm>
+
 #include "flashlight/fl/runtime/Device.h"
 
 namespace fl {
+
+void deviceImplTypeCheck(DeviceType expect, DeviceType actual) {
+  if (expect != actual) {
+    std::ostringstream oss;
+    oss << "[fl::Device::impl] "
+        << "specified device type: [" << expect << "] "
+        << "doesn't match actual device type: [" << actual << "]";
+    throw std::invalid_argument(oss.str());
+  }
+}
+
+const std::unordered_set<std::shared_ptr<runtime::Stream>>& Device::getStreams()
+  const {
+  return streams_;
+}
+
+void Device::addStream(std::shared_ptr<runtime::Stream> stream) {
+  if (&stream->device() != this) {
+    throw std::runtime_error(
+      "[Device::addStream] Must add stream to owner device");
+  }
+  streams_.insert(stream);
+}
+
+std::future<void> Device::sync() const {
+  return std::async(std::launch::async, [this]{
+    for (auto stream : streams_) {
+      stream->sync().wait();
+    }
+  });
+}
 
 void X64Device::setActive() const {
   // no op, CPU device is always active

--- a/flashlight/fl/runtime/DeviceManager.cpp
+++ b/flashlight/fl/runtime/DeviceManager.cpp
@@ -76,7 +76,7 @@ std::vector<Device const*> DeviceManager::getDevicesOfType(
   return devices;
 }
 
-const Device& DeviceManager::getDevice(const DeviceType type, int id) const {
+Device& DeviceManager::getDevice(const DeviceType type, int id) const {
   enforceDeviceTypeAvailable("[DeviceManager::getActiveDevice]", type);
   auto& idToDevice = deviceTypeToInfo_.at(type);
   if (idToDevice.count(id) == 0) {
@@ -86,7 +86,7 @@ const Device& DeviceManager::getDevice(const DeviceType type, int id) const {
   return *idToDevice.at(id);
 }
 
-const Device& DeviceManager::getActiveDevice(const DeviceType type) const {
+Device& DeviceManager::getActiveDevice(const DeviceType type) const {
   enforceDeviceTypeAvailable("[DeviceManager::getActiveDevice]", type);
   int activeDeviceId = getActiveDeviceId(type);
   return *deviceTypeToInfo_.at(type).at(activeDeviceId);

--- a/flashlight/fl/runtime/DeviceManager.h
+++ b/flashlight/fl/runtime/DeviceManager.h
@@ -83,7 +83,7 @@ class DeviceManager {
    *
    * @return a reference to the device of given type and native device id.
    */
-  const Device& getDevice(const DeviceType type, int id) const;
+  Device& getDevice(const DeviceType type, int id) const;
 
   /**
    * Gets the active device of given type.
@@ -92,7 +92,7 @@ class DeviceManager {
    *
    * @return a reference to the active device of given type.
    */
-  const Device& getActiveDevice(const DeviceType type) const;
+  Device& getActiveDevice(const DeviceType type) const;
 };
 
 } // namespace fl

--- a/flashlight/fl/runtime/Stream.h
+++ b/flashlight/fl/runtime/Stream.h
@@ -66,6 +66,13 @@ class Stream {
    *
    * @return a reference to the owner device of this stream.
    */
+  virtual Device& device() = 0;
+
+  /**
+   * Return the owner device of this stream.
+   *
+   * @return an immutable reference to the owner device of this stream.
+   */
   virtual const Device& device() const = 0;
 
   /**

--- a/flashlight/fl/test/runtime/DeviceTest.cpp
+++ b/flashlight/fl/test/runtime/DeviceTest.cpp
@@ -35,6 +35,30 @@ TEST(DeviceTest, setActive) {
   }
 }
 
+TEST(DeviceTest, sync) {
+  const auto& manager = DeviceManager::getInstance();
+  for (const auto type : fl::getDeviceTypes()) {
+    if (manager.isDeviceTypeAvailable(type)) {
+      for (const auto* device : manager.getDevicesOfType(type)) {
+        ASSERT_NO_THROW(device->sync());
+      }
+    }
+  }
+}
+
+TEST(DeviceTest, getStream) {
+  auto& manager = DeviceManager::getInstance();
+  for (const auto type : fl::getDeviceTypes()) {
+    if (manager.isDeviceTypeAvailable(type)) {
+      for (const auto* device : manager.getDevicesOfType(type)) {
+        for (const auto& stream : device->getStreams()) {
+          ASSERT_EQ(&stream->device(), device);
+        }
+      }
+    }
+  }
+}
+
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   fl::init();


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.** Changes *must* be discussed.

**Original Issue**: [corresponding issue on Github]

*Note:* You can add `closes #[issue number]` to automatically close the issue that this PR resolves when it is merged.

### Summary
Let device take shared ownership of the streams on it, thereby allowing us to delegate `Device::sync` to a series of `Stream::sync` by default.

### Test Plan (required)
New unit tests are added.
