### PR TITLE
Implement most of indexing

### DIFF
--- a/flashlight/fl/tensor/backend/onednn/OneDnnTensor.h
+++ b/flashlight/fl/tensor/backend/onednn/OneDnnTensor.h
@@ -50,7 +50,6 @@ class OneDnnTensor : public TensorAdapterBase {
      *        [4, 5, 6]]
      */
     dnnl::memory memory;
-    Shape shape;
     // Whether the data in `memory` is ready (its computation finished).
     bool isDataReady{false};
     bool isDevicePtrLocked{false};
@@ -60,6 +59,8 @@ class OneDnnTensor : public TensorAdapterBase {
 
   // shared among tensors that are shallow copied
   std::shared_ptr<SharedData> sharedData_;
+  Shape shape_;
+  dnnl::memory::desc memDesc_;
 
   // Return the underlying data handle in `memory`.
   // If `isDataReady` is false, sync and set it to true.
@@ -75,8 +76,15 @@ class OneDnnTensor : public TensorAdapterBase {
  public:
   /**
    * Helper constructor for shallow-copying. For internal use only.
+   *
+   * @param[in] sharedData shared data among shallow copies or view from indexing
+   * @param[in] shape_ Flashlight shape of the this Tensor (which may be a view)
+   * @param[in] memDesc OneDNN memory descriptor for this Tensor (which may be a view)
    */
-  explicit OneDnnTensor(std::shared_ptr<SharedData> sharedData);
+  OneDnnTensor(
+      std::shared_ptr<SharedData> sharedData,
+      const Shape& shape_,
+      const dnnl::memory::desc& memDesc);
 
   /**
    * Construct an OneDNNTensor with given shape and memory.
@@ -183,9 +191,18 @@ bool equals(OneDnnTensor&& other);
  * Get the underlying OneDNN memory handle.
  * NOTE not const-correct to conform with OneDNN primitive execution API.
  *
- * @return an immutable reference to the underlying OneDNN memory handle.
+ * @return a reference to the underlying OneDNN memory handle.
  */
 dnnl::memory& memory();
+
+/**
+ * Get the current OneDNN memory descriptor (which may be a view) for this tensor.
+ * Guaranteed to have same data type as original memory desc.
+ *
+ * @return an immutable reference to the underlying OneDNN memory descriptro.
+ */
+const dnnl::memory::desc& memoryDesc() const;
+
 };
 
 // Safe to drop `const`, as these are just checked version of `Tensor::impl`

--- a/flashlight/fl/tensor/backend/onednn/Utils.cpp
+++ b/flashlight/fl/tensor/backend/onednn/Utils.cpp
@@ -102,6 +102,10 @@ dnnl::memory::dims shapeToOneDnnDims(const Shape& shape) {
   return flDimsToOneDnnDims(shape.get());
 }
 
+Shape oneDnnDimsToShape(const dnnl::memory::dims& dims) {
+  return Shape(std::vector<Dim>(dims.rbegin(), dims.rend()));
+}
+
 bool isFpType(dnnl::memory::data_type type) {
   switch (type) {
     case dnnl::memory::data_type::f32:

--- a/flashlight/fl/tensor/backend/onednn/Utils.h
+++ b/flashlight/fl/tensor/backend/onednn/Utils.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <unordered_set>
+
 #include "flashlight/fl/tensor/Shape.h"
 #include "flashlight/fl/tensor/Types.h"
 
@@ -64,6 +66,13 @@ dnnl::memory::dims flDimsToOneDnnDims(const std::vector<Dim>& flDims);
 dnnl::memory::dims shapeToOneDnnDims(const Shape& shape);
 
 /**
+ * Convert OneDNN dimensions to a Flashlight Shape.
+ *
+ * @return the corresponding shape for given OneDNN dims.
+ */
+Shape oneDnnDimsToShape(const dnnl::memory::dims& dims);
+
+/**
  * Return the input type that can represent a larger range of data.
  *
  * @param[in] t1 the first input type.
@@ -85,6 +94,28 @@ dnnl::memory::data_type getTypeWithLargerRange(
 dnnl::memory::desc oneDnnContiguousMemDescFromShape(
     const Shape& shape,
     const dnnl::memory::data_type type);
+
+/**
+ * Return a copy of the given vector with items at given indices removed.
+ *
+ * @param[in] items vector to copy and filter.
+ * @param[in] indicesToFilter indices of items to be filtered.
+ * @return the filtered copy of given vector.
+ */
+template <typename T>
+std::vector<T> removeIndices(
+    const std::vector<T>& items,
+    const std::vector<int>& indicesToFilter) {
+  std::vector<T> itemsKept;
+  std::unordered_set<int> axesToFilterSet(
+      indicesToFilter.begin(), indicesToFilter.end());
+  for (int idx = 0; idx < items.size(); idx++) {
+    if (axesToFilterSet.count(idx) == 0) {
+      itemsKept.push_back(items[idx]);
+    }
+  }
+  return itemsKept;
+}
 
 } // namespace detail
 } // namespace fl


### PR DESCRIPTION
Summary:
As title. These cases are not supported (most benchmarks don't seem to use them anyway):

1. Advanced indexing (Tensor as index)
2. For `range(start, end, stride)`, stride != 1.

Reviewed By: jacobkahn

Differential Revision: D38361464

