### PR TITLE
Replace synchronizeStreams and getActiveStream in DistributedBackend with runtime abstractions

### DIFF
--- a/flashlight/fl/tensor/CUDAUtils.h
+++ b/flashlight/fl/tensor/CUDAUtils.h
@@ -21,6 +21,8 @@ namespace cuda {
 /**
  * Gets the Arrayfire CUDA stream. Gets the stream
  * for the device it's called on (with that device id)
+ *
+ * TODO get rid of this after runtime integration
  */
 cudaStream_t getActiveStream();
 
@@ -36,6 +38,8 @@ cudaStream_t getActiveStream();
  * on to complete before the blockee starts execution of its enqueued events
  * @param[in] event an existing CUDA event to use to record events on blockOn
  * CUDA stream
+ *
+ * TODO get rid of this after runtime integration
  */
 void synchronizeStreams(
     cudaStream_t blockee,

--- a/flashlight/fl/tensor/Compute.cpp
+++ b/flashlight/fl/tensor/Compute.cpp
@@ -22,6 +22,16 @@ void sync(const int deviceId) {
   Tensor().backend().sync(deviceId);
 }
 
+void relativeSync(
+    const runtime::Stream& wait,
+    const std::vector<const Tensor*>& waitOns) {
+  std::unordered_set<const runtime::Stream*> uniqueStreams;
+  for (const auto& waitOn : waitOns) {
+    uniqueStreams.insert(&waitOn->stream());
+  }
+  wait.relativeSync(uniqueStreams);
+}
+
 void eval(Tensor& tensor) {
   Tensor().backend().eval(tensor);
 }

--- a/flashlight/fl/tensor/Compute.h
+++ b/flashlight/fl/tensor/Compute.h
@@ -9,6 +9,10 @@
 
 #include <cstdlib>
 #include <iostream>
+#include <memory>
+#include <vector>
+
+#include "flashlight/fl/runtime/Stream.h"
 
 // TODO:fl::Tensor {misc} remove me when not dependent on AF
 namespace af {
@@ -36,6 +40,20 @@ void sync();
  * has completed.
  */
 void sync(const int deviceId);
+
+/**
+ * Synchronize future tasks on given stream w.r.t. current tasks on all unique
+ * streams of given tensors, i.e., the former can only start after the
+ * completion of the latter.
+ * NOTE this function may or may not block the calling thread.
+ *
+ * @param[in] wait the stream perform relative synchronization for.
+ * @param[in] waitOns the tensors whose streams to perform relative
+ * synchronization against.
+ */
+void relativeSync(
+    const runtime::Stream& wait,
+    const std::vector<const Tensor*>& waitOns);
 
 /**
  * Launches computation, [usually] asynchronously, on operations needed to make


### PR DESCRIPTION
Summary:
As title, this replaces all uses of `synchronizeStreams` and `getActiveStream` in `cuda/DistributedBackend.cpp`.

~~There are 2 more TODOs left for jacobkahn.~~ -- resolved by D37568719 (https://github.com/flashlight/flashlight/commit/866ff060b9c954df83a4c9bd284d024344a2dc88).

Eventually, these two functions will be removed and `tensor/CUDAUtils` will be folded into `runtime/CUDAUtils`.

Differential Revision: D37493923

