### PR TITLE
Fill out basic implementations for OneDNN tensor backend

### DIFF
--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -26,7 +26,7 @@ namespace fl {
  */
 
 /// Enum for various tensor backends.
-enum class TensorBackendType { Stub, ArrayFire };
+enum class TensorBackendType { Stub, ArrayFire, OneDnn };
 
 // See TensorAdapter.h
 class TensorAdapterBase;

--- a/flashlight/fl/tensor/backend/onednn/OneDnnBackend.cpp
+++ b/flashlight/fl/tensor/backend/onednn/OneDnnBackend.cpp
@@ -7,9 +7,11 @@
 
 #include "flashlight/fl/tensor/backend/onednn/OneDnnBackend.h"
 
+#include <iostream>
 #include <stdexcept>
 
 #include "flashlight/fl/tensor/TensorBase.h"
+#include "flashlight/fl/tensor/backend/onednn/OneDnnTensor.h"
 
 #define FL_ONEDNN_BACKEND_UNIMPLEMENTED \
   throw std::invalid_argument(          \
@@ -27,15 +29,13 @@ OneDnnBackend& OneDnnBackend::getInstance() {
 }
 
 TensorBackendType OneDnnBackend::backendType() const {
-  FL_ONEDNN_BACKEND_UNIMPLEMENTED;
+  return TensorBackendType::OneDnn;
 }
 
 /* -------------------------- Compute Functions -------------------------- */
 
 void OneDnnBackend::eval(const Tensor& /* tensor */) {
-  // Launch computation for a given tensor. Can be a noop for non-async
-  // runtimes.
-  FL_ONEDNN_BACKEND_UNIMPLEMENTED;
+  // no-op since OneDNN computations are launched eagerly
 }
 
 bool OneDnnBackend::supportsDataType(const fl::dtype& /* dtype */) const {
@@ -46,23 +46,23 @@ void OneDnnBackend::getMemMgrInfo(
     const char* /* msg */,
     const int /* deviceId */,
     std::ostream* /* ostream */) {
-  // Can be a noop if no memory manager is implemented.
-  FL_ONEDNN_BACKEND_UNIMPLEMENTED;
+  throw std::runtime_error(
+      "[OneDnnBackend] Currently no memory manager support");
 }
 
 void OneDnnBackend::setMemMgrLogStream(std::ostream* /* stream */) {
-  // Can be a noop if no memory manager is implemented.
-  FL_ONEDNN_BACKEND_UNIMPLEMENTED;
+  throw std::runtime_error(
+      "[OneDnnBackend] Currently no memory manager support");
 }
 
 void OneDnnBackend::setMemMgrLoggingEnabled(const bool /* enabled */) {
-  // Can be a noop if no memory manager is implemented.
-  FL_ONEDNN_BACKEND_UNIMPLEMENTED;
+  throw std::runtime_error(
+      "[OneDnnBackend] Currently no memory manager support");
 }
 
 void OneDnnBackend::setMemMgrFlushInterval(const size_t /* interval */) {
-  // Can be a noop if no memory manager is implemented.
-  FL_ONEDNN_BACKEND_UNIMPLEMENTED;
+  throw std::runtime_error(
+      "[OneDnnBackend] Currently no memory manager support");
 }
 
 /* -------------------------- Rand Functions -------------------------- */
@@ -514,8 +514,9 @@ Tensor OneDnnBackend::all(
   FL_ONEDNN_BACKEND_UNIMPLEMENTED;
 }
 
-void OneDnnBackend::print(const Tensor& /* tensor */) {
-  FL_ONEDNN_BACKEND_UNIMPLEMENTED;
+void OneDnnBackend::print(const Tensor& tensor) {
+  std::cout << "OneDnnTensor" << std::endl
+            << tensor.getAdapter<OneDnnTensor>().toString() << std::endl;
 }
 
 } // namespace fl

--- a/flashlight/fl/tensor/backend/onednn/OneDnnTensor.cpp
+++ b/flashlight/fl/tensor/backend/onednn/OneDnnTensor.cpp
@@ -7,6 +7,10 @@
 
 #include "flashlight/fl/tensor/backend/onednn/OneDnnTensor.h"
 
+#include <stdexcept>
+
+#include "flashlight/fl/tensor/backend/onednn/OneDnnBackend.h"
+
 #define FL_ONEDNN_TENSOR_UNIMPLEMENTED \
   throw std::invalid_argument(         \
       "OneDnnTensor::" + std::string(__func__) + " - unimplemented.");
@@ -27,7 +31,10 @@ OneDnnTensor::OneDnnTensor(
     const Tensor& /* values */,
     const Tensor& /* rowIdx */,
     const Tensor& /* colIdx */,
-    StorageType /* storageType */) {}
+    StorageType /* storageType */) {
+  throw std::runtime_error(
+      "OneDnnTensor currently doesn't support sparse tensor");
+}
 
 std::unique_ptr<TensorAdapterBase> OneDnnTensor::clone() const {
   FL_ONEDNN_TENSOR_UNIMPLEMENTED;
@@ -42,11 +49,11 @@ Tensor OneDnnTensor::shallowCopy() {
 }
 
 TensorBackendType OneDnnTensor::backendType() const {
-  FL_ONEDNN_TENSOR_UNIMPLEMENTED;
+  return backend().backendType();
 }
 
 TensorBackend& OneDnnTensor::backend() const {
-  FL_ONEDNN_TENSOR_UNIMPLEMENTED;
+  return OneDnnBackend::getInstance();
 }
 
 const Shape& OneDnnTensor::shape() {
@@ -58,7 +65,7 @@ fl::dtype OneDnnTensor::type() {
 }
 
 bool OneDnnTensor::isSparse() {
-  FL_ONEDNN_TENSOR_UNIMPLEMENTED;
+  return false;
 }
 
 Location OneDnnTensor::location() {
@@ -118,21 +125,19 @@ Tensor OneDnnTensor::asContiguousTensor() {
 }
 
 void OneDnnTensor::setContext(void* /* context */) {
-  // Used to store arbitrary data on a Tensor - can be a noop.
-  FL_ONEDNN_TENSOR_UNIMPLEMENTED;
+  // no-op
 }
 
 void* OneDnnTensor::getContext() {
-  // Used to store arbitrary data on a Tensor - can be a noop.
-  FL_ONEDNN_TENSOR_UNIMPLEMENTED;
+  return nullptr;
 }
 
 std::string OneDnnTensor::toString() {
   FL_ONEDNN_TENSOR_UNIMPLEMENTED;
 }
 
-std::ostream& OneDnnTensor::operator<<(std::ostream& /* ostr */) {
-  FL_ONEDNN_TENSOR_UNIMPLEMENTED;
+std::ostream& OneDnnTensor::operator<<(std::ostream& ostr) {
+  return ostr << toString();
 }
 
 /******************** Assignment Operators ********************/

--- a/flashlight/fl/tensor/backend/onednn/OneDnnTensor.h
+++ b/flashlight/fl/tensor/backend/onednn/OneDnnTensor.h
@@ -17,6 +17,9 @@ namespace fl {
  */
 class OneDnnTensor : public TensorAdapterBase {
  public:
+  /**
+   * Construct an empty OneDNNTensor.
+   */
   OneDnnTensor();
 
   /**
@@ -33,7 +36,7 @@ class OneDnnTensor : public TensorAdapterBase {
       const void* ptr,
       Location memoryLocation);
 
-  // Constructor for a sparse OneDNNTensor. Can throw if unimplemented.
+  // Constructor for a sparse OneDNNTensor; currently not supported.
   OneDnnTensor(
       const Dim nRows,
       const Dim nCols,


### PR DESCRIPTION
Summary:
This diff is meant to fill out 1-liner implementations for methods in `OneDnnBackend` and `OneDnnTensor`, which also sets the assumptions for the first prototype:
1. Tensors are contiguous
2. Tensors are not sparse
3. Tensor computations are launched eagerly (unlike ArrayFire, which has lazy evaluation)
4. No memory manager
5. Doesn't support context (like `ArrayFireTensor`).

Reviewed By: jacobkahn

Differential Revision: D37632031

