### PR TITLE
[ArrayFireBackend][toString] Properly release AF's string memory

### DIFF
--- a/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireTensor.cpp
@@ -357,7 +357,11 @@ void* ArrayFireTensor::getContext() {
 }
 
 std::string ArrayFireTensor::toString() {
-  return std::string(af::toString("ArrayFireTensor", getHandle()));
+  const char* afStr = af::toString("ArrayFireTensor", getHandle());
+  // std::string copies `afStr` content into its own buffer
+  const std::string str(afStr);
+  af::freeHost(afStr);
+  return str;
 }
 
 std::ostream& ArrayFireTensor::operator<<(std::ostream& ostr) {


### PR DESCRIPTION
### Summary
`ArrayFireTensor::toString` forgot to release the string memory returned by `af::toString`, which is [required to be manually released](https://github.com/arrayfire/arrayfire/blob/master/include/af/util.h#L98-L99).

### Test Plan (required)
Run valgrind or any memory leak check tool on the following code:
```c++
TEST(ArrayFireTensorBaseTest, toString) {
  fl::setDefaultTensorType<ArrayFireTensor>();
  full(Shape({2, 2}), 42).toString();
}
```
