### PR TITLE
Add Benchmarks to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -678,7 +678,7 @@ jobs:
   run_onednn_cpu_benchmarks:
     machine:
       image: ubuntu-2004:current
-    resource_class: large
+    resource_class: 2xlarge
     steps:
       - install_onednn
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,7 +218,9 @@ commands:
       - run:
           name: "Clone, build, and install oneDNN"
           command: |
+            cd /tmp
             git clone https://github.com/oneapi-src/oneDNN.git --branch v2.7
+            cd oneDNN
             cmake . -DCMAKE_BUILD_TYPE=Release
             cmake --build . --parallel
             camke --install .
@@ -683,7 +685,7 @@ jobs:
       - run:
           name: "Build Flashlight CPU backend with oneDNN"
           command: |
-            mkdir -p build && cd build
+            mkdir -p build
             cmake -S . -B build \
               -DBUILD_SHARED_LIBS=ON \
               -DCMAKE_BUILD_TYPE=Release \
@@ -696,6 +698,7 @@ jobs:
       - run:
           name: "Run stuff"
           command: |
+            cd build
             ls
             ls flashlight
             ls flashlight/fl

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,7 +213,7 @@ commands:
           name: "Install vcpkg dependencies"
           command: |
             MKLROOT=/opt/intel/mkl ./vcpkg/vcpkg install << parameters.vcpkg_deps >>
-  install_onednn:
+  install_onednn_and_mkl:
     steps:
       - run:
           name: "Install Ninja"
@@ -231,6 +231,9 @@ commands:
               -DDNNL_BUILD_EXAMPLES=OFF
             ninja
             sudo ninja install
+      - run:
+          name: "Install MKL"
+          command: sudo apt install intel-mkl
   flashlight_source_build_with_vcpkg:
     parameters:
       fl_build_fl_core:
@@ -687,7 +690,7 @@ jobs:
       image: ubuntu-2004:current
     resource_class: 2xlarge
     steps:
-      - install_onednn
+      - install_onednn_and_mkl
       - checkout
       - run:
           name: "Build Flashlight CPU backend with oneDNN"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -729,3 +729,6 @@ workflows:
     jobs:
       - ubuntu2004_cpu_python_bindings_simple
       - ubuntu2004_cuda_python_bindings
+  run_benchmarks:
+    jobs:
+      - run_onednn_cpu_benchmarks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,8 +222,8 @@ commands:
             git clone https://github.com/oneapi-src/oneDNN.git --branch v2.7
             cd oneDNN
             cmake . -DCMAKE_BUILD_TYPE=Release
-            cmake --build . --parallel
-            camke --install .
+            make -j$(nproc)
+            make install
   flashlight_source_build_with_vcpkg:
     parameters:
       fl_build_fl_core:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,7 +218,7 @@ commands:
       - run:
           name: "Install Ninja"
           command: |
-            sudo apt install ninja-build
+            sudo apt install -y ninja-build
       - run:
           name: "Clone, build, and install oneDNN"
           command: |
@@ -233,7 +233,7 @@ commands:
             sudo ninja install
       - run:
           name: "Install MKL"
-          command: sudo apt install intel-mkl
+          command: sudo apt install -y intel-mkl
   flashlight_source_build_with_vcpkg:
     parameters:
       fl_build_fl_core:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,14 +216,18 @@ commands:
   install_onednn:
     steps:
       - run:
+          name: "Install Ninja"
+          command: |
+            sudo apt install ninja-build
+      - run:
           name: "Clone, build, and install oneDNN"
           command: |
             cd /tmp
             git clone https://github.com/oneapi-src/oneDNN.git --branch v2.7
             cd oneDNN
-            cmake . -DCMAKE_BUILD_TYPE=Release
-            make -j$(nproc)
-            make install
+            cmake . -G Ninja -DCMAKE_BUILD_TYPE=Release
+            ninja
+            sudo ninja install
   flashlight_source_build_with_vcpkg:
     parameters:
       fl_build_fl_core:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,7 +225,10 @@ commands:
             cd /tmp
             git clone https://github.com/oneapi-src/oneDNN.git --branch v2.7
             cd oneDNN
