### PR TITLE
Replace TensorBackend::getStream with a new TensorBase::getStream

### DIFF
--- a/flashlight/fl/tensor/CUDAUtils.cpp
+++ b/flashlight/fl/tensor/CUDAUtils.cpp
@@ -6,15 +6,13 @@
  */
 
 #include "flashlight/fl/tensor/CUDAUtils.h"
-#include "flashlight/fl/tensor/CUDAStream.h"
 
 #include <sstream>
 #include <stdexcept>
 
-#include "flashlight/fl/tensor/Compute.h"
-
+#include "flashlight/fl/runtime/CUDAStream.h"
 // TODO: remove me after removing the dependency on Tensor
-#include "flashlight/fl/tensor/TensorBackend.h"
+#include "flashlight/fl/tensor/TensorBase.h"
 
 namespace fl {
 namespace cuda {
@@ -22,7 +20,7 @@ namespace cuda {
 // TODO{fl::Tensor}{CUDA} remove the dependency on Tensor so this can be
 // moved to a runtime abstraction
 cudaStream_t getActiveStream() {
-  return Tensor().backend().getStream().impl<CUDAStream>().handle();
+  return Tensor().stream().impl<runtime::CUDAStream>().handle();
 }
 
 void synchronizeStreams(

--- a/flashlight/pkg/speech/criterion/backend/cuda/ConnectionistTemporalClassificationCriterion.cpp
+++ b/flashlight/pkg/speech/criterion/backend/cuda/ConnectionistTemporalClassificationCriterion.cpp
@@ -13,7 +13,7 @@
 #include "flashlight/pkg/speech/criterion/CriterionUtils.h"
 
 #include "flashlight/fl/common/DevicePtr.h"
-#include "flashlight/fl/tensor/CUDAStream.h"
+#include "flashlight/fl/runtime/CUDAStream.h"
 #include "flashlight/fl/tensor/Index.h"
 #include "flashlight/fl/tensor/TensorBackend.h"
 #include "flashlight/lib/sequence/criterion/cuda/CriterionUtils.cuh"
@@ -50,7 +50,7 @@ std::vector<Variable> ConnectionistTemporalClassificationCriterion::forward(
   const int B = input.dim(2);
   const int batchL = target.dim(0);
   cudaStream_t stream =
-      input.tensor().backend().getStream().impl<CUDAStream>().handle();
+      input.tensor().stream().impl<fl::runtime::CUDAStream>().handle();
 
   ctcOptions options;
   options.loc = CTC_GPU;

--- a/flashlight/pkg/speech/criterion/backend/cuda/CriterionUtils.cpp
+++ b/flashlight/pkg/speech/criterion/backend/cuda/CriterionUtils.cpp
@@ -10,7 +10,7 @@
 #include <stdexcept>
 
 #include "flashlight/fl/common/DevicePtr.h"
-#include "flashlight/fl/tensor/CUDAStream.h"
+#include "flashlight/fl/runtime/CUDAStream.h"
 #include "flashlight/fl/tensor/TensorBackend.h"
 #include "flashlight/lib/sequence/criterion/cuda/CriterionUtils.cuh"
 #include "flashlight/lib/sequence/criterion/cuda/ViterbiPath.cuh"
@@ -63,7 +63,7 @@ Tensor viterbiPath(const Tensor& input, const Tensor& trans) {
         static_cast<const float*>(transRaw.get()),
         static_cast<int*>(pathRaw.get()),
         workspaceRaw.get(),
-        input.backend().getStream().impl<CUDAStream>().handle());
+        input.stream().impl<runtime::CUDAStream>().handle());
   }
 
   return path;
@@ -85,7 +85,7 @@ Tensor getTargetSizeArray(const Tensor& target, int maxSize) {
         maxSize,
         static_cast<const int*>(targetRaw.get()),
         static_cast<int*>(targetSizeRaw.get()),
-        target.backend().getStream().impl<CUDAStream>().handle());
+        target.stream().impl<runtime::CUDAStream>().handle());
   }
 
   return targetSize;

--- a/flashlight/pkg/speech/criterion/backend/cuda/ForceAlignmentCriterion.cpp
+++ b/flashlight/pkg/speech/criterion/backend/cuda/ForceAlignmentCriterion.cpp
@@ -10,7 +10,7 @@
 #include <stdexcept>
 
 #include "flashlight/fl/common/DevicePtr.h"
-#include "flashlight/fl/tensor/CUDAStream.h"
+#include "flashlight/fl/runtime/CUDAStream.h"
 #include "flashlight/fl/tensor/TensorBackend.h"
 #include "flashlight/lib/sequence/criterion/cuda/ForceAlignmentCriterion.cuh"
 #include "flashlight/pkg/speech/criterion/CriterionUtils.h"
@@ -61,7 +61,7 @@ static void backward(
         static_cast<float*>(inputGradRaw.get()),
         static_cast<float*>(transGradRaw.get()),
         workspaceRaw.get(),
-        inputs[0].tensor().backend().getStream().impl<CUDAStream>().handle());
+        inputs[0].tensor().stream().impl<runtime::CUDAStream>().handle());
   }
 
   inputs[0].addGrad(Variable(inputGrad, false));
