### PR TITLE
Fix distributed initialization

### DIFF
--- a/flashlight/fl/runtime/Device.cpp
+++ b/flashlight/fl/runtime/Device.cpp
@@ -43,8 +43,8 @@ std::future<void> Device::sync() const {
   });
 }
 
-void Device::addSetActiveCallback(std::function<void(int)>&& callback) {
-  setActiveCallbacks_.push_back((callback));
+void Device::addSetActiveCallback(std::function<void(int)> callback) {
+  setActiveCallbacks_.push_back(std::move(callback));
 }
 
 void Device::setActive() const {

--- a/flashlight/fl/runtime/Device.h
+++ b/flashlight/fl/runtime/Device.h
@@ -97,7 +97,7 @@ class Device {
    *
    * @param[in] callback the callback to be invoked with this device's native ID
    */
-  void addSetActiveCallback(std::function<void(int)>&& callback);
+  void addSetActiveCallback(std::function<void(int)> callback);
 
   /**
    * Get the underlying implementation of this device.

--- a/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireBackend.h
@@ -43,7 +43,12 @@ class ArrayFireBackend : public TensorBackend {
   std::unordered_map<int, int> idToNativeId_;
 
   // keep track of the individual active stream on each ArrayFire device
-  std::unordered_map<int, std::shared_ptr<const runtime::Stream>> afIdToStream_;
+  // NOTE using a `shared_ptr` to allow its capture in setActive callback;
+  // see constructor for details.
+  std::shared_ptr<
+      std::unordered_map<int, std::shared_ptr<const runtime::Stream>>>
+      afIdToStream_{std::make_shared<
+          std::unordered_map<int, std::shared_ptr<const runtime::Stream>>>()};
 
   // Intentionally private. Only one instance should exist/it should be accessed
   // via getInstance().
@@ -70,18 +75,11 @@ class ArrayFireBackend : public TensorBackend {
   const Stream& getStream() override;
 
   /**
-   * Return the currently active stream in ArrayFire.
-   *
-   * @return an immutable reference to the currently active stream in ArrayFire.
-   */
-  const runtime::Stream& getActiveStream() const;
-
-  /**
    * Return the stream from which the given array was created.
    *
    * @return an immutable reference to the stream from which `arr` was created.
    */
-  const runtime::Stream& getStreamOfArray(const af::array& arr) const;
+  const runtime::Stream& getStreamOfArray(const af::array& arr);
   bool supportsDataType(const fl::dtype& dtype) const override;
   // Memory management
   void getMemMgrInfo(const char* msg, const int nativeDeviceId, std::ostream* ostream)


### PR DESCRIPTION


**IMPORTANT: Please do not create a Pull Request without creating an issue first.** Changes *must* be discussed.

**Original Issue**: [corresponding issue on Github]

*Note:* You can add `closes #[issue number]` to automatically close the issue that this PR resolves when it is merged.

### Summary
An issue due to #910 was uncovered. To reproduce, build and run

```
 mpirun -n 2 <flashlight-build-dir>/flashlight/fl/test/AllReduceTest
```

It's fixed by lazily wrapping (and thus initializing) the ArrayFire streams (which are lazily initialized upon query). The underlying cause is unclear, but this ensures minimal changes to the program behavior after #910.

### Test Plan (required)

```
mpirun -n 2 <flashlight-build-dir>/flashlight/fl/test/AllReduceTest
```
Now passes