-            cmake . -G Ninja -DCMAKE_BUILD_TYPE=Release
+            cmake . -G Ninja \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DDNNL_BUILD_TESTS=OFF \
+              -DDNNL_BUILD_EXAMPLES=OFF
             ninja
             sudo ninja install
   flashlight_source_build_with_vcpkg:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,6 +213,15 @@ commands:
           name: "Install vcpkg dependencies"
           command: |
             MKLROOT=/opt/intel/mkl ./vcpkg/vcpkg install << parameters.vcpkg_deps >>
+  install_onednn:
+    steps:
+      - run:
+          name: "Clone, build, and install oneDNN"
+          command: |
+            git clone https://github.com/oneapi-src/oneDNN.git --branch v2.7
+            cmake . -DCMAKE_BUILD_TYPE=Release
+            cmake --build . --parallel
+            camke --install .
   flashlight_source_build_with_vcpkg:
     parameters:
       fl_build_fl_core:
@@ -663,6 +672,34 @@ jobs:
       - run:
           name: "Build another project that depends on flashlight"
           command: sudo docker exec -i flashlight bash < flashlight_compile_and_link_external_project.sh
+
+  run_onednn_cpu_benchmarks:
+    machine:
+      image: ubuntu-2004:current
+    resource_class: large
+    steps:
+      - install_onednn
+      - checkout
+      - run:
+          name: "Build Flashlight CPU backend with oneDNN"
+          command: |
+            mkdir -p build && cd build
+            cmake -S . -B build \
+              -DBUILD_SHARED_LIBS=ON \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_INSTALL_PREFIX=$HOME/usr \
+              -DFL_USE_ARRAYFIRE=OFF \
+              -DFL_USE_ONEDNN=ON \
+              -DFL_BUILD_DISTRIBUTED=OFF \
+              -DFL_BUILD_TESTS=OFF \
+              -DFL_BUILD_EXAMPLES=ON
+      - run:
+          name: "Run stuff"
+          command: |
+            ls
+            ls flashlight
+            ls flashlight/fl
+            ./flashlight/fl/benchmark
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -714,7 +714,7 @@ jobs:
             ls
             ls flashlight
             ls flashlight/fl
-            ls ./flashlight/fl/Benchmark
+            ls ./flashlight/fl/examples/Benchmark
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,7 +233,7 @@ commands:
             sudo ninja install
       - run:
           name: "Install MKL"
-          command: sudo apt install -y intel-mkl
+          command: DEBIAN_FRONTEND=noninteractive sudo apt install -y intel-mkl
   flashlight_source_build_with_vcpkg:
     parameters:
       fl_build_fl_core:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,7 +233,7 @@ commands:
             sudo ninja install
       - run:
           name: "Install MKL"
-          command: DEBIAN_FRONTEND=noninteractive sudo apt install -y intel-mkl
+          command: DEBIAN_FRONTEND=noninteractive sudo apt install -y intel-mkl-full
   flashlight_source_build_with_vcpkg:
     parameters:
       fl_build_fl_core:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -705,6 +705,7 @@ jobs:
               -DFL_BUILD_DISTRIBUTED=OFF \
               -DFL_BUILD_TESTS=OFF \
               -DFL_BUILD_EXAMPLES=ON
+            cmake --build build --parallel
       - run:
           name: "Run stuff"
           command: |
@@ -712,7 +713,7 @@ jobs:
             ls
             ls flashlight
             ls flashlight/fl
-            ./flashlight/fl/benchmark
+            ./flashlight/fl/Benchmark
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -709,11 +709,12 @@ jobs:
       - run:
           name: "Run stuff"
           command: |
+            # TODO(StrongerXi): modify this or above build options to run desired benches
             cd build
             ls
             ls flashlight
             ls flashlight/fl
-            ./flashlight/fl/Benchmark
+            ls ./flashlight/fl/Benchmark
 
 workflows:
   version: 2


### PR DESCRIPTION
Start adding a semblance of benchmarking to CI so we can iterate on performance on OSS environments consistently. cc @StrongerXi, who will modify these benchmarks/add additional ones we can run with the oneDNN backend.

The CircleCI Ubuntu 2xlarge instance is a 16 core x64 machine with 64 GB of RAM.

[Example of bench run](https://circleci.com/gh/flashlight/flashlight/23600?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link)

cc @bwasti

Test plan: CI