### PR TITLE
Add/consolidate to defaultTensorBackend()

### DIFF
--- a/flashlight/fl/common/Utils.cpp
+++ b/flashlight/fl/common/Utils.cpp
@@ -15,13 +15,14 @@
 #include <unordered_map>
 
 #include "flashlight/fl/tensor/Compute.h"
+#include "flashlight/fl/tensor/DefaultTensorType.h"
 #include "flashlight/fl/tensor/TensorBackend.h"
 #include "flashlight/fl/tensor/TensorBase.h"
 
 namespace fl {
 
 bool f16Supported() {
-  return Tensor().backend().isDataTypeSupported(fl::dtype::f16);
+  return defaultTensorBackend().isDataTypeSupported(fl::dtype::f16);
 }
 
 std::string dateTimeWithMicroSeconds() {

--- a/flashlight/fl/tensor/CMakeLists.txt
+++ b/flashlight/fl/tensor/CMakeLists.txt
@@ -65,6 +65,7 @@ target_sources(
   flashlight
   PRIVATE
   ${CMAKE_CURRENT_LIST_DIR}/Compute.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/DefaultTensorType.cpp
   ${CMAKE_CURRENT_LIST_DIR}/Index.cpp
   ${CMAKE_CURRENT_LIST_DIR}/Init.cpp
   ${CMAKE_CURRENT_LIST_DIR}/Random.cpp

--- a/flashlight/fl/tensor/Compute.cpp
+++ b/flashlight/fl/tensor/Compute.cpp
@@ -11,6 +11,7 @@
 
 #include "flashlight/fl/runtime/DeviceManager.h"
 #include "flashlight/fl/runtime/DeviceType.h"
+#include "flashlight/fl/tensor/DefaultTensorType.h"
 #include "flashlight/fl/tensor/TensorBackend.h"
 #include "flashlight/fl/tensor/TensorBase.h"
 
@@ -73,9 +74,7 @@ void relativeSync(
   wait.relativeSync(tensorsToUniqueStreams(waitOns));
 }
 
-void relativeSync(
-    const Stream& wait,
-    const std::vector<Tensor>& waitOns) {
+void relativeSync(const Stream& wait, const std::vector<Tensor>& waitOns) {
   // ensure computations are launched
   for (const auto& tensor : waitOns) {
     tensor.backend().eval(tensor);
@@ -83,9 +82,7 @@ void relativeSync(
   wait.relativeSync(tensorsToUniqueStreams(waitOns));
 }
 
-void relativeSync(
-  const std::vector<Tensor>& waits,
-  const Stream& waitOn) {
+void relativeSync(const std::vector<Tensor>& waits, const Stream& waitOn) {
   for (const auto& stream : tensorsToUniqueStreams(waits)) {
     stream->relativeSync(waitOn);
   }
@@ -117,19 +114,19 @@ void getMemMgrInfo(
     const char* msg,
     const int deviceId,
     std::ostream* ostream /* = &std::cout */) {
-  Tensor().backend().getMemMgrInfo(msg, deviceId, ostream);
+  defaultTensorBackend().getMemMgrInfo(msg, deviceId, ostream);
 }
 
 void setMemMgrLogStream(std::ostream* stream) {
-  Tensor().backend().setMemMgrLogStream(stream);
+  defaultTensorBackend().setMemMgrLogStream(stream);
 }
 
 void setMemMgrLoggingEnabled(const bool enabled) {
-  Tensor().backend().setMemMgrLoggingEnabled(enabled);
+  defaultTensorBackend().setMemMgrLoggingEnabled(enabled);
 }
 
 void setMemMgrFlushInterval(const size_t interval) {
-  Tensor().backend().setMemMgrFlushInterval(interval);
+  defaultTensorBackend().setMemMgrFlushInterval(interval);
 }
 
 } // namespace detail

--- a/flashlight/fl/tensor/DefaultTensorType.cpp
+++ b/flashlight/fl/tensor/DefaultTensorType.cpp
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "flashlight/fl/tensor/DefaultTensorType.h"
+
+namespace fl {
+
+TensorBackend& defaultTensorBackend() {
+  return Tensor().backend();
+}
+
+} // namespace fl

--- a/flashlight/fl/tensor/DefaultTensorType.h
+++ b/flashlight/fl/tensor/DefaultTensorType.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#if FL_USE_ARRAYFIRE
+  #include "flashlight/fl/tensor/backend/af/ArrayFireTensor.h"
+#endif
+#if FL_USE_TENSOR_STUB
+  #include "flashlight/fl/tensor/backend/stub/StubTensor.h"
+#endif
+
+namespace fl {
+
+#if FL_USE_ARRAYFIRE
+/**
+ * The default tensor type in Flashlight. Currently ArrayFire.
+ */
+using DefaultTensorType_t = fl::ArrayFireTensor;
+#else
+  #if FL_USE_TENSOR_STUB
+using DefaultTensorType_t = fl::StubTensor;
+  #endif
+#endif
+
+/**
+ * Returns a TensorBackend instance for the default tensor type, even if changed
+ * at runtime.
+ */
+TensorBackend& defaultTensorBackend();
+
+} // namespace fl

--- a/flashlight/fl/tensor/Init.cpp
+++ b/flashlight/fl/tensor/Init.cpp
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <string>
 
+#include "flashlight/fl/tensor/DefaultTensorType.h"
 #include "flashlight/fl/tensor/TensorBackend.h"
 
 namespace fl {
@@ -25,7 +26,7 @@ std::once_flag flInitFlag;
  * Can only be called once per process. Subsequent calls will be noops.
  */
 void init() {
-  std::call_once(flInitFlag, []() { Tensor().backend(); });
+  std::call_once(flInitFlag, []() { defaultTensorBackend(); });
 }
 
 } // namespace fl

--- a/flashlight/fl/tensor/Random.cpp
+++ b/flashlight/fl/tensor/Random.cpp
@@ -7,21 +7,22 @@
 
 #include "flashlight/fl/tensor/Random.h"
 
+#include "flashlight/fl/tensor/DefaultTensorType.h"
 #include "flashlight/fl/tensor/TensorBackend.h"
 #include "flashlight/fl/tensor/TensorBase.h"
 
 namespace fl {
 
 void setSeed(const int seed) {
-  Tensor().backend().setSeed(seed);
+  defaultTensorBackend().setSeed(seed);
 }
 
 Tensor randn(const Shape& shape, dtype type) {
-  return Tensor().backend().randn(shape, type);
+  return defaultTensorBackend().randn(shape, type);
 }
 
 Tensor rand(const Shape& shape, dtype type) {
-  return Tensor().backend().rand(shape, type);
+  return defaultTensorBackend().rand(shape, type);
 }
 
 } // namespace fl

--- a/flashlight/fl/tensor/TensorAdapter.cpp
+++ b/flashlight/fl/tensor/TensorAdapter.cpp
@@ -11,26 +11,9 @@
 #include <stdexcept>
 #include <utility>
 
+#include "flashlight/fl/tensor/DefaultTensorType.h"
 #include "flashlight/fl/tensor/TensorBackend.h"
 #include "flashlight/fl/tensor/TensorBase.h"
-
-#if FL_USE_ARRAYFIRE
-  #include "flashlight/fl/tensor/backend/af/ArrayFireTensor.h"
-#endif
-#if FL_USE_TENSOR_STUB
-  #include "flashlight/fl/tensor/backend/stub/StubTensor.h"
-#endif
-
-#if FL_USE_ARRAYFIRE
-/**
- * The default tensor type in Flashlight. Currently ArrayFire.
- */
-using DefaultTensorType_t = fl::ArrayFireTensor;
-#else
-  #if FL_USE_TENSOR_STUB
-using DefaultTensorType_t = fl::StubTensor;
-  #endif
-#endif
 
 /**
  * The compile time value which will be true if the default backend is

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -10,6 +10,7 @@
 #include <stdexcept>
 #include <utility>
 
+#include "flashlight/fl/tensor/DefaultTensorType.h"
 #include "flashlight/fl/tensor/TensorAdapter.h"
 #include "flashlight/fl/tensor/TensorBackend.h"
 
@@ -274,8 +275,7 @@ std::ostream& Tensor::operator<<(std::ostream& ostr) const {
     impl_->FUN(val);                     \
     return *this;                        \
   }
-#define FL_ASSIGN_TENSOR_OP(OP, FUN)                 \
-  FL_ASSIGN_OP_TYPE(OP, FUN, const Tensor&);
+#define FL_ASSIGN_TENSOR_OP(OP, FUN) FL_ASSIGN_OP_TYPE(OP, FUN, const Tensor&);
 #define FL_ASSIGN_SCALAR_OP(OP, FUN)                 \
   FL_ASSIGN_OP_TYPE(OP, FUN, const double&);         \
   FL_ASSIGN_OP_TYPE(OP, FUN, const float&);          \
@@ -291,8 +291,8 @@ std::ostream& Tensor::operator<<(std::ostream& ostr) const {
   FL_ASSIGN_OP_TYPE(OP, FUN, const long long&);      \
   FL_ASSIGN_OP_TYPE(OP, FUN, const unsigned long long&);
 
-#define FL_ASSIGN_OP(OP, FUN)                        \
-  FL_ASSIGN_TENSOR_OP(OP, FUN);                      \
+#define FL_ASSIGN_OP(OP, FUN)   \
+  FL_ASSIGN_TENSOR_OP(OP, FUN); \
   FL_ASSIGN_SCALAR_OP(OP, FUN);
 
 // (operator, function name on impl)
@@ -313,8 +313,8 @@ Tensor& Tensor::operator=(Tensor&& other) & {
   return *this;
 }
 
-// Move assignment operator when `this` is a rvalue, e.g., `x(0) = std::move(y)`.
-// In such cases, we copy the data from `other` to `this`.
+// Move assignment operator when `this` is a rvalue, e.g., `x(0) =
+// std::move(y)`. In such cases, we copy the data from `other` to `this`.
 Tensor& Tensor::operator=(Tensor&& other) && {
   this->impl_->assign(other);
   return *this;
@@ -340,11 +340,11 @@ Tensor& Tensor::operator=(const Tensor& other) && {
 #define FL_CREATE_FUN_LITERAL_TYPE(TYPE)                         \
   template <>                                                    \
   Tensor fromScalar(TYPE value, const dtype type) {              \
-    return Tensor().backend().fromScalar(value, type);           \
+    return defaultTensorBackend().fromScalar(value, type);       \
   }                                                              \
   template <>                                                    \
   Tensor full(const Shape& dims, TYPE value, const dtype type) { \
-    return Tensor().backend().full(dims, value, type);           \
+    return defaultTensorBackend().full(dims, value, type);       \
   }
 FL_CREATE_FUN_LITERAL_TYPE(const double&);
 FL_CREATE_FUN_LITERAL_TYPE(const float&);
@@ -362,7 +362,7 @@ FL_CREATE_FUN_LITERAL_TYPE(const unsigned short&);
 #undef FL_CREATE_FUN_LITERAL_TYPE
 
 Tensor identity(const Dim dim, const dtype type) {
-  return Tensor().backend().identity(dim, type);
+  return defaultTensorBackend().identity(dim, type);
 }
 
 #define FL_ARANGE_FUN_DEF(TYPE)                                             \
@@ -382,11 +382,11 @@ FL_ARANGE_FUN_DEF(const long long&);
 FL_ARANGE_FUN_DEF(const unsigned long long&);
 
 Tensor arange(const Shape& shape, const Dim seqDim, const dtype type) {
-  return Tensor().backend().arange(shape, seqDim, type);
+  return defaultTensorBackend().arange(shape, seqDim, type);
 }
 
 Tensor iota(const Shape& dims, const Shape& tileDims, const dtype type) {
-  return Tensor().backend().iota(dims, tileDims, type);
+  return defaultTensorBackend().iota(dims, tileDims, type);
 }
 
 /************************ Shaping and Indexing *************************/
@@ -850,9 +850,12 @@ bool isInvalidArray(const Tensor& tensor) {
 
 std::string tensorBackendTypeToString(const TensorBackendType type) {
   switch (type) {
-    case TensorBackendType::Stub: return "Stub";
-    case TensorBackendType::ArrayFire: return "ArrayFire";
-    case TensorBackendType::OneDnn: return "OneDnn";
+    case TensorBackendType::Stub:
+      return "Stub";
+    case TensorBackendType::ArrayFire:
+      return "ArrayFire";
+    case TensorBackendType::OneDnn:
+      return "OneDnn";
   }
   throw std::runtime_error("Unreachable -- unrecognized tensor backend type");
 }

--- a/flashlight/pkg/vision/tensor/VisionOps.cpp
+++ b/flashlight/pkg/vision/tensor/VisionOps.cpp
@@ -7,6 +7,7 @@
 
 #include "flashlight/pkg/vision/tensor/VisionOps.h"
 
+#include "flashlight/fl/tensor/DefaultTensorType.h"
 #include "flashlight/fl/tensor/TensorBackend.h"
 #include "flashlight/pkg/vision/tensor/VisionExtension.h"
 #include "flashlight/pkg/vision/tensor/VisionExtensionBackends.h"
@@ -94,7 +95,7 @@ Tensor shear(
 
 Tensor gaussianFilter(const Shape& shape) {
   // TODO{fl::Tensor} - empty tensor instantiation for default backend
-  return Tensor().backend().getExtension<VisionExtension>().gaussianFilter(
+  return defaultTensorBackend().getExtension<VisionExtension>().gaussianFilter(
       shape);
 }
 


### PR DESCRIPTION
Summary: Get rid of use cases of the hacky `Tensor().backend()` and prepare for a cleaner way to access the default backend instance whenever that gets implemented. Centralize the ugliness.

Differential Revision: D38759707

