### PR TITLE
Update Logging.h

### DIFF
--- a/flashlight/fl/common/Logging.h
+++ b/flashlight/fl/common/Logging.h
@@ -13,6 +13,7 @@
 #include <sstream>
 #include <string>
 #include <utility>
+#include <array>
 
 /**
  * \defgroup logging Logging Library


### PR DESCRIPTION
Added #include <array> to prevent build errors.

**IMPORTANT: Please do not create a Pull Request without creating an issue first.** Changes *must* be discussed.

**Original Issue**: Corresponding issue on GitHub #981 (`closes #981`)

### Summary
In the fl/common/Logging.h/.cpp a `#include <array>` is missing, which causes build errors when building from the source.

### Test Plan (required)
I added the missing include and the build (following the steps described in the README.md) was successful.
