### PR TITLE
Avoid potential extra tensor creation in TensorBase

### DIFF
--- a/flashlight/fl/tensor/TensorBackend.cpp
+++ b/flashlight/fl/tensor/TensorBackend.cpp
@@ -24,4 +24,68 @@ bool TensorBackend::isDataTypeSupported(const fl::dtype& dtype) const {
   return supported;
 }
 
+Tensor TensorBackend::clip(
+    const Tensor& tensor,
+    const Tensor& low,
+    const double& high) {
+  return clip(
+      tensor, low, full(tensor.shape(), high, dtype_traits<double>::ctype));
+}
+
+Tensor TensorBackend::clip(
+    const Tensor& tensor,
+    const double& low,
+    const Tensor& high) {
+  return clip(
+      tensor, full(tensor.shape(), low, dtype_traits<double>::ctype), high);
+}
+
+Tensor TensorBackend::clip(
+    const Tensor& tensor,
+    const double& low,
+    const double& high) {
+  return clip(
+      tensor,
+      full(tensor.shape(), low, dtype_traits<double>::ctype),
+      full(tensor.shape(), high, dtype_traits<double>::ctype));
+}
+
+Tensor TensorBackend::where(
+    const Tensor& condition,
+    const Tensor& x,
+    const double& y) {
+  return where(condition, x, full(condition.shape(), y, x.type()));
+}
+
+Tensor TensorBackend::where(
+    const Tensor& condition,
+    const double& x,
+    const Tensor& y) {
+  return where(condition, full(condition.shape(), x, y.type()), y);
+}
+
+Tensor TensorBackend::minimum(const Tensor& lhs, const double& rhs) {
+  return minimum(lhs, full(lhs.shape(), rhs, dtype_traits<double>::ctype));
+}
+
+Tensor TensorBackend::minimum(const double& lhs, const Tensor& rhs) {
+  return minimum(full(rhs.shape(), lhs, dtype_traits<double>::ctype), rhs);
+}
+
+Tensor TensorBackend::maximum(const Tensor& lhs, const double& rhs) {
+  return maximum(lhs, full(lhs.shape(), rhs, dtype_traits<double>::ctype));
+}
+
+Tensor TensorBackend::maximum(const double& lhs, const Tensor& rhs) {
+  return maximum(full(rhs.shape(), lhs, dtype_traits<double>::ctype), rhs);
+}
+
+Tensor TensorBackend::power(const Tensor& lhs, const double& rhs) {
+  return power(lhs, full(lhs.shape(), rhs, dtype_traits<double>::ctype));
+}
+
+Tensor TensorBackend::power(const double& lhs, const Tensor& rhs) {
+  return power(full(rhs.shape(), lhs, dtype_traits<double>::ctype), rhs);
+}
+
 } // namespace fl

