### PR TITLE
Implement element-wise operators

### DIFF
--- a/flashlight/fl/tensor/backend/onednn/OneDnnBackend.h
+++ b/flashlight/fl/tensor/backend/onednn/OneDnnBackend.h
@@ -33,6 +33,13 @@ class OneDnnBackend : public TensorBackend {
       dnnl::algorithm alg,
       std::optional<dnnl::memory::data_type> dstType = std::nullopt);
 
+  // Apply the given OneDNN element-wise operation to the tensor
+  Tensor applyEltwiseOp(
+      const Tensor& tensor,
+      const dnnl::algorithm alg,
+      float alpha = 0,
+      float beta = 0);
+
   Tensor randnCpu(const Shape& shape, dtype type);
   Tensor randCpu(const Shape& shape, dtype type);
 


### PR DESCRIPTION
Summary: As title. This covers all element-wise operators used in common benchmarks, e.g., ResNet, MNIST.

Reviewed By: benoitsteiner

Differential Revision: D38050584

