### PR TITLE
Use a newly created stream for cudnn via the runtime abstractions

### DIFF
--- a/flashlight/fl/autograd/tensor/backend/cudnn/CMakeLists.txt
+++ b/flashlight/fl/autograd/tensor/backend/cudnn/CMakeLists.txt
@@ -28,4 +28,5 @@ target_compile_definitions(
   flashlight
   PUBLIC
   "-DNO_CUDNN_DESTROY_HANDLE"
+  "-DNO_CUDNN_DESTROY_STREAM"
   )

--- a/flashlight/fl/autograd/tensor/backend/cudnn/CudnnUtils.h
+++ b/flashlight/fl/autograd/tensor/backend/cudnn/CudnnUtils.h
@@ -10,6 +10,7 @@
 #include <cudnn.h>
 
 #include "flashlight/fl/common/Defines.h"
+#include "flashlight/fl/runtime/CUDAStream.h"
 #include "flashlight/fl/tensor/TensorBase.h"
 
 namespace fl {
@@ -106,5 +107,6 @@ const void* kZero(const fl::dtype t);
 
 // TODO: move this to CudnnAutogradExtension if we make it a singleton
 cudnnHandle_t getCudnnHandle();
+const runtime::CUDAStream& getCudnnStream();
 
 } // namespace fl

--- a/flashlight/fl/tensor/Compute.h
+++ b/flashlight/fl/tensor/Compute.h
@@ -56,6 +56,33 @@ void relativeSync(
     const std::vector<const Tensor*>& waitOns);
 
 /**
+ * Synchronize future tasks on given stream w.r.t. current tasks on all unique
+ * streams of given tensors, i.e., the former can only start after the
+ * completion of the latter.
+ * NOTE this function may or may not block the calling thread.
+ *
+ * @param[in] wait the stream perform relative synchronization for.
+ * @param[in] waitOns the tensors whose streams to perform relative
+ * synchronization against.
+ */
+void relativeSync(
+    const runtime::Stream& wait,
+    const std::vector<Tensor>& waitOns);
+
+/**
+ * Synchronize future tasks on the streams of `waits` w.r.t. current task on given
+ * stream, i.e., the former can only start after the completion of the latter.
+ * NOTE this function may or may not block the calling thread.
+ *
+ * @param[in] waits the tensors whose streams to perform relative
+ * synchronization for.
+ * @param[in] waitOn the stream to perform relative synchronization against.
+ */
+void relativeSync(
+  const std::vector<Tensor>& waits,
+  const runtime::Stream& waitOn);
+
+/**
  * Launches computation, [usually] asynchronously, on operations needed to make
  * a particular value for a tensor available.
  *


### PR DESCRIPTION
Summary:
Instead of using the currently active stream in `autograd/.../cudnn` (and assuming the backend only has 1 active stream per device, which is true for ArrayFire), this diff creates a new CUDA Stream and relatively synchronize it as necessary.

This way, we make no assumption on the streams, i.e., each input/output tensor could be on different stream, and the cudnn logic won't break.

When do we relativeSync?
1. Right before creating `DevicePtr`, sync cudnnstream against the tensor, but if reuse DevicePtr in the same function, no need to sync anymore, because it was synced at beginning, and will be up-to-date as cudnn use it.
2. For final output, sync its stream against cudnnstream, because the client of autograd expects the output `Tensor` to be ready to go.

Differential Revision: D37495449

