### PR TITLE
Fix OneDNN autograd compilation error on MacOS

### DIFF
--- a/flashlight/fl/autograd/tensor/backend/onednn/DnnlUtils.cpp
+++ b/flashlight/fl/autograd/tensor/backend/onednn/DnnlUtils.cpp
@@ -61,9 +61,7 @@ DnnlEngine& DnnlEngine::getInstance() {
 }
 
 dnnl::memory::dims convertToDnnlDims(const std::vector<Dim>& shape) {
-  // DNNL uses ints in dims
-  std::vector<long int> intVec(shape.begin(), shape.end());
-  return dnnl::memory::dims(intVec);
+  return dnnl::memory::dims(shape.begin(), shape.end());
 }
 
 dnnl::memory::dims convertShapeToDnnlDims(const Shape& shape) {


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.** Changes *must* be discussed.

**Original Issue**: [corresponding issue on Github]

*Note:* You can add `closes #[issue number]` to automatically close the issue that this PR resolves when it is merged.

### Summary

Compiling `DnnlUtils.cpp` on MacOS gives the following error:

```
.../flashlight/fl/autograd/tensor/backend/onednn/DnnlUtils.cpp:66:10: error: no matching conversion for functional-style cast from 'std::vector<long>' to 'dnnl::memory::dims' (aka 'vector<long long>')
  return dnnl::memory::dims(intVec);
         ^~~~~~~~~~~~~~~~~~~~~~~~~
/Library/Developer/CommandLineTools/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/vector:503:40: note: candidate constructor not viable: no known conversion from 'std::vector<long>' to 'const std::__1::vector<long long>::allocator_type' (aka 'const std::__1::allocator<long long>') for 1st argument
    _LIBCPP_INLINE_VISIBILITY explicit vector(const allocator_type& __a)
                                       ^
/Library/Developer/CommandLineTools/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/vector:515:14: note: candidate constructor not viable: no known conversion from 'std::vector<long>' to 'std::__1::vector<long long>::size_type' (aka 'unsigned long') for 1st argument
    explicit vector(size_type __n);
             ^
/Library/Developer/CommandLineTools/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/vector:559:5: note: candidate constructor not viable: no known conversion from 'vector<long, allocator<long>>' to 'const vector<long long, allocator<long long>>' for 1st argument
    vector(const vector& __x);
    ^
/Library/Developer/CommandLineTools/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/vector:566:5: note: candidate constructor not viable: no known conversion from 'std::vector<long>' to 'initializer_list<std::__1::vector<long long>::value_type>' (aka 'initializer_list<long long>') for 1st argument
    vector(initializer_list<value_type> __il);
    ^
/Library/Developer/CommandLineTools/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/vector:572:5: note: candidate constructor not viable: no known conversion from 'vector<long, allocator<long>>' to 'vector<long long, allocator<long long>>' for 1st argument
    vector(vector&& __x)
    ^
/Library/Developer/CommandLineTools/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/vector:497:5: note: candidate constructor not viable: requires 0 arguments, but 1 was provided
    vector() _NOEXCEPT_(is_nothrow_default_constructible<allocator_type>::value)
    ^
/Library/Developer/CommandLineTools/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/vector:517:14: note: candidate constructor not viable: requires 2 arguments, but 1 was provided
    explicit vector(size_type __n, const allocator_type& __a);
             ^
/Library/Developer/CommandLineTools/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/vector:519:5: note: candidate constructor not viable: requires 2 arguments, but 1 was provided
    vector(size_type __n, const value_type& __x);
    ^
/Library/Developer/CommandLineTools/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/vector:522:9: note: candidate constructor template not viable: requires 2 arguments, but 1 was provided
        vector(_InputIterator __first,
        ^
/Library/Developer/CommandLineTools/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/vector:537:9: note: candidate constructor template not viable: requires 2 arguments, but 1 was provided
        vector(_ForwardIterator __first,
        ^
/Library/Developer/CommandLineTools/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/vector:560:5: note: candidate constructor not viable: requires 2 arguments, but 1 was provided
    vector(const vector& __x, const allocator_type& __a);
    ^
/Library/Developer/CommandLineTools/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/vector:569:5: note: candidate constructor not viable: requires 2 arguments, but 1 was provided
    vector(initializer_list<value_type> __il, const allocator_type& __a);
    ^
/Library/Developer/CommandLineTools/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/vector:580:5: note: candidate constructor not viable: requires 2 arguments, but 1 was provided
    vector(vector&& __x, const allocator_type& __a);
    ^
/Library/Developer/CommandLineTools/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/vector:520:5: note: candidate constructor not viable: requires 3 arguments, but 1 was provided
    vector(size_type __n, const value_type& __x, const allocator_type& __a);
    ^
/Library/Developer/CommandLineTools/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/vector:530:9: note: candidate constructor template not viable: requires at least 3 arguments, but 1 was provided
        vector(_InputIterator __first, _InputIterator __last, const allocator_type& __a,
        ^
/Library/Developer/CommandLineTools/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/vector:544:9: note: candidate constructor template not viable: requires at least 3 arguments, but 1 was provided
        vector(_ForwardIterator __first, _ForwardIterator __last, const allocator_type& __a,
        ^
1 error generated.
```

`long int` resolves to `int` on MacOS, which differs from `dnnl::memory::dim` which is `long long`.

This PR offers a more general solution by minimizing assumptions on the concrete `dnnl::memory::dim` type.

### Test Plan (required)
Successful compilation of `Benchmark` target on MacOS.