### PR TITLE
Properly initialize arrayfire handle in ArrayFireTensor default constructor

### DIFF
--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
@@ -61,7 +61,8 @@ ArrayFireTensor::ArrayFireTensor(
     unsigned numDims)
     : arrayHandle_(arr), numDims_(numDims) {}
 
-ArrayFireTensor::ArrayFireTensor() : handle_(ArrayComponent()) {}
+ArrayFireTensor::ArrayFireTensor()
+    : arrayHandle_(std::make_shared<af::array>()), handle_(ArrayComponent()) {}
 
 ArrayFireTensor::ArrayFireTensor(
     const Shape& shape,

--- a/flashlight/fl/test/tensor/af/ArrayFireTensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/af/ArrayFireTensorBaseTest.cpp
@@ -420,6 +420,11 @@ TEST(ArrayFireTensorBaseTest, device) {
   AF_CHECK(af_unlock_array(arr.get())); // safety
 }
 
+TEST(ArrayFireTensorBaseTest, defaultConstructor) {
+  auto t = ArrayFireTensor();
+  ASSERT_TRUE(t.getHandle().isempty());
+}
+
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   fl::init();


### PR DESCRIPTION
Summary: As title, simply initialize it to an empty tensor/array.

Differential Revision: D37507683

