### PR TITLE
Implement OneDnnBackend::transpose

### DIFF
--- a/flashlight/fl/tensor/backend/onednn/OneDnnTensor.cpp
+++ b/flashlight/fl/tensor/backend/onednn/OneDnnTensor.cpp
@@ -476,4 +476,8 @@ bool OneDnnTensor::equals(OneDnnTensor&& other) {
       : bytesEqual(lhsData, rhsData, thisMemDesc.get_size());
 }
 
+dnnl::memory& OneDnnTensor::memory() {
+  return sharedData_->memory;
+}
+
 } // namespace fl

--- a/flashlight/fl/tensor/backend/onednn/OneDnnTensor.h
+++ b/flashlight/fl/tensor/backend/onednn/OneDnnTensor.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "flashlight/fl/tensor/TensorAdapter.h"
+#include "flashlight/fl/tensor/backend/onednn/OneDnnBackend.h"
 
 #include <memory>
 
@@ -168,6 +169,14 @@ class OneDnnTensor : public TensorAdapterBase {
  * @return true if this OneDnn tensor equals the given one.
  */
 bool equals(OneDnnTensor&& other);
+
+/**
+ * Get the underlying OneDNN memory handle.
+ * NOTE not const-correct to conform with OneDNN primitive execution API.
+ *
+ * @return an immutable reference to the underlying OneDNN memory handle.
+ */
+dnnl::memory& memory();
 };
 
 } // namespace fl


### PR DESCRIPTION
Summary:
As title.

This is tricky because OneDNN doesn't provide a `transpose` primitive. For details, see documentation in the implementation.

Reviewed By: jacobkahn

Differential Revision: D37910088

