### PR TITLE
Use the correct TensorBackend

### DIFF
--- a/flashlight/fl/tensor/Compute.cpp
+++ b/flashlight/fl/tensor/Compute.cpp
@@ -92,7 +92,7 @@ void relativeSync(
 }
 
 void eval(Tensor& tensor) {
-  Tensor().backend().eval(tensor);
+  tensor.backend().eval(tensor);
 }
 
 int getDevice() {


### PR DESCRIPTION
Summary:
`eval()` in `Compute.cpp` currently constructor a new empty tensor to get the backend and use `TensorBackend::eval`.

However, the current default Tensor type might differ from the input Tensor, so it's safer to use the input tensor's backend instead.

Differential Revision: D38451127

