### PR TITLE
[flashlight][Tensor] Refine Tensor API's assignment operator semantics

### DIFF
--- a/flashlight/fl/tensor/TensorAdapter.h
+++ b/flashlight/fl/tensor/TensorAdapter.h
@@ -65,8 +65,8 @@ class TensorAdapterBase {
       StorageType storageType);
 
   /**
-   * Copies the tensor adapter. The implementation defines whether or not tensor
-   * data itself is copied - this is not an implementation requirement.
+   * Copies the tensor adapter. The copy is not required to be eager -- the
+   * implementation can use copy-on-write.
    */
   virtual std::unique_ptr<TensorAdapterBase> clone() const = 0;
 

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -565,8 +565,9 @@ class Tensor {
   std::ostream& operator<<(std::ostream& ostr) const;
 
   /******************** Assignment Operators ********************/
-#define ASSIGN_OP(OP)                    \
-  Tensor& OP(const Tensor& val);         \
+#define ASSIGN_TENSOR_OP(OP)             \
+  Tensor& OP(const Tensor& val);
+#define ASSIGN_SCALAR_OP(OP)             \
   Tensor& OP(const double& val);         \
   Tensor& OP(const float& val);          \
   Tensor& OP(const int& val);            \
@@ -580,13 +581,29 @@ class Tensor {
   Tensor& OP(const unsigned long& val);  \
   Tensor& OP(const long long& val);      \
   Tensor& OP(const unsigned long long& val);
+#define ASSIGN_OP(OP)                    \
+  ASSIGN_TENSOR_OP(OP);                  \
+  ASSIGN_SCALAR_OP(OP);
 
-  ASSIGN_OP(operator=);
+  ASSIGN_SCALAR_OP(operator=);
   ASSIGN_OP(operator+=);
   ASSIGN_OP(operator-=);
   ASSIGN_OP(operator*=);
   ASSIGN_OP(operator/=);
+#undef ASSIGN_TENSOR_OP
+#undef ASSIGN_SCALAR_OP
 #undef ASSIGN_OP
+
+  /* The following assignment operator differentiation via member method
+   * ref-qualifier ensures that
+   * 1. For `x = ...;`, the behavior is the same as the copy/move constructor.
+   * 2. For `... = ...`, a copy is made from the rhs tensor data to the lhs one.
+   *    This allows tensor mutation via indexing, e.g., `t(0, 0) = 42`.
+   */
+  Tensor& operator=(Tensor&& other) &;
+  Tensor& operator=(Tensor&& other) &&;
+  Tensor& operator=(const Tensor& other) &;
+  Tensor& operator=(const Tensor& other) &&;
 };
 
 /**

--- a/flashlight/fl/test/tensor/af/ArrayFireTensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/af/ArrayFireTensorBaseTest.cpp
@@ -187,13 +187,17 @@ TEST(ArrayFireTensorBaseTest, ArrayFireAssignmentOperators) {
   af_get_data_ref_count(&refCount, aArr.get());
   ASSERT_EQ(refCount, 2);
 
-  af::array& bArr = toArray(b);
-  b = fl::full({4, 4}, 2.);
+  // copy, else it'll get released below when we reassign a new tensor to b
+  af::array bArr = toArray(b);
   af_get_data_ref_count(&refCount, bArr.get());
-  ASSERT_EQ(refCount, 1);
+  ASSERT_EQ(refCount, 3); // aArr, bArr, b.arrayHandle_
+
+  b = fl::full({4, 4}, 2.); // b points to a new array now
+  af_get_data_ref_count(&refCount, bArr.get());
+  ASSERT_EQ(refCount, 2); // aArr, bArr
 
   af_get_data_ref_count(&refCount, aArr.get());
-  ASSERT_EQ(refCount, 1);
+  ASSERT_EQ(refCount, 2); // aArr, bArr
 }
 
 TEST(ArrayFireTensorBaseTest, BinaryOperators) {


### PR DESCRIPTION
### Summary
Currently `x = std::move(y)` triggers deep copy for tensors. This commit refines the Tensor API's assignment operators to enforce the ideal semantics, i.e.,
1. Conform to copy/move constructor for assignment when lhs is a lvalue (like the example above).
2. Trigger copying when lhs is a rvalue (e.g., `x(0, 0) = 42`).

### Test Plan (required)
New unit tests are added to demonstrate the intended semantics of move/copy constructors, and each variant of the assignment operators.
