### PR TITLE
Enforce range::end exclusivity

### DIFF
--- a/flashlight/app/asr/Train.cpp
+++ b/flashlight/app/asr/Train.cpp
@@ -746,7 +746,7 @@ int main(int argc, char** argv) {
       auto viterbipath = criterion
                              ->viterbiPath(
                                  op(fl::span, fl::span, b),
-                                 inputSizes(fl::span, fl::range(b, b)))
+                                 inputSizes(fl::span, fl::range(b, b + 1)))
                              .toHostVector<int>();
       auto tgtraw = tgt.toHostVector<int>();
 

--- a/flashlight/fl/examples/AdaptiveClassification.cpp
+++ b/flashlight/fl/examples/AdaptiveClassification.cpp
@@ -82,12 +82,12 @@ int main(int /* unused */, const char** /* unused */) {
   auto log_prob = criterion.getActivation()->forward(result).tensor();
   Tensor max_value, prediction;
   fl::max(max_value, prediction, log_prob, 0);
-  auto accuracy = mean(prediction == label(fl::span, fl::range(0, 0)), {0});
+  auto accuracy = mean(prediction == label(fl::span, fl::range(0, 1)), {0});
   std::cout << "Accuracy: " << accuracy << std::endl;
 
   auto pred = asActivation->predict(result).tensor();
   accuracy = mean(
-      fl::reshape(pred, label.shape()) == label(fl::span, fl::range(0, 0)),
+      fl::reshape(pred, label.shape()) == label(fl::span, fl::range(0, 1)),
       {0});
   std::cout << "Accuracy: " << accuracy << std::endl;
 

--- a/flashlight/fl/nn/Utils.cpp
+++ b/flashlight/fl/nn/Utils.cpp
@@ -150,7 +150,7 @@ Tensor join(
     for (int d = 0; d < maxNumDims; ++d) {
       sel[d] = fl::range(inputs[i].dim(d));
     }
-    sel[batchDim] = fl::range(i, i);
+    sel[batchDim] = fl::range(i, i + 1);
     if (!inputs[i].isEmpty()) {
       padSeq(sel) = inputs[i];
     }

--- a/flashlight/fl/nn/modules/AdaptiveSoftMax.cpp
+++ b/flashlight/fl/nn/modules/AdaptiveSoftMax.cpp
@@ -63,7 +63,7 @@ Variable AdaptiveSoftMax::getFullLogProb(
     tailOutput = matmul(params_[2 + i * 2], tailOutput);
     auto idx = i + cutoff_[0];
     tailOutput = logSoftmax(tailOutput, 0) +
-        tileAs(headOutput(fl::range(idx, idx)), tailOutput);
+        tileAs(headOutput(fl::range(idx, idx + 1)), tailOutput);
     output(fl::range(cutoff_[i], cutoff_[i + 1])) = tailOutput.tensor();
   }
 

--- a/flashlight/fl/tensor/Index.h
+++ b/flashlight/fl/tensor/Index.h
@@ -14,26 +14,34 @@
 namespace fl {
 
 /**
- * Represents the last index along an axis of a tensor.
+ * Represents the imaginary index _after_ the last index along an axis of a
+ * tensor. We have this special case because the `range::end` is exclusive.
  */
-struct end_t {
-  operator Dim() const {
-    return -1;
-  }
-};
+struct end_t{};
 
-// A static alias for end that can properly decay to an index type
+// A static instance of end_t for convenience, e.g., one can use it in
+// `range(0, end)` to index all elements along certain axis.
 static const end_t end = end_t();
 
 /**
  * An entity representing a contiguous or strided sequence of indices.
+ *
+ * Assuming an axis has N elements, this is the mapping from negative to
+ * positive indices:
+ *  -------------------------
+ *  | -N | -N+1 | ... |  -1 |
+ *  -------------------------
+ *  |  0 |    1 | ... | N-1 |
+ *  -------------------------
  */
 class range {
   using idx = std::variant<end_t, Dim>;
+  static constexpr Dim kDefaultStride = 1;
 
   Dim start_{0};
-  Dim end_{fl::end};
-  Dim stride_{1};
+  // end is exclusive; std::nullopt means including the last element
+  std::optional<Dim> end_{std::nullopt};
+  Dim stride_{kDefaultStride};
 
  public:
   /**
@@ -46,7 +54,7 @@ class range {
    *
    * @param[in] idx the end index of the range, which will start from 0
    */
-  explicit range(const idx& idx);
+  explicit range(const Dim& idx);
 
   /**
    * Construct a range with the indices [start, end) (i.e. [start, end - 1])
@@ -54,7 +62,7 @@ class range {
    * @param[in] start the starting index of the range
    * @param[in] end the end index of the range, which will start from 0
    */
-  range(const idx& start, const idx& end);
+  range(const Dim& start, const idx& end);
 
   /**
    * Construct a range with the indices [start, end) (i.e. [start, end - 1])
@@ -64,10 +72,13 @@ class range {
    * @param[in] end the end index of the range, which will start from 0
    * @param[in] stride the interval over which successive range elements appear
    */
-  range(const idx& start, const idx& end, const Dim stride);
+  range(const Dim& start, const idx& end, const Dim stride);
 
   Dim start() const;
-  Dim end() const;
+  // std::nullopt represents `end_t`
+  const std::optional<Dim>& end() const;
+  // throw if end is `end_t`
+  Dim endVal() const;
   Dim stride() const;
   bool operator==(const range& other) const;
   bool operator!=(const range& other) const;

--- a/flashlight/fl/test/contrib/modules/ContribModuleTest.cpp
+++ b/flashlight/fl/test/contrib/modules/ContribModuleTest.cpp
@@ -164,23 +164,23 @@ void transformerPadMaskFwd(bool isfp16) {
   auto output1 = tr.forward({input1NoPad,
                              Variable(
                                  padMask(fl::range(0, timesteps / 2))(
-                                     fl::span, fl::range(0, 0)),
+                                     fl::span, fl::range(0, 1)),
                                  false)})
                      .front();
   auto output2 =
-      tr.forward({input2, Variable(padMask(fl::span, fl::range(1, 1)), false)})
+      tr.forward({input2, Variable(padMask(fl::span, fl::range(1, 2)), false)})
           .front();
   ASSERT_TRUE(allClose(
-      output.tensor()(fl::span, fl::span, fl::range(1, 1)), output2.tensor()));
+      output.tensor()(fl::span, fl::span, fl::range(1, 2)), output2.tensor()));
   ASSERT_TRUE(allClose(
-      outputNoPad.tensor()(fl::span, fl::span, fl::range(1, 1)),
+      outputNoPad.tensor()(fl::span, fl::span, fl::range(1, 2)),
       output2.tensor()));
   ASSERT_TRUE(allClose(
-      output.tensor()(fl::span, fl::iota({timesteps / 2}), fl::range(0, 0)),
+      output.tensor()(fl::span, fl::iota({timesteps / 2}), fl::range(0, 1)),
       output1.tensor()));
   ASSERT_FALSE(allClose(
       outputNoPad.tensor()(
-          fl::span, fl::iota({timesteps / 2}), fl::range(0, 0)),
+          fl::span, fl::iota({timesteps / 2}), fl::range(0, 1)),
       output1.tensor()));
 }
 

