### PR TITLE
Rename rename acoustic-model-specific callbacks

### DIFF
--- a/cmake/BuildFlashlightText.cmake
+++ b/cmake/BuildFlashlightText.cmake
@@ -5,7 +5,7 @@ include(ExternalProject)
 set(flashlight-text_TEMP_INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/extern/flashlight-text)
 set(flashlight-text_URL https://github.com/flashlight/text.git)
 set(flashlight-text_BUILD ${CMAKE_CURRENT_BINARY_DIR}/third-party/flashlight-text)
-set(flashlight-text_TAG v0.1)
+set(flashlight-text_TAG 46f62b29ec2db8389efcdb731ebff05fb400a95e) # 20220928
 set(flashlight-text_BINARY_DIR ${flashlight-text_BUILD}/src/flashlight-text-build)
 
 if (BUILD_SHARED_LIBS)

--- a/flashlight/app/asr/Decode.cpp
+++ b/flashlight/app/asr/Decode.cpp
@@ -529,14 +529,14 @@ int main(int argc, char** argv) {
     }
 
     if (criterionType == CriterionType::S2S) {
-      auto amUpdateFunc = FLAGS_criterion == kSeq2SeqRNNCriterion
-          ? buildSeq2SeqRnnAmUpdateFunction(
+      auto emittingModelUpdateFunc = FLAGS_criterion == kSeq2SeqRNNCriterion
+          ? buildSeq2SeqRnnUpdateFunction(
                 localCriterion,
                 FLAGS_decoderattnround,
                 FLAGS_beamsize,
                 FLAGS_attentionthreshold,
                 FLAGS_smoothingtemperature)
-          : buildSeq2SeqTransformerAmUpdateFunction(
+          : buildSeq2SeqTransformerUpdateFunction(
                 localCriterion,
                 FLAGS_beamsize,
                 FLAGS_attentionthreshold,
@@ -557,7 +557,7 @@ int main(int argc, char** argv) {
             trie,
             localLm,
             eosIdx,
-            amUpdateFunc,
+            emittingModelUpdateFunc,
             FLAGS_maxdecoderoutputlen,
             FLAGS_decodertype == "tkn"));
         LOG(INFO) << "[Decoder] LexiconSeq2Seq decoder with "
@@ -574,7 +574,7 @@ int main(int argc, char** argv) {
             },
             localLm,
             eosIdx,
-            amUpdateFunc,
+            emittingModelUpdateFunc,
             FLAGS_maxdecoderoutputlen));
         LOG(INFO)
             << "[Decoder] LexiconFreeSeq2Seq decoder with token-LM loaded in thread: "
@@ -728,7 +728,7 @@ int main(int argc, char** argv) {
           }
 
           auto score = results[i].score;
-          auto amScore = results[i].amScore;
+          auto amScore = results[i].emittingModelScore;
           auto lmScore = results[i].lmScore;
           auto outString = sampleId + " | " + std::to_string(score) + " | " +
               std::to_string(amScore) + " | " + std::to_string(lmScore) +

--- a/flashlight/pkg/speech/criterion/Seq2SeqCriterion.cpp
+++ b/flashlight/pkg/speech/criterion/Seq2SeqCriterion.cpp
@@ -272,8 +272,7 @@ std::pair<Variable, Variable> Seq2SeqCriterion::decoder(
       y = Variable(maxIdx, false);
     } else if (samplingStrategy_ == fl::pkg::speech::kRandSampling) {
       y = Variable(
-          (fl::rand({1, target.dim(1)}) * (nClass_ - 1))
-              .astype(fl::dtype::s32),
+          (fl::rand({1, target.dim(1)}) * (nClass_ - 1)).astype(fl::dtype::s32),
           false);
     } else {
       throw std::invalid_argument("Invalid sampling strategy");
@@ -566,7 +565,8 @@ Seq2SeqCriterion::decodeBatchStep(
       for (int i = 0; i < batchSize; i++) {
         statesVector[i] = inStates[i]->hidden[n];
       }
-      Variable inStateHiddenBatched = concatenate(statesVector, 1).asContiguous();
+      Variable inStateHiddenBatched =
+          concatenate(statesVector, 1).asContiguous();
       std::tie(yBatched, outStateBatched) =
           decodeRNN(n)->forward(yBatched, inStateHiddenBatched);
     }
@@ -609,8 +609,9 @@ Seq2SeqCriterion::decodeBatchStep(
   outBatched = logSoftmax(outBatched / smoothingTemperature, 0);
   std::vector<std::vector<float>> out(batchSize);
   for (int i = 0; i < batchSize; i++) {
-    out[i] =
-        outBatched(fl::span, fl::range(i, i + 1)).tensor().toHostVector<float>();
+    out[i] = outBatched(fl::span, fl::range(i, i + 1))
+                 .tensor()
+                 .toHostVector<float>();
   }
 
   return std::make_pair(out, outstates);
@@ -638,7 +639,7 @@ std::string Seq2SeqCriterion::prettyString() const {
   return "Seq2SeqCriterion";
 }
 
-AMUpdateFunc buildSeq2SeqRnnAmUpdateFunction(
+EmittingModelUpdateFunc buildSeq2SeqRnnUpdateFunction(
     std::shared_ptr<SequenceCriterion>& criterion,
     int attRound,
     int beamSize,
@@ -649,60 +650,63 @@ AMUpdateFunc buildSeq2SeqRnnAmUpdateFunction(
 
   const Seq2SeqCriterion* s2sCriterion =
       static_cast<Seq2SeqCriterion*>(criterion.get());
-  auto amUpdateFunc = [buf, s2sCriterion](
-                          const float* emissions,
-                          const int N,
-                          const int T,
-                          const std::vector<int>& rawY,
-                          const std::vector<AMStatePtr>& rawPrevStates,
-                          int& t) {
-    if (t == 0) {
-      buf->input = fl::Variable(
-          Tensor::fromBuffer({N, T}, emissions, MemoryLocation::Host), false);
-    }
-    int batchSize = rawY.size();
-    buf->prevStates.resize(0);
-    buf->ys.resize(0);
+  auto emittingModelUpdateFunc =
+      [buf, s2sCriterion](
+          const float* emissions,
+          const int N,
+          const int T,
+          const std::vector<int>& rawY,
+          const std::vector<EmittingModelStatePtr>& rawPrevStates,
+          int& t) {
+        if (t == 0) {
+          buf->input = fl::Variable(
+              Tensor::fromBuffer({N, T}, emissions, MemoryLocation::Host),
+              false);
+        }
+        int batchSize = rawY.size();
+        buf->prevStates.resize(0);
+        buf->ys.resize(0);
 
-    // Cast to seq2seq states
-    for (int i = 0; i < batchSize; i++) {
-      Seq2SeqState* prevState =
-          static_cast<Seq2SeqState*>(rawPrevStates[i].get());
-      fl::Variable y;
-      if (t > 0) {
-        y = fl::constant(rawY[i], {1}, fl::dtype::s32, false);
-      } else {
-        prevState = &buf->dummyState;
-      }
-      buf->ys.push_back(y);
-      buf->prevStates.push_back(prevState);
-    }
+        // Cast to seq2seq states
+        for (int i = 0; i < batchSize; i++) {
+          Seq2SeqState* prevState =
+              static_cast<Seq2SeqState*>(rawPrevStates[i].get());
+          fl::Variable y;
+          if (t > 0) {
+            y = fl::constant(rawY[i], {1}, fl::dtype::s32, false);
+          } else {
+            prevState = &buf->dummyState;
+          }
+          buf->ys.push_back(y);
+          buf->prevStates.push_back(prevState);
+        }
 
-    // Run forward in batch
-    std::vector<std::vector<float>> amScores;
-    std::vector<Seq2SeqStatePtr> outStates;
+        // Run forward in batch
+        std::vector<std::vector<float>> amScores;
+        std::vector<Seq2SeqStatePtr> outStates;
 
-    std::tie(amScores, outStates) = s2sCriterion->decodeBatchStep(
-        buf->input,
-        buf->ys,
-        buf->prevStates,
-        buf->attentionThreshold,
-        buf->smoothingTemperature);
+        std::tie(amScores, outStates) = s2sCriterion->decodeBatchStep(
+            buf->input,
+            buf->ys,
+            buf->prevStates,
+            buf->attentionThreshold,
+            buf->smoothingTemperature);
 
-    // Cast back to void*
-    std::vector<AMStatePtr> out;
-    for (auto& os : outStates) {
-      if (os->isValid) {
-        out.push_back(os);
-      } else {
-        out.push_back(nullptr);
-      }
-    }
-    return std::make_pair(amScores, out);
-  };
+        // Cast back to void*
+        std::vector<EmittingModelStatePtr> out;
+        for (auto& os : outStates) {
+          if (os->isValid) {
+            out.push_back(os);
+          } else {
+            out.push_back(nullptr);
+          }
+        }
+        return std::make_pair(amScores, out);
+      };
 
-  return amUpdateFunc;
+  return emittingModelUpdateFunc;
 }
+
 } // namespace speech
 } // namespace pkg
 } // namespace fl

--- a/flashlight/pkg/speech/criterion/Seq2SeqCriterion.h
+++ b/flashlight/pkg/speech/criterion/Seq2SeqCriterion.h
@@ -216,7 +216,7 @@ struct Seq2SeqDecoderBuffer {
   }
 };
 
-AMUpdateFunc buildSeq2SeqRnnAmUpdateFunction(
+EmittingModelUpdateFunc buildSeq2SeqRnnUpdateFunction(
     std::shared_ptr<SequenceCriterion>& criterion,
     int attRound,
     int beamSize,

--- a/flashlight/pkg/speech/criterion/SequenceCriterion.h
+++ b/flashlight/pkg/speech/criterion/SequenceCriterion.h
@@ -42,16 +42,17 @@ class SequenceCriterion : public fl::Container {
   FL_SAVE_LOAD_WITH_BASE(fl::Container)
 };
 
-typedef std::shared_ptr<void> AMStatePtr;
-typedef std::function<
-    std::pair<std::vector<std::vector<float>>, std::vector<AMStatePtr>>(
-        const float*,
-        const int,
-        const int,
-        const std::vector<int>&,
-        const std::vector<AMStatePtr>&,
-        int&)>
-    AMUpdateFunc;
+using EmittingModelStatePtr = std::shared_ptr<void>;
+using EmittingModelUpdateFunc = std::function<std::pair<
+    std::vector<std::vector<float>>,
+    std::vector<EmittingModelStatePtr>>(
+    const float*,
+    const int,
+    const int,
+    const std::vector<int>&,
+    const std::vector<EmittingModelStatePtr>&,
+    int&)>;
+
 } // namespace speech
 } // namespace pkg
 } // namespace fl

--- a/flashlight/pkg/speech/criterion/TransformerCriterion.h
+++ b/flashlight/pkg/speech/criterion/TransformerCriterion.h
@@ -14,8 +14,8 @@
 #include "flashlight/pkg/speech/criterion/attention/attention.h"
 #include "flashlight/pkg/speech/criterion/attention/window.h"
 
-#include "flashlight/pkg/runtime/common/DistributedUtils.h"
 #include "flashlight/fl/contrib/modules/Transformer.h"
+#include "flashlight/pkg/runtime/common/DistributedUtils.h"
 
 namespace fl {
 namespace pkg {
@@ -52,14 +52,11 @@ class TransformerCriterion : public SequenceCriterion {
   std::vector<fl::Variable> forward(
       const std::vector<fl::Variable>& inputs) override;
 
-  Tensor viterbiPath(
-      const Tensor& input,
-      const Tensor& inputSizes = Tensor()) override;
+  Tensor viterbiPath(const Tensor& input, const Tensor& inputSizes = Tensor())
+      override;
 
-  std::pair<Tensor, fl::Variable> viterbiPathBase(
-      const Tensor& input,
-      const Tensor& inputSizes,
-      bool saveAttn);
+  std::pair<Tensor, fl::Variable>
+  viterbiPathBase(const Tensor& input, const Tensor& inputSizes, bool saveAttn);
 
   std::pair<fl::Variable, fl::Variable> vectorizedDecoder(
       const fl::Variable& input,
@@ -149,7 +146,7 @@ struct TS2SDecoderBuffer {
   }
 };
 
-AMUpdateFunc buildSeq2SeqTransformerAmUpdateFunction(
+EmittingModelUpdateFunc buildSeq2SeqTransformerUpdateFunction(
     std::shared_ptr<SequenceCriterion>& criterion,
     int beamSize,
     float attThr,


### PR DESCRIPTION
Summary: Rename speech-specific things (mostly `acoustic model`) to refer to an "emitting model" which might not be a speech-based model.

This is per https://github.com/flashlight/text/pull/18

Differential Revision: D39797755

