### PR TITLE
Support querying stream of Tensor

### DIFF
--- a/flashlight/fl/tensor/TensorAdapter.h
+++ b/flashlight/fl/tensor/TensorAdapter.h
@@ -165,6 +165,17 @@ class TensorAdapterBase {
   virtual Shape strides() = 0;
 
   /**
+   * Get the stream which contains(ed) the computation required to realize an
+   * up-to-date value for this tensor. For instance, `device()` may not yield a
+   * pointer to the up-to-date value -- to use this pointer, `Stream::sync` or
+   * `Stream::relativeSync` is required.
+   *
+   * @return an immutable reference to the stream that contains(ed) the
+   * computations which create this tensor.
+   */
+  virtual const runtime::Stream& stream() const = 0;
+
+  /**
    * Returns a tensor with elements cast as a particular type
    *
    * @param[in] the type to which to cast the tensor

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -248,6 +248,10 @@ Shape Tensor::strides() const {
   return impl_->strides();
 }
 
+const runtime::Stream& Tensor::stream() const {
+  return impl_->stream();
+}
+
 void Tensor::setContext(void* context) {
   impl_->setContext(context);
 }

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -20,6 +20,12 @@
 
 namespace fl {
 
+namespace runtime {
+
+class Stream; // See runtime/Stream.h
+
+};
+
 /**
  * \defgroup tensor_constants Tensor constants
  * @{
@@ -299,6 +305,17 @@ class Tensor {
    * @return a Shape containing strides in each dimension.
    */
   Shape strides() const;
+
+  /**
+   * Get the stream which contains(ed) the computation required to realize an
+   * up-to-date value for this tensor. For instance, `device()` may not yield a
+   * pointer to the up-to-date value -- to use this pointer, `Stream::sync` or
+   * `Stream::relativeSync` is required.
+   *
+   * @return an immutable reference to the stream that contains(ed) the
+   * computations which create this tensor.
+   */
+  virtual const runtime::Stream& stream() const;
 
   /**
    * Returns a tensor with elements cast as a particular type

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
@@ -13,6 +13,8 @@
 #include "flashlight/fl/tensor/Stream.h"
 #include "flashlight/fl/tensor/TensorBackend.h"
 
+#include <af/array.h>
+
 namespace fl {
 
 /**
@@ -40,6 +42,9 @@ class ArrayFireBackend : public TensorBackend {
   std::unordered_map<int, int> nativeIdToId_;
   std::unordered_map<int, int> idToNativeId_;
 
+  // keep track of the individual active stream on each ArrayFire device
+  std::unordered_map<int, std::shared_ptr<const runtime::Stream>> afIdToStream_;
+
   // Intentionally private. Only one instance should exist/it should be accessed
   // via getInstance().
   ArrayFireBackend();
@@ -63,6 +68,20 @@ class ArrayFireBackend : public TensorBackend {
   void setDevice(const int nativeDeviceId) override;
   int getDeviceCount() override;
   const Stream& getStream() override;
+
+  /**
+   * Return the currently active stream in ArrayFire.
+   *
+   * @return an immutable reference to the currently active stream in ArrayFire.
+   */
+  const runtime::Stream& getActiveStream() const;
+
+  /**
+   * Return the stream from which the given array was created.
+   *
+   * @return an immutable reference to the stream from which `arr` was created.
+   */
+  const runtime::Stream& getStreamOfArray(const af::array& arr) const;
   bool supportsDataType(const fl::dtype& dtype) const override;
   // Memory management
   void getMemMgrInfo(const char* msg, const int nativeDeviceId, std::ostream* ostream)

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
@@ -242,6 +242,12 @@ Shape ArrayFireTensor::strides() {
   return detail::afToFlDims(af::getStrides(getHandle()), numDims());
 }
 
+const runtime::Stream& ArrayFireTensor::stream() const {
+  // TODO indexing is unlikely to change the stream associated with a tensor.
+  // But if it can, we need to call `getHandle()` here.
+  return ArrayFireBackend::getInstance().getStreamOfArray(*arrayHandle_);
+}
+
 Tensor ArrayFireTensor::astype(const dtype type) {
   auto a = getHandle().as(detail::flToAfType(type));
   return toTensor<ArrayFireTensor>(std::move(a), numDims());

--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.h
@@ -13,6 +13,7 @@
 
 #include <variant>
 
+#include "flashlight/fl/runtime/Stream.h"
 #include "flashlight/fl/tensor/Index.h"
 #include "flashlight/fl/tensor/Shape.h"
 #include "flashlight/fl/tensor/TensorAdapter.h"
@@ -184,6 +185,7 @@ class ArrayFireTensor : public TensorAdapterBase {
   bool isLocked() override;
   bool isContiguous() override;
   Shape strides() override;
+  const runtime::Stream& stream() const override;
   Tensor astype(const dtype type) override;
   Tensor index(const std::vector<Index>& indices) override;
   Tensor flatten() const override;

--- a/flashlight/fl/tensor/backend/stub/StubTensor.cpp
+++ b/flashlight/fl/tensor/backend/stub/StubTensor.cpp
@@ -93,6 +93,10 @@ Shape StubTensor::strides() {
   FL_STUB_TENSOR_UNIMPLEMENTED;
 }
 
+const runtime::Stream& StubTensor::stream() const {
+  FL_STUB_TENSOR_UNIMPLEMENTED;
+}
+
 Tensor StubTensor::astype(const dtype /* type */) {
   FL_STUB_TENSOR_UNIMPLEMENTED;
 }

--- a/flashlight/fl/tensor/backend/stub/StubTensor.h
+++ b/flashlight/fl/tensor/backend/stub/StubTensor.h
@@ -61,6 +61,7 @@ class StubTensor : public TensorAdapterBase {
   bool isLocked() override;
   bool isContiguous() override;
   Shape strides() override;
+  const runtime::Stream& stream() const override;
   Tensor astype(const dtype type) override;
   Tensor index(const std::vector<Index>& indices) override;
   Tensor flatten() const override;

--- a/flashlight/fl/test/tensor/TensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/TensorBaseTest.cpp
@@ -445,6 +445,14 @@ TEST(TensorBaseTest, strides) {
   ASSERT_EQ(t.strides(), Shape({1, 10}));
 }
 
+TEST(TensorBaseTest, stream) {
+  auto t1 = fl::rand({10, 10});
+  auto t2 = -t1;
+  auto t3 = t1 + t2;
+  ASSERT_EQ(&t1.stream(), &t2.stream());
+  ASSERT_EQ(&t1.stream(), &t3.stream());
+}
+
 TEST(TensorBaseTest, asContiguousTensor) {
   auto t = fl::rand({5, 6, 7, 8});
   auto indexed =


### PR DESCRIPTION
Summary: Add a `Tensor::stream()` method to retrieve the stream from which the tensor was created, thereby enabling non-blocking relative synchronization, i.e., for CUDA streams.

Differential Revision: D37475889

