### PR TITLE
[JitBackend] Fix memory leaks in `Node::replaceAllUsesWith` and unit tests

### DIFF
--- a/flashlight/fl/tensor/backend/jit/ir/Node.cpp
+++ b/flashlight/fl/tensor/backend/jit/ir/Node.cpp
@@ -77,13 +77,11 @@ const UseList& Node::uses() const {
 }
 
 void Node::replaceAllUsesWith(Node* newInput) {
-  refCount_++; // a trick to avoid freeing this node in last iteration
-  while (!uses_.empty()) { // each iteration updates uses
+  // each iteration updates links an existing user to newInput
+  while (!uses_.empty()) {
     const auto* nextUse = *uses_.begin();
     nextUse->user()->setInput(nextUse->inputIdx(), newInput);
   }
-  newInput->uses_.splice(newInput->uses_.end(), std::move(uses_));
-  decRefCount(); // neutralize the refCount increment
 }
 
 unsigned Node::getRefCount() const {

--- a/flashlight/fl/tensor/backend/jit/ir/Node.h
+++ b/flashlight/fl/tensor/backend/jit/ir/Node.h
@@ -28,6 +28,14 @@ using UseList = std::list<Use*>;
  * Ownership model:
  * 1. Node has shared ownership via manual refcount update.
  * 2. Use is owned by user node.
+ *
+ * Possible stages of lifetime
+ * 1. After the initial node creation (subclass must enforce heap allocation),
+ *    the creator is the owner (responsible for manually deleting the node).
+ * 2. The first `incRefCount` call promotes the node into managed lifetime, and
+ *    caller becomes the first owner in the new shared ownership.
+ * 3. Ensuing `(inc/dec)RefCount` calls takes/releases the shared ownership
+ * 4. The last `decRefCount` call will delete the node.
  */
 class Node {
   std::vector<Node*> inputs_;
@@ -68,14 +76,6 @@ class Node {
   // Mainly for debugging/testing
   unsigned getRefCount() const;
   // Use carefully -- this manually simulates shared ownership of a node
-  //
-  // Possible stages of lifetime
-  // 1. After the initial node creation (guarded to be heap allocation), the
-  //    creator is the owner (responsible for manually deleting the node)
-  // 2. The first `incRefCount` caller claims the ownership (becomes the first
-  //    owner in the shared ownership)
-  // 3. Ensuing `(inc/dec)RefCount` calls takes/releases the shared ownership
-  // 4. The last `decRefCount` call will delete the node.
   void incRefCount();
   void decRefCount();
 

--- a/flashlight/fl/test/tensor/jit/JitTensorTest.cpp
+++ b/flashlight/fl/test/tensor/jit/JitTensorTest.cpp
@@ -60,16 +60,17 @@ void testBinaryOp(Op func, BinaryOp op) {
 } // namespace
 
 TEST_F(JitTensorTest, constructor) {
-  const auto data = defaultBackend_.rand(Shape({2, 2}), dtype::f32);
+  const auto dataTensor = defaultBackend_.rand(Shape({2, 2}), dtype::f32);
+  const auto data = dataTensor.toHostVector<float>();
   const Tensor tensor =
-      Tensor::fromBuffer(data.shape(), data.host<float>(), Location::Host);
+      Tensor::fromBuffer(dataTensor.shape(), data.data(), Location::Host);
   const auto& jitTensor = toJitTensorBase(tensor);
   const auto node = jitTensor.node();
   ASSERT_EQ(node->inputs(), NodeList({}));
   ASSERT_EQ(node->getRefCount(), 1);
   ASSERT_EQ(node->uses(), UseValList({}));
   ASSERT_TRUE(node->isValue());
-  ASSERT_TRUE(allClose(data, node->getResult().value()));
+  ASSERT_TRUE(allClose(dataTensor, node->getResult().value()));
 }
 
 TEST_F(JitTensorTest, full) {


### PR DESCRIPTION
### Summary
This PR
- fixes some memory leaks I discovered while running leak checking tools on JIT unit tests.
- simplifies `Node::replaceAllUsesWith`

Manual refcount is dangerous, but I think it'll pay off for future optimization pass writers.

### Test Plan (required)
Added unit tests, and ran them with `leaks` tool on MacOS.

```
make JitNodeTest JitTensorTest
./flashlight/fl/test/JitNodeTest
./flashlight/fl/test/JitTensorTest
```