### PR TITLE
Fix clone semantics

### DIFF
--- a/flashlight/fl/tensor/backend/onednn/OneDnnTensor.cpp
+++ b/flashlight/fl/tensor/backend/onednn/OneDnnTensor.cpp
@@ -125,11 +125,6 @@ OneDnnTensor::OneDnnTensor(
 }
 
 std::unique_ptr<TensorAdapterBase> OneDnnTensor::clone() const {
-  // shallow copy the underlying memory
-  return std::make_unique<OneDnnTensor>(sharedData_);
-}
-
-Tensor OneDnnTensor::copy() {
   // TODO copy on write
   auto& srcMem = sharedData_->memory;
   const auto type = srcMem.get_desc().data_type();
@@ -147,7 +142,11 @@ Tensor OneDnnTensor::copy() {
 
   // execute primitive
   reorderPrimitive.execute(backend().nativeStream(), srcMem, dstMem);
-  return toTensor<OneDnnTensor>(sharedData_->shape, std::move(dstMem));;
+  return std::make_unique<OneDnnTensor>(sharedData_->shape, std::move(dstMem));
+}
+
+Tensor OneDnnTensor::copy() {
+  return Tensor(clone());
 }
 
 Tensor OneDnnTensor::shallowCopy() {

--- a/flashlight/fl/test/tensor/onednn/OneDnnTensorTest.cpp
+++ b/flashlight/fl/test/tensor/onednn/OneDnnTensorTest.cpp
@@ -353,6 +353,7 @@ TEST(OneDnnTensorTest, copy) {
   assertOneDnnTensorEq(t1, t1.copy());
 
   // ensure it's not a shallow copy
+  // TODO properly test against effects once we support indexing
   auto t2 = t1.copy();
   t1 = fl::full({2, 2, 2}, 0, type); // t2 won't be affected
   assertOneDnnTensorEq(t1, fl::full({2, 2, 2}, 0, type));


### PR DESCRIPTION
Summary: As title. `clone` is meant to be a deep copy (with flexible implementation strategies like CoW).

Reviewed By: jacobkahn

Differential Revision: D38334302

