### PR TITLE
Fix unit test

### DIFF
--- a/flashlight/fl/test/tensor/onednn/OneDnnTensorTest.cpp
+++ b/flashlight/fl/test/tensor/onednn/OneDnnTensorTest.cpp
@@ -342,7 +342,7 @@ TEST(OneDnnTensorTest, assign) {
 
   // ensure it's not a shallow copy
   t2 = t1;
-  t1 = fl::full({2, 2, 2}, 0); // t2 won't be affected
+  t1 = fl::full({2, 2, 2}, 0, type); // t2 won't be affected
   assertOneDnnTensorEq(t1, fl::full({2, 2, 2}, 0, type));
   assertOneDnnTensorEq(t2, fl::full({2, 2, 2}, 40.7, type));
 }


### PR DESCRIPTION
Summary: Type mismatch not caught by CI because we haven't set up CI for OneDNN backend yet.

Reviewed By: jacobkahn

Differential Revision: D38338114

