### PR TITLE
Improve stream class hierarchy

### DIFF
--- a/flashlight/fl/runtime/CMakeLists.txt
+++ b/flashlight/fl/runtime/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(
   ${CMAKE_CURRENT_LIST_DIR}/DeviceManager.cpp
   ${CMAKE_CURRENT_LIST_DIR}/DeviceType.cpp
   ${CMAKE_CURRENT_LIST_DIR}/Stream.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/SynchronousStream.cpp
   )
 
 if (FL_USE_CUDA)

--- a/flashlight/fl/runtime/SynchronousStream.cpp
+++ b/flashlight/fl/runtime/SynchronousStream.cpp
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "flashlight/fl/runtime/SynchronousStream.h"
+
+namespace fl {
+
+X64Device& SynchronousStream::device() {
+  return device_;
+}
+
+const X64Device& SynchronousStream::device() const {
+  return device_;
+}
+
+void SynchronousStream::relativeSync(const SynchronousStream& waitOn) const {
+  waitOn.sync();
+}
+
+} // namespace fl

--- a/flashlight/fl/runtime/SynchronousStream.h
+++ b/flashlight/fl/runtime/SynchronousStream.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "flashlight/fl/runtime/DeviceManager.h"
+#include "flashlight/fl/runtime/Stream.h"
+
+namespace fl {
+
+/**
+ * An abstraction for a synchronous stream. The word "synchronous" describes the
+ * relative synchronization strategy, i.e., it merely delegates to `sync`.
+ */
+class SynchronousStream : public StreamTrait<SynchronousStream> {
+ protected:
+  X64Device& device_{DeviceManager::getInstance()
+                         .getActiveDevice(DeviceType::x64)
+                         .impl<X64Device>()};
+
+ public:
+  // prevent name hiding
+  using StreamTrait<SynchronousStream>::relativeSync;
+
+  static constexpr StreamType type = StreamType::Synchronous;
+
+  X64Device& device() override;
+  const X64Device& device() const override;
+  void relativeSync(const SynchronousStream& waitOn) const override;
+};
+
+} // namespace fl

--- a/flashlight/fl/tensor/backend/af/ArrayFireCPUStream.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireCPUStream.cpp
@@ -9,17 +9,7 @@
 
 #include <af/device.h>
 
