### PR TITLE
Expand OneDnnTensor binary operators to support literals and limited broadcasting.

### DIFF
--- a/flashlight/fl/tensor/backend/onednn/OneDnnTensor.cpp
+++ b/flashlight/fl/tensor/backend/onednn/OneDnnTensor.cpp
@@ -54,14 +54,6 @@ bool bytesEqual(const void* lhs, const void* rhs, unsigned numBytes) {
   return std::memcmp(lhs, rhs, numBytes) == 0;
 }
 
-dnnl::memory::desc copyMemDescWithNewType(
-    const dnnl::memory::desc& memDesc,
-    const dnnl::memory::data_type newType) {
-  dnnl::memory::desc memDescCopy = memDesc;
-  memDescCopy.data.data_type = dnnl::memory::convert_to_c(newType);
-  return memDescCopy;
-}
-
 } // namespace
 
 OneDnnTensor::SharedData::~SharedData() {
@@ -246,7 +238,7 @@ Tensor OneDnnTensor::astype(const dtype type) {
   const auto engine = srcMem.get_engine();
   const auto& srcMemDesc = srcMem.get_desc();
   const auto dstMemDesc =
-      copyMemDescWithNewType(srcMemDesc, detail::flToOneDnnType(type));
+      detail::copyMemDescWithNewType(srcMemDesc, detail::flToOneDnnType(type));
   auto dstMem = dnnl::memory(dstMemDesc, engine);
 
   // prepare primitive

--- a/flashlight/fl/tensor/backend/onednn/Utils.cpp
+++ b/flashlight/fl/tensor/backend/onednn/Utils.cpp
@@ -125,5 +125,13 @@ dnnl::memory::data_type getTypeWithLargerRange(
   return isFpType(t1) ? t1 : t2;
 }
 
+dnnl::memory::desc copyMemDescWithNewType(
+    const dnnl::memory::desc& memDesc,
+    const dnnl::memory::data_type newType) {
+  dnnl::memory::desc memDescCopy = memDesc;
+  memDescCopy.data.data_type = dnnl::memory::convert_to_c(newType);
+  return memDescCopy;
+}
+
 } // namespace detail
 } // namespace fl

--- a/flashlight/fl/tensor/backend/onednn/Utils.h
+++ b/flashlight/fl/tensor/backend/onednn/Utils.h
@@ -74,5 +74,14 @@ dnnl::memory::data_type getTypeWithLargerRange(
     dnnl::memory::data_type t1,
     dnnl::memory::data_type t2);
 
+/**
+ * Copy the given memory descriptor with a new given type.
+ *
+ * @return a copy of the given memory descriptor with a new given type.
+ */
+dnnl::memory::desc copyMemDescWithNewType(
+    const dnnl::memory::desc& memDesc,
+    const dnnl::memory::data_type newType);
+
 } // namespace detail
 } // namespace fl

--- a/flashlight/fl/test/tensor/onednn/OneDnnTensorTest.cpp
+++ b/flashlight/fl/test/tensor/onednn/OneDnnTensorTest.cpp
@@ -270,8 +270,17 @@ TEST(OneDnnTensorTest, arithmetics) {
   auto t2 = fl::Tensor::fromVector<int>({2, 2}, {1, 2, 3, 4});
   auto t3 = fl::Tensor::fromVector<int>({2, 2}, {3, 5, 7, 9});
 
-  assertOneDnnTensorEq(
+  assertOneDnnTensorEq( // implicit casting
       t1 + t2, fl::Tensor::fromVector<float>({2, 2}, {1, 3, 5, 7}));
+
+  // literal with casting
+  auto t = fl::Tensor::fromVector<float>({2, 2}, {1, 2, 3, 4});
+  double oneDouble = 1.0f;
+  double oneInt = 1;
+  assertOneDnnTensorEq(t, t1 + oneDouble);
+  assertOneDnnTensorEq(t, oneDouble + t1);
+  assertOneDnnTensorEq(t, t1 + oneInt);
+  assertOneDnnTensorEq(t, oneInt + t1);
 
   assertOneDnnTensorEq(
       t3 - t2, fl::Tensor::fromVector<int>({2, 2}, {2, 3, 4, 5}));
@@ -289,6 +298,15 @@ TEST(OneDnnTensorTest, comparison) {
 
   assertOneDnnTensorEq(
       t1 == t2, fl::Tensor::fromVector<char>({2, 2}, {1, 0, 1, 0}));
+
+  // literals with casting
+  auto t = fl::Tensor::fromVector<char>({2, 2}, {0, 1, 1, 0});
+  double twoDouble = 2.0f;
+  double twoInt = 2;
+  assertOneDnnTensorEq(t, t2 == twoDouble);
+  assertOneDnnTensorEq(t, twoDouble == t2);
+  assertOneDnnTensorEq(t, t2 == twoInt);
+  assertOneDnnTensorEq(t, twoInt == t2);
 
   assertOneDnnTensorEq(
       t1 != t2, fl::Tensor::fromVector<char>({2, 2}, {0, 1, 0, 1}));


### PR DESCRIPTION
Summary:
As title, it expand existing binary operators to support expressions like
```
Tensor(...) + 42
```

In order to maximize performance, we support broadcasting for same # of dimensions, so we can convert the literal to a `1 x 1 x ... x 1` tensor and apply the binary operation, thereby minimizing memory allocation.

Reviewed By: jacobkahn

Differential Revision: D37910090

