### PR TITLE
[build] Always transitively find thread lib if building core

### DIFF
--- a/cmake/flashlightConfig.cmake.in
+++ b/cmake/flashlightConfig.cmake.in
@@ -38,6 +38,7 @@ if (@FL_BUILD_STANDALONE@)
   endif()
   # Core dependencies
   if (@FL_BUILD_CORE@)
+    find_dependency(Threads)
     if (@FL_USE_ARRAYFIRE@)
       find_dependency(ArrayFire 3.7.1)
     endif()


### PR DESCRIPTION
See title. `fl/common` requires linking a thread impl for the `ThreadPool` abstraction -- properly require that threads are a transitive dependency whenever using threading components

Test plan: CI