### PR TITLE
Fix cereal install dirs for non-standalone build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,7 +162,7 @@ if (FL_BUILD_CORE)
     include(${CMAKE_MODULE_PATH}/BuildCereal.cmake)
     add_dependencies(flashlight cereal)
     # Move cereal headers at install time
-    install(DIRECTORY ${CEREAL_SOURCE_DIR}/include/cereal
+    install(DIRECTORY ${CEREAL_SOURCE_DIR}/include/cereal/
       DESTINATION ${CEREAL_INSTALL_PATH}
       COMPONENT cereal
       FILES_MATCHING


### PR DESCRIPTION
Summary: Per bwasti, install the contents of `cereal` into `include/cereal` not `include/cereal/cereal` to get rid of a `-I` in the wild. CMake is a cargo cult sometimes.

Differential Revision: D38518554