-#include "flashlight/fl/runtime/DeviceManager.h"
-
 namespace fl {
-
-X64Device& ArrayFireCPUStream::device() {
-  return device_;
-}
-
-const X64Device& ArrayFireCPUStream::device() const {
-  return device_;
-}
 
 std::shared_ptr<ArrayFireCPUStream> ArrayFireCPUStream::create() {
   // TODO `std::make_shared` requires a public constructor, which could be
@@ -33,10 +23,6 @@ std::shared_ptr<ArrayFireCPUStream> ArrayFireCPUStream::create() {
 
 void ArrayFireCPUStream::sync() const {
   af::sync(af::getDevice());
-}
-
-void ArrayFireCPUStream::relativeSync(const ArrayFireCPUStream& waitOn) const {
-  waitOn.sync();
 }
 
 } // namespace fl

--- a/flashlight/fl/tensor/backend/af/ArrayFireCPUStream.h
+++ b/flashlight/fl/tensor/backend/af/ArrayFireCPUStream.h
@@ -7,23 +7,15 @@
 
 #pragma once
 
-#include "flashlight/fl/runtime/DeviceManager.h"
-#include "flashlight/fl/runtime/Stream.h"
+#include "flashlight/fl/runtime/SynchronousStream.h"
 
 namespace fl {
 
 /**
  * An abstraction for ArrayFire's CPU Stream with controlled creation methods.
  */
-class ArrayFireCPUStream : public StreamTrait<ArrayFireCPUStream> {
-  X64Device& device_{DeviceManager::getInstance().getActiveDevice(DeviceType::x64).impl<X64Device>()};
-
+class ArrayFireCPUStream : public SynchronousStream {
  public:
-  // prevent name hiding
-  using StreamTrait<ArrayFireCPUStream>::relativeSync;
-
-  static constexpr StreamType type = StreamType::Synchronous;
-
   /**
    * Creates an ArrayFireCPUStream and automatically register it with
    * the active x64 device from DeviceManager.
@@ -32,10 +24,7 @@ class ArrayFireCPUStream : public StreamTrait<ArrayFireCPUStream> {
    */
   static std::shared_ptr<ArrayFireCPUStream> create();
 
-  X64Device& device() override;
-  const X64Device& device() const override;
   void sync() const override;
-  void relativeSync(const ArrayFireCPUStream& waitOn) const override;
 };
 
 } // namespace fl

--- a/flashlight/fl/tensor/backend/onednn/OneDnnBackend.cpp
+++ b/flashlight/fl/tensor/backend/onednn/OneDnnBackend.cpp
@@ -55,17 +55,6 @@ Tensor fullWithTypeCpu(const Shape& shape, V value, const dtype type) {
   return toTensor<OneDnnTensor>(shape, type, data.data(), Location::Host);
 }
 
-template <typename T, typename V>
-Tensor fullWithType(const Shape& shape, V value, const dtype type) {
-  const auto engineKind = OneDnnBackend::getInstance().engine().get_kind();
-  if (engineKind == dnnl::engine::kind::cpu) {
-    return fullWithTypeCpu<T, V>(shape, value, type);
-  } else {
-  throw std::runtime_error(
-      "[OneDnnBackend::fullWithType] unimplemented for non-CPU engine");
-  }
-}
-
 struct BinaryOpOutputDesc {
   dnnl::memory::desc dstMemDesc;
   const Shape dstShape;
@@ -288,6 +277,16 @@ FL_ONEDNN_BACKEND_CREATE_FUN_LITERAL_DEF(const bool&);
 FL_ONEDNN_BACKEND_CREATE_FUN_LITERAL_DEF(const short&);
 FL_ONEDNN_BACKEND_CREATE_FUN_LITERAL_DEF(const unsigned short&);
 #undef FL_ONEDNN_BACKEND_CREATE_FUN_LITERAL_DEF
+
+template <typename T, typename V>
+Tensor OneDnnBackend::fullWithType(const Shape& shape, V value, const dtype type) {
+  if (engine_.get_kind() == dnnl::engine::kind::cpu) {
+    return fullWithTypeCpu<T, V>(shape, value, type);
+  } else {
+  throw std::runtime_error(
+      "[OneDnnBackend::fullWithType] unimplemented for non-CPU engine");
+  }
+}
 
 Tensor OneDnnBackend::identity(const Dim /* dim */, const dtype /* type */) {
   FL_ONEDNN_BACKEND_UNIMPLEMENTED;

--- a/flashlight/fl/tensor/backend/onednn/OneDnnBackend.h
+++ b/flashlight/fl/tensor/backend/onednn/OneDnnBackend.h
@@ -43,6 +43,9 @@ class OneDnnBackend : public TensorBackend {
   Tensor randnCpu(const Shape& shape, dtype type);
   Tensor randCpu(const Shape& shape, dtype type);
 
+  template <typename T, typename V>
+  Tensor fullWithType(const Shape& shape, V value, const dtype type);
+
  public:
   OneDnnBackend();
 

--- a/flashlight/fl/tensor/backend/onednn/OneDnnCPUStream.cpp
+++ b/flashlight/fl/tensor/backend/onednn/OneDnnCPUStream.cpp
@@ -9,20 +9,10 @@
 
 #include <stdexcept>
 
-#include "flashlight/fl/runtime/DeviceManager.h"
-
 namespace fl {
 
 OneDnnCPUStream::OneDnnCPUStream(const dnnl::engine& engine) {
   stream_ = std::make_unique<dnnl::stream>(engine);
-}
-
-X64Device& OneDnnCPUStream::device() {
-  return device_;
-}
-
-const X64Device& OneDnnCPUStream::device() const {
-  return device_;
 }
 
 std::shared_ptr<OneDnnCPUStream> OneDnnCPUStream::create(
@@ -38,14 +28,6 @@ std::shared_ptr<OneDnnCPUStream> OneDnnCPUStream::create(
 
 void OneDnnCPUStream::sync() const {
   stream_->wait();
-}
-
-void OneDnnCPUStream::relativeSync(const OneDnnCPUStream& waitOn) const {
-  waitOn.sync();
-}
-
-dnnl::engine OneDnnCPUStream::engine() const {
-  return stream_->get_engine();
 }
 
 dnnl::stream& OneDnnCPUStream::handle() {

--- a/flashlight/fl/tensor/backend/onednn/OneDnnCPUStream.h
+++ b/flashlight/fl/tensor/backend/onednn/OneDnnCPUStream.h
@@ -9,8 +9,7 @@
 
 #include <memory>
 
-#include "flashlight/fl/runtime/DeviceManager.h"
-#include "flashlight/fl/runtime/Stream.h"
+#include "flashlight/fl/runtime/SynchronousStream.h"
 
 #include <dnnl.hpp>
 
@@ -19,21 +18,13 @@ namespace fl {
 /**
  * An abstraction for OneDNN's CPU Stream with controlled creation methods.
  */
-class OneDnnCPUStream : public StreamTrait<OneDnnCPUStream> {
-  X64Device& device_{DeviceManager::getInstance()
-                         .getActiveDevice(DeviceType::x64)
-                         .impl<X64Device>()};
+class OneDnnCPUStream : public SynchronousStream {
   std::unique_ptr<dnnl::stream> stream_; // stored as a pointer to satisfy `sync() const`
 
   // internal constructor used to create the native OneDNN stream.
   explicit OneDnnCPUStream(const dnnl::engine& engine);
 
  public:
-  // prevent name hiding
-  using StreamTrait<OneDnnCPUStream>::relativeSync;
-
-  static constexpr StreamType type = StreamType::Synchronous;
-
   /**
    * Creates an OneDnnCPUStream on given engine and automatically register it
    * with the active x64 device from DeviceManager.
@@ -44,17 +35,7 @@ class OneDnnCPUStream : public StreamTrait<OneDnnCPUStream> {
    */
   static std::shared_ptr<OneDnnCPUStream> create(const dnnl::engine& engine);
 
-  X64Device& device() override;
-  const X64Device& device() const override;
   void sync() const override;
-  void relativeSync(const OneDnnCPUStream& waitOn) const override;
-
-  /**
-   * Gets the OneDNN engine that owns the underlying stream.
-   *
-   * @return the OneDNN engine that owns the underlying stream.
-   */
-  dnnl::engine engine() const;
 
   /**
    * Gets the underlying OneDNN stream.


### PR DESCRIPTION
Summary:
This goes back to [this comment](https://www.internalfb.com/diff/D37305354 (https://github.com/flashlight/flashlight/commit/18392c30c74606c97d7c66f4c64aa0d15dd70995)?dst_version_fbid=596316795154487&transaction_fbid=606755523893863).

It results in the following class diagram for streams:

```

          Stream
         /      \
CUDAStream       Synchronous
                 /          \
         ArrayFireCPU       OneDnnCPU
```

Reviewed By: jacobkahn

Differential Revision: D38368321

