### PR TITLE
[build] Don't install lib headers if not building libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,8 +124,6 @@ if (FL_LIBRARIES_BUILD_FOR_PYTHON)
   include(${FL_BINDING_PYTHON}/CMakeLists.txt)
 endif ()
 
-setup_install_headers(${FL_LIB_DIR} ${FL_INSTALL_INC_DIR_HEADER_LOC})
-
 # --------------------------- Core Options  ---------------------------
 
 option(FL_BUILD_CORE "Build flashlight core" ON)

--- a/flashlight/lib/CMakeLists.txt
+++ b/flashlight/lib/CMakeLists.txt
@@ -14,8 +14,10 @@ option(
   "Build flashlight set library"
   ${FL_BUILD_ALL_LIBS})
 if(FL_BUILD_LIB_SET)
-  include(${CMAKE_CURRENT_LIST_DIR}/set/CMakeLists.txt)
+  set(FL_SET_LIB_DIR ${CMAKE_CURRENT_LIST_DIR}/set)
+  include(${FL_SET_LIB_DIR}/CMakeLists.txt)
   list(APPEND INSTALLABLE_TARGETS fl_lib_set)
+  setup_install_headers(${FL_SET_LIB_DIR} ${FL_INSTALL_INC_DIR_HEADER_LOC})
 endif()
 
 # sequence
@@ -24,8 +26,10 @@ option(
   "Build flashlight sequence library"
   ${FL_BUILD_ALL_LIBS})
 if(FL_BUILD_LIB_SEQUENCE)
-  include(${CMAKE_CURRENT_LIST_DIR}/sequence/CMakeLists.txt)
+  set(FL_SEQUENCE_LIB_DIR ${CMAKE_CURRENT_LIST_DIR}/sequence)
+  include(${FL_SEQUENCE_LIB_DIR}/CMakeLists.txt)
   list(APPEND INSTALLABLE_TARGETS fl_lib_sequence)
+  setup_install_headers(${FL_SEQUENCE_LIB_DIR} ${FL_INSTALL_INC_DIR_HEADER_LOC})
 endif()
 
 # audio
@@ -34,6 +38,8 @@ option(
   "Build flashlight audio library"
   ${FL_BUILD_ALL_LIBS})
 if(FL_BUILD_LIB_AUDIO)
-  include(${CMAKE_CURRENT_LIST_DIR}/audio/CMakeLists.txt)
+  set(FL_AUDIO_LIB_DIR ${CMAKE_CURRENT_LIST_DIR}/audio)
+  include(${FL_AUDIO_LIB_DIR}/CMakeLists.txt)
   list(APPEND INSTALLABLE_TARGETS fl_lib_audio)
+  setup_install_headers(${FL_AUDIO_LIB_DIR} ${FL_INSTALL_INC_DIR_HEADER_LOC})
 endif()


### PR DESCRIPTION
See title. Remove cruft from core-only installs. `lib` is going away soon anyways so preemptively make sure everything works once those headers aren't installed by default.

Test plan:
CI + cluster build with:
```
cmake .. \
    -G Ninja \
    -DBUILD_SHARED_LIBS=ON \
    -DCMAKE_BUILD_TYPE=Release -DFL_BUILD_LIB_SET=ON \
    -DCMAKE_INSTALL_PREFIX=/tmp/usr \
    -DFL_USE_ARRAYFIRE=ON \
    -DFL_ARRAYFIRE_USE_CPU=ON \
    -DFL_USE_ONEDNN=OFF \
    -DFL_BUILD_DISTRIBUTED=OFF \
    -DFL_BUILD_TESTS=OFF \
    -DFL_BUILD_EXAMPLES=OFF -DArrayFire_DIR=/checkpoint/jacobkahn/usr/share/ArrayFire/cmake
  ninja install
```