--- a/flashlight/fl/test/nn/ModuleTest.cpp
+++ b/flashlight/fl/test/nn/ModuleTest.cpp
@@ -183,9 +183,9 @@ TEST(ModuleTest, GLUFwd) {
   auto batchOutVar = glu(inVar);
 
   for (int i = 0; i < batchsize; ++i) {
-    expected_outVar = glu.forward(inVar(fl::span, fl::span, fl::range(i, i)));
+    expected_outVar = glu.forward(inVar(fl::span, fl::span, fl::range(i, i + 1)));
     ASSERT_TRUE(allClose(
-        batchOutVar.tensor()(fl::span, fl::span, fl::range(i, i)),
+        batchOutVar.tensor()(fl::span, fl::span, fl::range(i, i + 1)),
         expected_outVar.tensor(),
         1E-7));
   }
@@ -219,10 +219,10 @@ TEST_F(ModuleTestF16, GLUFwdF16) {
   auto batchOutVar = glu(inVar);
 
   for (int i = 0; i < batchsize; ++i) {
-    expected_outVar = glu.forward(inVar(fl::span, fl::span, fl::range(i, i)));
+    expected_outVar = glu.forward(inVar(fl::span, fl::span, fl::range(i, i + 1)));
     ASSERT_EQ(batchOutVar.type(), expected_outVar.type());
     ASSERT_TRUE(allClose(
-        batchOutVar.tensor()(fl::span, fl::span, fl::range(i, i)),
+        batchOutVar.tensor()(fl::span, fl::span, fl::range(i, i + 1)),
         expected_outVar.tensor(),
         1E-3));
   }
@@ -256,9 +256,9 @@ TEST(ModuleTest, LogSoftmaxFwd) {
 
   for (int i = 0; i < batchsize; ++i) {
     auto expected_outVar =
-        lsm.forward(inVar(fl::span, fl::span, fl::range(i, i)));
+        lsm.forward(inVar(fl::span, fl::span, fl::range(i, i + 1)));
     ASSERT_TRUE(allClose(
-        batchOutVar.tensor()(fl::span, fl::span, fl::range(i, i)),
+        batchOutVar.tensor()(fl::span, fl::span, fl::range(i, i + 1)),
         expected_outVar.tensor(),
         1E-7));
   }
@@ -299,9 +299,9 @@ TEST_F(ModuleTestF16, LogSoftmaxFwdF16) {
 
   for (int i = 0; i < batchsize; ++i) {
     auto expected_outVar =
-        lsm.forward(inVar(fl::span, fl::span, fl::range(i, i)));
+        lsm.forward(inVar(fl::span, fl::span, fl::range(i, i + 1)));
     ASSERT_TRUE(allClose(
-        batchOutVar.tensor()(fl::span, fl::span, fl::range(i, i)),
+        batchOutVar.tensor()(fl::span, fl::span, fl::range(i, i + 1)),
         expected_outVar.tensor(),
         1E-7));
   }
@@ -316,9 +316,9 @@ TEST(ModuleTest, ConvolutionFwd) {
 
   for (int i = 0; i < batchsize; ++i) {
     auto expected_outVar = conv(
-        Variable(input(fl::span, fl::span, fl::span, fl::range(i, i)), false));
+        Variable(input(fl::span, fl::span, fl::span, fl::range(i, i + 1)), false));
     ASSERT_TRUE(allClose(
-        batchOutVar.tensor()(fl::span, fl::span, fl::span, fl::range(i, i)),
+        batchOutVar.tensor()(fl::span, fl::span, fl::span, fl::range(i, i + 1)),
         expected_outVar.tensor(),
         1E-5));
   }
@@ -338,9 +338,9 @@ TEST_F(ModuleTestF16, ConvolutionFwdF16) {
 
   for (int i = 0; i < batchsize; ++i) {
     auto expected_outVar = conv(
-        Variable(input(fl::span, fl::span, fl::span, fl::range(i, i)), false));
+        Variable(input(fl::span, fl::span, fl::span, fl::range(i, i + 1)), false));
     ASSERT_TRUE(allClose(
-        batchOutVar.tensor()(fl::span, fl::span, fl::span, fl::range(i, i)),
+        batchOutVar.tensor()(fl::span, fl::span, fl::span, fl::range(i, i + 1)),
         expected_outVar.tensor(),
         1E-7));
   }
@@ -359,9 +359,9 @@ TEST(ModuleTest, ConvolutionWithGroupFwd) {
   auto batchOutVar = conv(Variable(input, false));
   for (int i = 0; i < batchsize; ++i) {
     auto expected_outVar = conv(
-        Variable(input(fl::span, fl::span, fl::span, fl::range(i, i)), false));
+        Variable(input(fl::span, fl::span, fl::span, fl::range(i, i + 1)), false));
     ASSERT_TRUE(allClose(
-        batchOutVar.tensor()(fl::span, fl::span, fl::span, fl::range(i, i)),
+        batchOutVar.tensor()(fl::span, fl::span, fl::span, fl::range(i, i + 1)),
         expected_outVar.tensor(),
         1E-5));
   }
@@ -376,9 +376,9 @@ TEST(ModuleTest, PoolingFwd) {
   for (int i = 0; i < batchsize; ++i) {
     ASSERT_EQ(input.shape(), batchOutVar.shape());
     auto expected_outVar = pool(
-        Variable(input(fl::span, fl::span, fl::span, fl::range(i, i)), false));
+        Variable(input(fl::span, fl::span, fl::span, fl::range(i, i + 1)), false));
     ASSERT_TRUE(allClose(
-        batchOutVar.tensor()(fl::span, fl::span, fl::span, fl::range(i, i)),
+        batchOutVar.tensor()(fl::span, fl::span, fl::span, fl::range(i, i + 1)),
         expected_outVar.tensor(),
         1E-7));
   }
@@ -397,9 +397,9 @@ TEST_F(ModuleTestF16, PoolingFwdF16) {
   for (int i = 0; i < batchsize; ++i) {
     ASSERT_EQ(input.shape(), batchOutVar.shape());
     auto expected_outVar = pool(
-        Variable(input(fl::span, fl::span, fl::span, fl::range(i, i)), false));
+        Variable(input(fl::span, fl::span, fl::span, fl::range(i, i + 1)), false));
     ASSERT_TRUE(allClose(
-        batchOutVar.tensor()(fl::span, fl::span, fl::span, fl::range(i, i)),
+        batchOutVar.tensor()(fl::span, fl::span, fl::span, fl::range(i, i + 1)),
         expected_outVar.tensor(),
         1E-7));
   }
@@ -632,7 +632,7 @@ TEST(ModuleTest, PaddingFwd) {
   auto input = Variable(fl::rand({1, 2, 3, 4}, fl::dtype::f64), true);
   auto output = module(input);
   ASSERT_EQ(output.shape(), Shape({4, 9, 3, 4}));
-  ASSERT_TRUE(allClose(input, output(fl::range(1, 1), fl::range(3, 5))));
+  ASSERT_TRUE(allClose(input, output(fl::range(1, 2), fl::range(3, 5))));
   ASSERT_NEAR(
       fl::sum(input.tensor()).scalar<double>(),
       fl::sum(output.tensor()).scalar<double>() + 408,
@@ -836,7 +836,7 @@ TEST(ModuleTest, AdaptiveSoftMaxLossBatchFwd) {
   auto singleOut = fl::full({T, B}, 0, fl::dtype::f32);
   for (int i = 0; i < B; ++i) {
     auto singleOutVar = asml->forward(
-        x(fl::span, fl::span, fl::range(i, i)), y(fl::span, fl::range(i, i)));
+        x(fl::span, fl::span, fl::range(i, i + 1)), y(fl::span, fl::range(i, i + 1)));
     singleOut(fl::span, i) = singleOutVar.tensor();
   }
 

--- a/flashlight/fl/test/nn/NNUtilsTest.cpp
+++ b/flashlight/fl/test/nn/NNUtilsTest.cpp
@@ -39,29 +39,29 @@ TEST(UtilsTest, Join) {
   ASSERT_EQ(o1.shape(), Shape({30, 1, 300, 3}));
   ASSERT_TRUE(
       fl::all(
-          o1(fl::range(25), fl::range(0, 0), fl::range(300), fl::range(0, 0)) ==
+          o1(fl::range(25), fl::range(0, 1), fl::range(300), fl::range(0, 1)) ==
           a)
           .asScalar<bool>());
   ASSERT_TRUE(fl::all(
                   o1(fl::range(25, 29),
-                     fl::range(0, 0),
+                     fl::range(0, 1),
                      fl::range(300),
-                     fl::range(0, 0)) == 0)
+                     fl::range(0, 1)) == 0)
                   .asScalar<bool>());
   ASSERT_TRUE(
       fl::all(
-          o1(fl::range(20), fl::range(0, 0), fl::range(300), fl::range(1, 1)) ==
+          o1(fl::range(20), fl::range(0, 1), fl::range(300), fl::range(1, 2)) ==
           b)
           .asScalar<bool>());
   ASSERT_TRUE(fl::all(
                   o1(fl::range(20, 29),
-                     fl::range(0, 0),
+                     fl::range(0, 1),
                      fl::range(300),
-                     fl::range(1, 1)) == 0)
+                     fl::range(1, 2)) == 0)
                   .asScalar<bool>());
   ASSERT_TRUE(
       fl::all(
-          o1(fl::range(30), fl::range(0, 0), fl::range(300), fl::range(2, 2)) ==
+          o1(fl::range(30), fl::range(0, 1), fl::range(300), fl::range(2, 3)) ==
           c)
           .asScalar<bool>());
 
@@ -69,45 +69,45 @@ TEST(UtilsTest, Join) {
   ASSERT_EQ(o2.shape(), Shape({30, 1, 300, 3}));
   ASSERT_TRUE(
       fl::all(
-          o2(fl::range(25), fl::range(0, 0), fl::range(300), fl::range(0, 0)) ==
+          o2(fl::range(25), fl::range(0, 1), fl::range(300), fl::range(0, 1)) ==
           a)
           .asScalar<bool>());
   ASSERT_TRUE(fl::all(
                   o2(fl::range(25, 29),
-                     fl::range(0, 0),
+                     fl::range(0, 1),
                      fl::range(300),
-                     fl::range(0, 0)) == -1)
+                     fl::range(0, 1)) == -1)
                   .asScalar<bool>());
   ASSERT_TRUE(
       fl::all(
-          o2(fl::range(20), fl::range(0, 0), fl::range(300), fl::range(1, 1)) ==
+          o2(fl::range(20), fl::range(0, 1), fl::range(300), fl::range(1, 2)) ==
           b)
           .asScalar<bool>());
   ASSERT_TRUE(fl::all(
                   o2(fl::range(20, 29),
-                     fl::range(0, 0),
+                     fl::range(0, 1),
                      fl::range(300),
-                     fl::range(1, 1)) == -1)
+                     fl::range(1, 2)) == -1)
                   .asScalar<bool>());
   ASSERT_TRUE(
       fl::all(
-          o2(fl::range(30), fl::range(0, 0), fl::range(300), fl::range(2, 2)) ==
+          o2(fl::range(30), fl::range(0, 1), fl::range(300), fl::range(2, 3)) ==
           c)
           .asScalar<bool>());
 
   auto o3 = join({a, b, c}, -1, 1);
   ASSERT_EQ(o3.shape(), Shape({30, 3, 300, 1}));
