### PR TITLE
Eliminate dependency from runtime to tensor

### DIFF
--- a/flashlight/fl/runtime/CUDADevice.cpp
+++ b/flashlight/fl/runtime/CUDADevice.cpp
@@ -5,12 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <stdexcept>
-
 #include "flashlight/fl/runtime/CUDADevice.h"
-#include "flashlight/fl/tensor/CUDAUtils.h"
-
-#include <cuda_runtime.h>
+#include "flashlight/fl/runtime/CUDAUtils.h"
 
 namespace fl {
 
@@ -21,7 +17,7 @@ int CUDADevice::nativeId() const {
 }
 
 void CUDADevice::setActiveImpl() const {
-  FL_CUDA_CHECK(cudaSetDevice(nativeId_));
+  FL_RUNTIME_CUDA_CHECK(cudaSetDevice(nativeId_));
 }
 
 } // namespace fl

--- a/flashlight/fl/runtime/CUDAUtils.h
+++ b/flashlight/fl/runtime/CUDAUtils.h
@@ -12,6 +12,14 @@
 
 #include "flashlight/fl/runtime/Device.h"
 
+#include <cuda_runtime.h>
+
+// TODO copied from tensor/CUDAUtils.h to temporarily avoid circular dependency
+// merge into this file during final runtime integration
+/// usage: `FL_CUDA_CHECK(cudaError_t err[, const char* prefix])`
+#define FL_RUNTIME_CUDA_CHECK(...) \
+  ::fl::cuda::detail::cudaCheck(__VA_ARGS__, __FILE__, __LINE__)
+
 namespace fl {
 namespace cuda {
 
@@ -28,6 +36,16 @@ int getActiveDeviceId();
  * @return an unordered map from native CUDA device id to CUDA device.
  */
 std::unordered_map<int, const std::unique_ptr<Device>> createCUDADevices();
+
+// TODO copied from tensor/CUDAUtils.h to temporarily avoid circular dependency
+// merge into this file during final runtime integration
+namespace detail {
+
+void cudaCheck(cudaError_t err, const char* file, int line);
+
+void cudaCheck(cudaError_t err, const char* prefix, const char* file, int line);
+
+} // namespace detail
 
 } // namespace cuda
 } // namespace fl


### PR DESCRIPTION
Summary: Remove the last dependency from runtime to tensor -- use of `tensor/CUDAUtils`, which will eventually be folded into runtime.

Reviewed By: jacobkahn

Differential Revision: D37467160

