### PR TITLE
[pre-release] flashlight 0.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-project(flashlight LANGUAGES CXX C VERSION 0.3.2)
+project(flashlight LANGUAGES CXX C VERSION 0.4)
 
 include(CTest)
 include(CMakeDependentOption)

--- a/flashlight/fl/examples/CMakeLists.txt
+++ b/flashlight/fl/examples/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(flashlight-examples LANGUAGES CXX C VERSION 0.3.2)
+project(flashlight-examples LANGUAGES CXX C VERSION 0.4)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 


### PR DESCRIPTION
Pre-release of 0.4 — bump project CMake lib version tag. This is the first release that uses the Flashlight Tensor API. See tag/pre-release notes for more details.

Test plan: CI