-  ASSERT_TRUE(fl::all(o3(fl::range(25), fl::range(0, 0), fl::range(300)) == a)
+  ASSERT_TRUE(fl::all(o3(fl::range(25), fl::range(0, 1), fl::range(300)) == a)
                   .asScalar<bool>());
   ASSERT_TRUE(
-      fl::all(o3(fl::range(25, 29), fl::range(0, 0), fl::range(300)) == -1)
+      fl::all(o3(fl::range(25, 29), fl::range(0, 1), fl::range(300)) == -1)
           .asScalar<bool>());
-  ASSERT_TRUE(fl::all(o3(fl::range(20), fl::range(1, 1), fl::range(300)) == b)
+  ASSERT_TRUE(fl::all(o3(fl::range(20), fl::range(1, 2), fl::range(300)) == b)
                   .asScalar<bool>());
   ASSERT_TRUE(
-      fl::all(o3(fl::range(20, 29), fl::range(1, 1), fl::range(300)) == -1)
+      fl::all(o3(fl::range(20, 29), fl::range(1, 2), fl::range(300)) == -1)
           .asScalar<bool>());
-  ASSERT_TRUE(fl::all(o3(fl::range(30), fl::range(2, 2), fl::range(300)) == c)
+  ASSERT_TRUE(fl::all(o3(fl::range(30), fl::range(2, 3), fl::range(300)) == c)
                   .asScalar<bool>());
 }
 

--- a/flashlight/fl/test/tensor/IndexTest.cpp
+++ b/flashlight/fl/test/tensor/IndexTest.cpp
@@ -18,16 +18,21 @@ using namespace fl;
 TEST(IndexTest, range) {
   auto s1 = fl::range(3);
   ASSERT_EQ(s1.start(), 0);
-  ASSERT_EQ(s1.end(), 2);
+  ASSERT_EQ(s1.endVal(), 3);
   ASSERT_EQ(s1.stride(), 1);
 
   auto s2 = fl::range(4, 5);
   ASSERT_EQ(s2.start(), 4);
-  ASSERT_EQ(s2.end(), 4);
+  ASSERT_EQ(s2.endVal(), 5);
   ASSERT_EQ(s2.stride(), 1);
 
   auto s3 = fl::range(7, 8, 9);
   ASSERT_EQ(s3.stride(), 9);
+
+  auto s4 = fl::range(1, fl::end, 2);
+  ASSERT_EQ(s4.start(), 1);
+  ASSERT_EQ(s4.end(), std::nullopt);
+  ASSERT_EQ(s4.stride(), 2);
 }
 
 TEST(IndexTest, rangeEq) {
@@ -60,9 +65,11 @@ TEST(IndexTest, Shape) {
   ASSERT_EQ(t(2, fl::span).shape(), Shape({4}));
   ASSERT_EQ(t(2).shape(), Shape({4}));
   ASSERT_EQ(t(fl::range(3)).shape(), Shape({3, 4}));
-  ASSERT_EQ(t(fl::range(1, 1)).shape(), Shape({1, 4}));
+  // TODO {0, 4} once empty ranges are supported across all backends
+  // ASSERT_EQ(t(fl::range(1, 1)).shape(), Shape({1, 4}));
   ASSERT_EQ(t(fl::range(1, 2)).shape(), Shape({1, 4}));
-  ASSERT_EQ(t(fl::span, fl::range(1, 1)).shape(), Shape({4, 1}));
+  // TODO ditto
+  // ASSERT_EQ(t(fl::span, fl::range(1, 1)).shape(), Shape({4, 1}));
   ASSERT_EQ(t(fl::range(1, 2), fl::range(1, 2)).shape(), Shape({1, 1}));
   ASSERT_EQ(t(fl::range(0, fl::end)).shape(), Shape({4, 4}));
   ASSERT_EQ(t(fl::range(0, fl::end, 2)).shape(), Shape({2, 4}));

--- a/flashlight/fl/test/tensor/af/ArrayFireTensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/af/ArrayFireTensorBaseTest.cpp
@@ -8,9 +8,11 @@
 #include <arrayfire.h>
 #include <gtest/gtest.h>
 
+#include <exception>
 #include <stdexcept>
 #include <utility>
 
+#include "af/util.h"
 #include "flashlight/fl/tensor/Init.h"
 #include "flashlight/fl/tensor/Random.h"
 #include "flashlight/fl/tensor/TensorBackend.h"
@@ -427,6 +429,18 @@ TEST(ArrayFireTensorBaseTest, device) {
 TEST(ArrayFireTensorBaseTest, defaultConstructor) {
   auto t = ArrayFireTensor();
   ASSERT_TRUE(t.getHandle().isempty());
+}
+
+TEST(ArrayFireTensorBaseTest, emptyRangeIndexing) {
+  // TODO the following should all return empty tensor, but AF currently doesn't
+  // have a way to represent empty range, and we are just throwing internally.
+  auto t = fl::rand({5});
+  ASSERT_THROW(t(fl::range(5, fl::end)).shape(), std::exception);
+  ASSERT_THROW(t(fl::range(4, -1)).shape(), std::exception);
+  ASSERT_THROW(t(fl::range(0, 0)).shape(), std::exception);
+  ASSERT_THROW(t(fl::range(1, 1)).shape(), std::exception);
+  ASSERT_THROW(t(fl::range(4, 4)).shape(), std::exception);
+  ASSERT_THROW(t(fl::range(0, -5)).shape(), std::exception);
 }
 
 int main(int argc, char** argv) {

--- a/flashlight/pkg/speech/test/criterion/Seq2SeqTest.cpp
+++ b/flashlight/pkg/speech/test/criterion/Seq2SeqTest.cpp
@@ -82,7 +82,7 @@ TEST(Seq2SeqTest, Seq2Seq) {
   ASSERT_TRUE(allClose(attention, attentionSeq, 1e-6));
 
   // Check size 1 Target works
-  target = target(fl::range(0, 0), fl::span);
+  target = target(fl::range(0, 1), fl::span);
   auto loss =
       seq2seq({noGrad(input), noGrad(target), fl::noGrad(Tensor())}).front();
 

--- a/flashlight/pkg/vision/criterion/Hungarian.cpp
+++ b/flashlight/pkg/vision/criterion/Hungarian.cpp
@@ -91,8 +91,8 @@ std::vector<std::pair<Tensor, Tensor>> HungarianMatcher::compute(
   std::vector<std::pair<Tensor, Tensor>> results;
   for (int b = 0; b < predBoxes.dim(2); b++) {
     auto result = matchBatch(
-        predBoxes(fl::span, fl::span, fl::range(b, b)),
-        predLogits(fl::span, fl::span, fl::range(b, b)),
+        predBoxes(fl::span, fl::span, fl::range(b, b + 1)),
+        predLogits(fl::span, fl::span, fl::range(b, b + 1)),
         targetBoxes[b],
         targetClasses[b]);
     results.emplace_back(result);

--- a/flashlight/pkg/vision/criterion/SetCriterion.cpp
+++ b/flashlight/pkg/vision/criterion/SetCriterion.cpp
@@ -155,7 +155,7 @@ SetCriterion::LossDict SetCriterion::forward(
   for (int i = 0; i < predBoxesAux.dim(3); i++) {
     auto predBoxes = predBoxesAux(fl::span, fl::span, fl::span, i);
     auto predLogits =
-        predLogitsAux(fl::span, fl::span, fl::span, fl::range(i, i));
+        predLogitsAux(fl::span, fl::span, fl::span, fl::range(i, i + 1));
 
     std::vector<Tensor> targetBoxesArray(targetBoxes.size());
     std::vector<Tensor> targetClassesArray(targetClasses.size());

--- a/flashlight/pkg/vision/dataset/BoxUtils.cpp
+++ b/flashlight/pkg/vision/dataset/BoxUtils.cpp
@@ -20,30 +20,30 @@ namespace pkg {
 namespace vision {
 
 Tensor cxcywh2xyxy(const Tensor& bboxes) {
-  auto xc = bboxes(fl::range(0, 0));
-  auto yc = bboxes(fl::range(1, 1));
-  auto w = bboxes(fl::range(2, 2));
-  auto h = bboxes(fl::range(3, 3));
+  auto xc = bboxes(fl::range(0, 1));
+  auto yc = bboxes(fl::range(1, 2));
+  auto w = bboxes(fl::range(2, 3));
+  auto h = bboxes(fl::range(3, 4));
 
   return fl::concatenate(
       0, xc - 0.5 * w, yc - 0.5 * h, xc + 0.5 * w, yc + 0.5 * h);
 }
 
 fl::Variable cxcywh2xyxy(const Variable& bboxes) {
-  auto xc = bboxes(fl::range(0, 0));
-  auto yc = bboxes(fl::range(1, 1));
-  auto w = bboxes(fl::range(2, 2));
-  auto h = bboxes(fl::range(3, 3));
+  auto xc = bboxes(fl::range(0, 1));
+  auto yc = bboxes(fl::range(1, 2));
+  auto w = bboxes(fl::range(2, 3));
+  auto h = bboxes(fl::range(3, 4));
 
   return fl::concatenate(
       {xc - 0.5 * w, yc - 0.5 * h, xc + 0.5 * w, yc + 0.5 * h}, 0);
 }
 
 Tensor xyxy2cxcywh(const Tensor& bboxes) {
-  auto x0 = bboxes(fl::range(0, 0));
-  auto y0 = bboxes(fl::range(1, 1));
-  auto x1 = bboxes(fl::range(2, 2));
-  auto y1 = bboxes(fl::range(3, 3));
+  auto x0 = bboxes(fl::range(0, 1));
+  auto y0 = bboxes(fl::range(1, 2));
+  auto x1 = bboxes(fl::range(2, 3));
+  auto y1 = bboxes(fl::range(3, 4));
   Tensor result =
       fl::concatenate(0, (x0 + x1) / 2, (y0 + y1) / 2, (x1 - x0), (y1 - y0));
   return result;
@@ -85,19 +85,19 @@ fl::Variable flatten(const fl::Variable& x, int start, int stop) {
 };
 
 Tensor boxArea(const Tensor& bboxes) {
-  auto x0 = bboxes(fl::range(0, 0));
-  auto y0 = bboxes(fl::range(1, 1));
-  auto x1 = bboxes(fl::range(2, 2));
-  auto y1 = bboxes(fl::range(3, 3));
+  auto x0 = bboxes(fl::range(0, 1));
+  auto y0 = bboxes(fl::range(1, 2));
+  auto x1 = bboxes(fl::range(2, 3));
+  auto y1 = bboxes(fl::range(3, 4));
   auto result = (x1 - x0) * (y1 - y0);
   return result;
 }
 
 fl::Variable boxArea(const fl::Variable& bboxes) {
-  auto x0 = bboxes(fl::range(0, 0));
-  auto y0 = bboxes(fl::range(1, 1));
-  auto x1 = bboxes(fl::range(2, 2));
-  auto y1 = bboxes(fl::range(3, 3));
+  auto x0 = bboxes(fl::range(0, 1));
+  auto y0 = bboxes(fl::range(1, 2));
+  auto x1 = bboxes(fl::range(2, 3));
+  auto y1 = bboxes(fl::range(3, 4));
   auto result = (x1 - x0) * (y1 - y0);
   return result;
 }
@@ -149,7 +149,7 @@ std::tuple<Tensor, Tensor> boxIou(
   auto rb = cartesian(
       bboxes1(fl::range(2, 4)), bboxes2(fl::range(2, 4)), fl::minimum);
   auto wh = fl::maximum((rb - lt), 0.0);
-  auto inter = wh(fl::range(0, 0)) * wh(fl::range(1, 1));
+  auto inter = wh(fl::range(0, 1)) * wh(fl::range(1, 2));
   auto uni = cartesian(area1, area2, fl::operator+) - inter;
   auto iou = inter / uni;
   iou = flatten(iou, 0, 1);
@@ -173,7 +173,7 @@ std::tuple<fl::Variable, fl::Variable> boxIou(
       cartesian(bboxes1(fl::range(0, 2)), bboxes2(fl::range(0, 2)), fl::max);
   auto rb = cartesian(bboxes1(fl::range(2, 4)), bboxes2(fl::range(2, 4)), min);
   auto wh = max((rb - lt), 0.0);
-  auto inter = wh(fl::range(0, 0)) * wh(fl::range(1, 1));
+  auto inter = wh(fl::range(0, 1)) * wh(fl::range(1, 2));
   auto uni = cartesian(area1, area2, fl::operator+) - inter;
   auto iou = inter / uni;
   iou = flatten(iou, 0, 1);
@@ -200,7 +200,7 @@ fl::Variable generalizedBoxIou(
   auto lt = cartesian(bboxes1(fl::range(0, 2)), bboxes2(fl::range(0, 2)), min);
   auto rb = cartesian(bboxes1(fl::range(2, 4)), bboxes2(fl::range(2, 4)), max);
   auto wh = max((rb - lt), 0.0);
-  auto area = wh(fl::range(0, 0)) * wh(fl::range(1, 1));
+  auto area = wh(fl::range(0, 1)) * wh(fl::range(1, 2));
   area = flatten(area, 0, 1);
   return iou - (area - uni) / area;
 }
@@ -221,7 +221,7 @@ Tensor generalizedBoxIou(const Tensor& bboxes1, const Tensor& bboxes2) {
   auto rb = cartesian(
       bboxes1(fl::range(2, 4)), bboxes2(fl::range(2, 4)), fl::maximum);
   auto wh = fl::maximum((rb - lt), 0.0);
-  auto area = wh(fl::range(0, 0)) * wh(fl::range(1, 1));
+  auto area = wh(fl::range(0, 1)) * wh(fl::range(1, 2));
   area = flatten(area, 0, 1);
   return iou - (area - uni) / area;
 }

--- a/flashlight/pkg/vision/dataset/Coco.cpp
+++ b/flashlight/pkg/vision/dataset/Coco.cpp
@@ -49,9 +49,9 @@ std::pair<Tensor, Tensor> makeImageAndMaskBatch(
     Shape dims = sample.shape();
     int w = dims[0];
     int h = dims[1];
-    batcharr(fl::range(0, w), fl::range(0, h), fl::span, fl::range(i, i)) =
+    batcharr(fl::range(0, w), fl::range(0, h), fl::span, fl::range(i, i + 1)) =
         data[i];
-    maskarr(fl::range(0, w), fl::range(0, h), fl::span, fl::range(i, i)) =
+    maskarr(fl::range(0, w), fl::range(0, h), fl::span, fl::range(i, i + 1)) =
         fl::full({w, h}, 1);
   }
   return std::make_pair(batcharr, maskarr);

--- a/flashlight/pkg/vision/dataset/CocoTransforms.cpp
+++ b/flashlight/pkg/vision/dataset/CocoTransforms.cpp
@@ -49,8 +49,8 @@ crop(const std::vector<Tensor>& in, int x, int y, int tw, int th) {
     croppedBoxes = fl::minimum(croppedBoxes, maxSizeArray);
     croppedBoxes = fl::maximum(croppedBoxes, 0.0);
     Tensor keep = fl::all(
-        croppedBoxes(fl::span, fl::range(1, 1), fl::span) >
-            croppedBoxes(fl::span, fl::range(0, 0), fl::span),
+        croppedBoxes(fl::span, fl::range(1, 2), fl::span) >
+            croppedBoxes(fl::span, fl::range(0, 1), fl::span),
         {0});
     croppedBoxes = fl::reshape(croppedBoxes, {4, boxes.dim(1)});
     croppedBoxes = croppedBoxes(fl::span, keep);


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.** Changes *must* be discussed.

**Original Issue**: [corresponding issue on Github]

*Note:* You can add `closes #[issue number]` to automatically close the issue that this PR resolves when it is merged.

### Summary
Addresses 2 things:
1. Some parts of the codebase are not using `range::end` correctly -- they assumed `range(k, k)` denotes a sequence of 1 element, when it should denote an empty sequence.
2. `range::end` is inclusive, despite the constructor being inclusive for input `end`.

### Test Plan (required)
New tests are added.