@@ -114,7 +114,7 @@ Variable ForceAlignmentCriterion::forward(
         static_cast<const float*>(transRaw.get()),
         static_cast<float*>(lossRaw.get()),
         workspaceRaw.get(),
-        input.backend().getStream().impl<CUDAStream>().handle());
+        input.stream().impl<runtime::CUDAStream>().handle());
   }
 
   return Variable(
@@ -176,7 +176,7 @@ Tensor ForceAlignmentCriterion::viterbiPath(
         static_cast<const float*>(transRaw.get()),
         static_cast<int*>(bestPathsRaw.get()),
         workspaceRaw.get(),
-        input.backend().getStream().impl<CUDAStream>().handle());
+        input.stream().impl<runtime::CUDAStream>().handle());
   }
   return bestPathsVar;
 }

--- a/flashlight/pkg/speech/criterion/backend/cuda/FullConnectionCriterion.cpp
+++ b/flashlight/pkg/speech/criterion/backend/cuda/FullConnectionCriterion.cpp
@@ -10,7 +10,7 @@
 #include <stdexcept>
 
 #include "flashlight/fl/common/DevicePtr.h"
-#include "flashlight/fl/tensor/CUDAStream.h"
+#include "flashlight/fl/runtime/CUDAStream.h"
 #include "flashlight/fl/tensor/TensorBackend.h"
 #include "flashlight/lib/sequence/criterion/cuda/FullConnectionCriterion.cuh"
 #include "flashlight/pkg/speech/criterion/CriterionUtils.h"
@@ -56,7 +56,7 @@ static void backward(
         static_cast<float*>(inputGradRaw.get()),
         static_cast<float*>(transGradRaw.get()),
         workspaceRaw.get(),
-        inputs[0].tensor().backend().getStream().impl<CUDAStream>().handle());
+        inputs[0].tensor().stream().impl<runtime::CUDAStream>().handle());
   }
 
   inputs[0].addGrad(Variable(inputGrad, false));
@@ -115,7 +115,7 @@ Variable FullConnectionCriterion::forward(
         static_cast<const float*>(transRaw.get()),
         static_cast<float*>(lossRaw.get()),
         workspaceRaw.get(),
-        input.backend().getStream().impl<CUDAStream>().handle());
+        input.stream().impl<runtime::CUDAStream>().handle());
   }
 
   return Variable(


### PR DESCRIPTION
Summary: As title. This replaces all existing uses of `TensorBackend::getStream`, which will be removed from the API in an upcoming diff.

Reviewed By: jacobkahn

Differential Revision: D37492583

