### PR TITLE
Fix ostream op overload link issue on macos

### DIFF
--- a/flashlight/fl/runtime/DeviceType.h
+++ b/flashlight/fl/runtime/DeviceType.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <ostream>
 #include <string>
 #include <unordered_set>
 

--- a/flashlight/fl/tensor/Types.h
+++ b/flashlight/fl/tensor/Types.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <ostream>
 #include <string>
 
 namespace fl {


### PR DESCRIPTION
See title — ordering of translation units on macos 
```
Undefined symbols for architecture x86_64:
  "std::__1::basic_ostream<char, std::__1::char_traits<char> >& std::__1::operator<<<char, std::__1::char_traits<char>, std::__1::allocator<char> >(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)", referenced from:
      fl::operator<<(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, fl::dtype const&) in Types.cpp.o
      fl::operator<<(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, fl::DeviceType const&) in DeviceType.cpp.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [libflashlight.0.3.2.dylib] Error 1
make[1]: *** [CMakeFiles/flashlight.dir/all] Error 2
make: *** [all] Error 2
```

Compiler never compiled because `ostream&` can exist as an incomplete type, but op overloading needed the symbol at link time.

Test plan: CI
+
```
brew tap bwasti/flashlight
brew install --build-from-source flashlight
```