--- a/flashlight/fl/tensor/TensorBackend.h
+++ b/flashlight/fl/tensor/TensorBackend.h
@@ -117,6 +117,12 @@ class TensorBackend {
   virtual Tensor
   clip(const Tensor& tensor, const Tensor& low, const Tensor& high) = 0;
   virtual Tensor
+  clip(const Tensor& tensor, const Tensor& low, const double& high);
+  virtual Tensor
+  clip(const Tensor& tensor, const double& low, const Tensor& high);
+  virtual Tensor
+  clip(const Tensor& tensor, const double& low, const double& high);
+  virtual Tensor
   roll(const Tensor& tensor, const int shift, const unsigned axis) = 0;
   virtual Tensor isnan(const Tensor& tensor) = 0;
   virtual Tensor isinf(const Tensor& tensor) = 0;
@@ -125,6 +131,10 @@ class TensorBackend {
   virtual Tensor triu(const Tensor& tensor) = 0;
   virtual Tensor
   where(const Tensor& condition, const Tensor& x, const Tensor& y) = 0;
+  virtual Tensor
+  where(const Tensor& condition, const Tensor& x, const double& y);
+  virtual Tensor
+  where(const Tensor& condition, const double& x, const Tensor& y);
   virtual void topk(
       Tensor& values,
       Tensor& indices,
@@ -190,8 +200,14 @@ class TensorBackend {
 #undef FL_BINARY_OP_LITERALS_DECL
 
   virtual Tensor minimum(const Tensor& lhs, const Tensor& rhs) = 0;
+  virtual Tensor minimum(const Tensor& lhs, const double& rhs);
+  virtual Tensor minimum(const double& lhs, const Tensor& rhs);
   virtual Tensor maximum(const Tensor& lhs, const Tensor& rhs) = 0;
+  virtual Tensor maximum(const Tensor& lhs, const double& rhs);
+  virtual Tensor maximum(const double& lhs, const Tensor& rhs);
   virtual Tensor power(const Tensor& lhs, const Tensor& rhs) = 0;
+  virtual Tensor power(const Tensor& lhs, const double& rhs);
+  virtual Tensor power(const double& lhs, const Tensor& rhs);
 
   /******************************* BLAS ********************************/
   virtual Tensor matmul(

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -470,16 +470,16 @@ Tensor clip(const Tensor& tensor, const Tensor& low, const Tensor& high) {
 
 Tensor clip(const Tensor& tensor, const Tensor& low, const double& high) {
   FL_TENSOR_BACKENDS_MATCH_CHECK(tensor, low);
-  return clip(tensor, low, full(tensor.shape(), high));
+  return tensor.backend().clip(tensor, low, high);
 }
 
 Tensor clip(const Tensor& tensor, const double& low, const Tensor& high) {
   FL_TENSOR_BACKENDS_MATCH_CHECK(tensor, high);
-  return clip(tensor, full(tensor.shape(), low), high);
+  return tensor.backend().clip(tensor, low, high);
 }
 
 Tensor clip(const Tensor& tensor, const double& low, const double& high) {
-  return clip(tensor, full(tensor.shape(), low), full(tensor.shape(), high));
+  return tensor.backend().clip(tensor, low, high);
 }
 
 Tensor roll(const Tensor& tensor, const int shift, const unsigned axis) {
@@ -513,14 +513,12 @@ Tensor where(const Tensor& condition, const Tensor& x, const Tensor& y) {
 
 Tensor where(const Tensor& condition, const Tensor& x, const double& y) {
   FL_TENSOR_BACKENDS_MATCH_CHECK(condition, x);
-  return condition.backend().where(
-      condition, x, fl::full(condition.shape(), y, x.type()));
+  return condition.backend().where(condition, x, y);
 }
 
 Tensor where(const Tensor& condition, const double& x, const Tensor& y) {
   FL_TENSOR_BACKENDS_MATCH_CHECK(condition, y);
-  return condition.backend().where(
-      condition, fl::full(condition.shape(), x, y.type()), y);
+  return condition.backend().where(condition, x, y);
 }
 
 void topk(
@@ -625,19 +623,19 @@ Tensor maximum(const Tensor& lhs, const Tensor& rhs) {
 }
 
 Tensor minimum(const Tensor& lhs, const double& rhs) {
-  return minimum(lhs, full(lhs.shape(), rhs));
+  return lhs.backend().minimum(lhs, rhs);
 }
 
 Tensor minimum(const double& lhs, const Tensor& rhs) {
-  return minimum(full(rhs.shape(), lhs), rhs);
+  return rhs.backend().minimum(lhs, rhs);
 }
 
 Tensor maximum(const Tensor& lhs, const double& rhs) {
-  return maximum(lhs, full(lhs.shape(), rhs));
+  return lhs.backend().maximum(lhs, rhs);
 }
 
 Tensor maximum(const double& lhs, const Tensor& rhs) {
-  return maximum(full(rhs.shape(), lhs), rhs);
+  return rhs.backend().maximum(lhs, rhs);
 }
 
 Tensor power(const Tensor& lhs, const Tensor& rhs) {
@@ -646,11 +644,11 @@ Tensor power(const Tensor& lhs, const Tensor& rhs) {
 }
 
 Tensor power(const Tensor& lhs, const double& rhs) {
-  return lhs.backend().power(lhs, full(lhs.shape(), rhs));
+  return lhs.backend().power(lhs, rhs);
 }
 
 Tensor power(const double& lhs, const Tensor& rhs) {
-  return rhs.backend().power(full(rhs.shape(), lhs), rhs);
+  return rhs.backend().power(lhs, rhs);
 }
 
 /******************************* BLAS ********************************/

--- a/flashlight/fl/test/tensor/TensorUnaryOpsTest.cpp
+++ b/flashlight/fl/test/tensor/TensorUnaryOpsTest.cpp
@@ -172,6 +172,34 @@ TEST(TensorUnaryOpsTest, flip) {
   ASSERT_TRUE(allClose(fl::flip(c, 0), c));
 }
 
+TEST(TensorUnaryOpsTest, where) {
+  // 1 0
+  // 0 1
+  auto cond = fl::Tensor::fromVector<char>({2, 2}, {1, 0, 0, 1});
+  // 0 2
+  // 1 3
+  auto x = fl::Tensor::fromVector<int>({2, 2}, {0, 1, 2, 3});
+  // 4 6
+  // 5 7
+  auto y = fl::Tensor::fromVector<int>({2, 2}, {4, 5, 6, 7});
+
+  // 0 6
+  // 5 3
+  ASSERT_TRUE(allClose(
+        fl::where(cond, x, y),
+        fl::Tensor::fromVector<int>({2, 2}, {0, 5, 6, 3})));
+  // 0 1
+  // 1 3
+  ASSERT_TRUE(allClose(
+        fl::where(cond, x, 1.0),
+        fl::Tensor::fromVector<int>({2, 2}, {0, 1, 1, 3})));
+  // 2 6
+  // 5 2
+  ASSERT_TRUE(allClose(
+        fl::where(cond, 2.0, y),
+        fl::Tensor::fromVector<int>({2, 2}, {2, 5, 6, 2})));
+}
+
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   fl::init();


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.** Changes *must* be discussed.

**Original Issue**: [corresponding issue on Github]

*Note:* You can add `closes #[issue number]` to automatically close the issue that this PR resolves when it is merged.

### Summary
`TensorBase.cpp` had some potentially inefficient default implementations like:
```c++
Tensor minimum(const Tensor& lhs, const double& rhs) {
  return minimum(lhs, full(lhs.shape(), rhs));
}
```

This is not affecting the existing ArrayFire backend because of its lazy semantics & JIT.

However, it'll affect backends which eagerly allocates tensors in TensorBackend::full. Moreover, it's likely that backends will have optimal primitives which take scalar as input in these cases. Therefore the Tensor API should _allow_ the backend implementers to use those.

Furthurmore, `full` should be called on the tensor backend of the other tensor, otherwise things will fail if we feed a non-default tensor to these functions.

This commit solves these by adding _default overridable_ implementations of these methods (those with literal input), thereby (1). leaving existing backends unchanged and preserving their behavior, (2). enabling future backend implementers to override and use their optimal primitives, if desired.

### Test Plan (required)
Existing tests cover most of the ops involved. New unit tests are added for `where`.
