### PR TITLE
Remove implicit assumption on contiguous data

### DIFF
--- a/flashlight/fl/tensor/backend/onednn/OneDnnBackend.h
+++ b/flashlight/fl/tensor/backend/onednn/OneDnnBackend.h
@@ -68,7 +68,7 @@ class OneDnnBackend : public TensorBackend {
    *
    * @return the active native OneDNN stream.
    */
-  const dnnl::stream& nativeStream() const;
+  dnnl::stream& nativeStream() const;
 
   /**
    * Gets the active OneDNN engine.
@@ -76,6 +76,13 @@ class OneDnnBackend : public TensorBackend {
    * @return the active OneDNN engine.
    */
   const dnnl::engine& engine() const;
+
+  /**
+   * Gets the OneDNN CPU engine.
+   *
+   * @return the OneDNN CPU engine.
+   */
+  const dnnl::engine& cpuEngine() const;
 
   /* -------------------------- Compute Functions -------------------------- */
   void eval(const Tensor& tensor) override;

--- a/flashlight/fl/tensor/backend/onednn/OneDnnTensor.h
+++ b/flashlight/fl/tensor/backend/onednn/OneDnnTensor.h
@@ -69,6 +69,9 @@ class OneDnnTensor : public TensorAdapterBase {
   // data is fully ready.
   const void* getContiguousData();
 
+  // return the # of bytes for the data represented by this tensor.
+  unsigned getSizeInBytes() const;
+
  public:
   /**
    * Helper constructor for shallow-copying. For internal use only.
@@ -117,7 +120,7 @@ class OneDnnTensor : public TensorAdapterBase {
   ~OneDnnTensor() override = default;
   std::unique_ptr<TensorAdapterBase> clone() const override;
   TensorBackendType backendType() const override;
-  TensorBackend& backend() const override;
+  OneDnnBackend& backend() const override;
   Tensor copy() override;
   Tensor shallowCopy() override;
   const Shape& shape() override;

--- a/flashlight/fl/tensor/backend/onednn/Utils.cpp
+++ b/flashlight/fl/tensor/backend/onednn/Utils.cpp
@@ -125,12 +125,14 @@ dnnl::memory::data_type getTypeWithLargerRange(
   return isFpType(t1) ? t1 : t2;
 }
 
-dnnl::memory::desc copyMemDescWithNewType(
-    const dnnl::memory::desc& memDesc,
-    const dnnl::memory::data_type newType) {
-  dnnl::memory::desc memDescCopy = memDesc;
-  memDescCopy.data.data_type = dnnl::memory::convert_to_c(newType);
-  return memDescCopy;
+dnnl::memory::desc oneDnnContiguousMemDescFromShape(
+    const Shape& shape,
+    const dnnl::memory::data_type type) {
+  return dnnl::memory::desc(
+      detail::shapeToOneDnnDims(shape),
+      type,
+      detail::shapeToOneDnnStrides(shape),
+      /* allowEmpty */ true);
 }
 
 } // namespace detail

--- a/flashlight/fl/tensor/backend/onednn/Utils.h
+++ b/flashlight/fl/tensor/backend/onednn/Utils.h
@@ -57,13 +57,6 @@ std::string oneDnnDataTypeToStr(const dnnl::memory::data_type type);
 dnnl::memory::dims shapeToOneDnnDims(const Shape& shape);
 
 /**
- * Convert a Flashlight Shape to OneDNN strides, assuming row-major order.
- *
- * @return the corresponding OneDNN strides for given shape.
- */
-dnnl::memory::dims shapeToOneDnnStrides(const Shape& shape);
-
-/**
  * Return the input type that can represent a larger range of data.
  *
  * @param[in] t1 the first input type.
@@ -75,13 +68,16 @@ dnnl::memory::data_type getTypeWithLargerRange(
     dnnl::memory::data_type t2);
 
 /**
- * Copy the given memory descriptor with a new given type.
+ * Create a contiguous row-major OneDNN memory descriptor based on given
+ * Flashlight Shape and OneDNN type.
  *
- * @return a copy of the given memory descriptor with a new given type.
+ * @param[in] shape the Flashlight Shape.
+ * @param[in] type the OneDNN data type.
+ * @return the memory descriptor created.
  */
-dnnl::memory::desc copyMemDescWithNewType(
-    const dnnl::memory::desc& memDesc,
-    const dnnl::memory::data_type newType);
+dnnl::memory::desc oneDnnContiguousMemDescFromShape(
+    const Shape& shape,
+    const dnnl::memory::data_type type);
 
 } // namespace detail
 } // namespace fl


### PR DESCRIPTION
Summary:
As title. 2 benefits down the line:

1. makes addition of indexing a lot smoother (as indexing could create strided tensor).
2. makes the ops more generic -- (ideally) can directly support GPU engine.

Reviewed By: jacobkahn

Differential Revision: D38332881

