### PR TITLE
Implement OneDnnTensor::equals for testing/debugging

### DIFF
--- a/flashlight/fl/tensor/backend/onednn/OneDnnTensor.h
+++ b/flashlight/fl/tensor/backend/onednn/OneDnnTensor.h
@@ -47,6 +47,10 @@ class OneDnnTensor : public TensorAdapterBase {
   dnnl::memory memory_;
   Shape shape_;
 
+  // Trigger computation to convert to contiguous tensor if needed, block until
+  // data is fully ready.
+  const void* getContiguousData();
+
  public:
   /**
    * Construct an OneDNNTensor with given shape and memory.
@@ -138,6 +142,13 @@ class OneDnnTensor : public TensorAdapterBase {
   ASSIGN_OP(inPlaceDivide); // /=
 #undef ASSIGN_OP_TYPE
 #undef ASSIGN_OP
+
+/**
+ * Deep comparison over shape, type, and data (with some tolerance for float).
+ *
+ * @return true if this OneDnn tensor equals the given one.
+ */
+bool equals(OneDnnTensor&& other);
 };
 
 } // namespace fl

--- a/flashlight/fl/test/tensor/onednn/OneDnnTensorTest.cpp
+++ b/flashlight/fl/test/tensor/onednn/OneDnnTensorTest.cpp
@@ -142,6 +142,41 @@ TEST(OneDnnTensorTest, toString) {
       "  [7, 9, 11]]]\n");
 }
 
+TEST(OneDnnTensorTest, equals) {
+  const fl::Shape shape{2, 3, 4};
+  const fl::Location location = fl::Location::Host;
+
+  {
+    std::vector<int> data(shape.elements());
+    const fl::dtype type = fl::dtype::s32;
+    std::generate(data.begin(), data.end(), std::rand);
+    OneDnnTensor t1 = OneDnnTensor(shape, type, data.data(), location);
+    ASSERT_TRUE(t1.equals(OneDnnTensor(shape, type, data.data(), location)));
+    data[0]++;
+    ASSERT_FALSE(t1.equals(OneDnnTensor(shape, type, data.data(), location)));
+  }
+
+  {
+    std::vector<float> data(shape.elements());
+    const fl::dtype type = fl::dtype::f32;
+    std::generate(data.begin(), data.end(), std::rand);
+    OneDnnTensor t1 = OneDnnTensor(shape, type, data.data(), location);
+    ASSERT_TRUE(t1.equals(OneDnnTensor(shape, type, data.data(), location)));
+    data[0] = (data[0] + 1) * (data[0] + 1); // make sure it's different enough
+    ASSERT_FALSE(t1.equals(OneDnnTensor(shape, type, data.data(), location)));
+  }
+
+  {
+    std::vector<char> data(shape.elements());
+    const fl::dtype type = fl::dtype::u8;
+    std::generate(data.begin(), data.end(), std::rand);
+    OneDnnTensor t1 = OneDnnTensor(shape, type, data.data(), location);
+    ASSERT_TRUE(t1.equals(OneDnnTensor(shape, type, data.data(), location)));
+    data[0]++;
+    ASSERT_FALSE(t1.equals(OneDnnTensor(shape, type, data.data(), location)));
+  }
+}
+
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   fl::init();


### PR DESCRIPTION
Summary: As title, this is a backend-independent way of comparing Tensors (we can eventually move it to `TensorBase`). It will help testing, debugging, and future backend implementers.

Reviewed By: jacobkahn

Differential Revision: D37910091

