### PR TITLE
Bump cereal to v1.3.2

### DIFF
--- a/cmake/BuildCereal.cmake
+++ b/cmake/BuildCereal.cmake
@@ -2,7 +2,7 @@ include(ExternalProject)
 
 set(cereal_URL https://github.com/USCiLab/cereal.git)
 set(cereal_BUILD ${CMAKE_CURRENT_BINARY_DIR}/cereal)
-set(cereal_TAG 02eace19a99ce3cd564ca4e379753d69af08c2c8) # version 1.3.0
+set(cereal_TAG v1.3.2)
 
 # Download Cereal
 ExternalProject_Add(


### PR DESCRIPTION
See title. Update to make some macOS builds more robust.

Test plan:
CI + local build on macOS