### PR TITLE
Upgrade CMake minumum to version 3.16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ commands:
         default: "ON"
         type: string
       version:
-        default: "3.10"
+        default: "3.16"
         type: string
       version_build:
         default: "1"
@@ -342,7 +342,7 @@ commands:
           command: |
             set +H
             echo "printf '#include <flashlight/fl/flashlight.h>\nint main() { auto x = fl::constant(1.0, {1}); auto y = x + 1; return !fl::allClose(y, x + x); }\n' > main.cpp" >> flashlight_compile_and_link_external_project.sh
-            echo "printf 'cmake_minimum_required(VERSION 3.10)\nset(CMAKE_CXX_STANDARD 17)\nset(CMAKE_CXX_STANDARD_REQUIRED ON)\nfind_package(flashlight CONFIG REQUIRED)\nadd_executable(main main.cpp)\ntarget_link_libraries(main PRIVATE flashlight::flashlight)\n' > CMakeLists.txt" >> flashlight_compile_and_link_external_project.sh
+            echo "printf 'cmake_minimum_required(VERSION 3.16)\nset(CMAKE_CXX_STANDARD 17)\nset(CMAKE_CXX_STANDARD_REQUIRED ON)\nfind_package(flashlight CONFIG REQUIRED)\nadd_executable(main main.cpp)\ntarget_link_libraries(main PRIVATE flashlight::flashlight)\n' > CMakeLists.txt" >> flashlight_compile_and_link_external_project.sh
             echo "export CC=/usr/bin/gcc-7 && export CXX=/usr/bin/g++-7 && export MKLROOT=/opt/intel/mkl" >> flashlight_compile_and_link_external_project.sh
             echo "mkdir -p build && cd build && cmake .. -DDNNL_DIR=/opt/onednn/lib/cmake/dnnl && make" >> flashlight_compile_and_link_external_project.sh
             echo "./main" >> flashlight_compile_and_link_external_project.sh
@@ -350,7 +350,7 @@ commands:
   ubuntu_install_and_setup_cmake:
     parameters:
       version:
-        default: "3.10"
+        default: "3.16"
         type: string
       version_build:
         default: "1"
@@ -367,7 +367,7 @@ commands:
   ubuntu_install_and_setup_cmake_in_docker:
     parameters:
       version:
-        default: "3.10"
+        default: "3.16"
         type: string
       version_build:
         default: "1"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 project(flashlight LANGUAGES CXX C VERSION 0.3.2)
 

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 include(${CMAKE_MODULE_PATH}/Buildpybind11.cmake)
 include(${CMAKE_MODULE_PATH}/pybind11Tools.cmake)

--- a/flashlight/app/CMakeLists.txt
+++ b/flashlight/app/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 fl_dependent_option(
   FL_BUILD_ALL_APPS

--- a/flashlight/app/asr/CMakeLists.txt
+++ b/flashlight/app/asr/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 cmake_dependent_option(FL_BUILD_APP_ASR_TOOLS "Build ASR App tools" ON "FL_BUILD_APP_ASR" OFF)
 

--- a/flashlight/app/asr/tools/CMakeLists.txt
+++ b/flashlight/app/asr/tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 # TODO: move this to another place once we have other working tools.
 # Use something similar to build_test where libs can be specified in a

--- a/flashlight/app/benchmark/CMakeLists.txt
+++ b/flashlight/app/benchmark/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 add_library(
   flashlight-app-benchmark

--- a/flashlight/app/benchmark/models/CMakeLists.txt
+++ b/flashlight/app/benchmark/models/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 target_sources(
   flashlight-app-benchmark

--- a/flashlight/app/imgclass/CMakeLists.txt
+++ b/flashlight/app/imgclass/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 add_executable(fl_img_imagenet_resnet34
   ${CMAKE_CURRENT_LIST_DIR}/examples/Defines.cpp

--- a/flashlight/app/lm/CMakeLists.txt
+++ b/flashlight/app/lm/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 # ----------------------------- Binaries -----------------------------
 add_executable(fl_lm_train

--- a/flashlight/app/lm/common/CMakeLists.txt
+++ b/flashlight/app/lm/common/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 target_sources(
   flashlight-app-lm

--- a/flashlight/app/objdet/CMakeLists.txt
+++ b/flashlight/app/objdet/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 add_executable(
   fl_img_imagenet_resnet50_backbone

--- a/flashlight/fl/CMakeLists.txt
+++ b/flashlight/fl/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 # ----------------------------- Setup -----------------------------
 set(FL_CORE_COMPONENT_SRC_DIR "${CMAKE_CURRENT_LIST_DIR}") # module root

--- a/flashlight/fl/autograd/CMakeLists.txt
+++ b/flashlight/fl/autograd/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 # ----------------------------- Autograd -----------------------------
 set(

--- a/flashlight/fl/autograd/tensor/CMakeLists.txt
+++ b/flashlight/fl/autograd/tensor/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 option(FL_USE_CUDNN "Build ArrayFire tensor backend" OFF)
 

--- a/flashlight/fl/autograd/tensor/backend/cudnn/CMakeLists.txt
+++ b/flashlight/fl/autograd/tensor/backend/cudnn/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 target_sources(
   flashlight

--- a/flashlight/fl/autograd/tensor/backend/onednn/CMakeLists.txt
+++ b/flashlight/fl/autograd/tensor/backend/onednn/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 target_sources(
   flashlight

--- a/flashlight/fl/common/CMakeLists.txt
+++ b/flashlight/fl/common/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 # ----------------------------- Common -----------------------------
 set(

--- a/flashlight/fl/contrib/CMakeLists.txt
+++ b/flashlight/fl/contrib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 # Root dir is `flashlight/contrib`
 set(FL_CONTRIB_ROOT_PATH ${CMAKE_CURRENT_LIST_DIR})

--- a/flashlight/fl/contrib/modules/CMakeLists.txt
+++ b/flashlight/fl/contrib/modules/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 set(
   FL_CONTRIB_MODULE_SOURCES

--- a/flashlight/fl/dataset/CMakeLists.txt
+++ b/flashlight/fl/dataset/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 set(
   DATASET_SOURCES

--- a/flashlight/fl/distributed/CMakeLists.txt
+++ b/flashlight/fl/distributed/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 # Distributed Training Backend
 cmake_dependent_option(FL_BUILD_DISTRIBUTED

--- a/flashlight/fl/examples/CMakeLists.txt
+++ b/flashlight/fl/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 project(flashlight-examples LANGUAGES CXX C VERSION 0.3.2)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/flashlight/fl/meter/CMakeLists.txt
+++ b/flashlight/fl/meter/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 set(
   METER_SOURCES

--- a/flashlight/fl/nn/CMakeLists.txt
+++ b/flashlight/fl/nn/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 # ----------------------------- NN Modules -----------------------------
 

--- a/flashlight/fl/optim/CMakeLists.txt
+++ b/flashlight/fl/optim/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 # ----------------------------- Optim -----------------------------
 

--- a/flashlight/fl/runtime/CMakeLists.txt
+++ b/flashlight/fl/runtime/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 target_sources(
   flashlight

--- a/flashlight/fl/tensor/CMakeLists.txt
+++ b/flashlight/fl/tensor/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 # Enable or disable compute backends. Example:
 #

--- a/flashlight/fl/tensor/backend/af/CMakeLists.txt
+++ b/flashlight/fl/tensor/backend/af/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 # ----------------------------- ArrayFire -----------------------------
 find_package(ArrayFire REQUIRED)

--- a/flashlight/fl/tensor/backend/af/mem/CMakeLists.txt
+++ b/flashlight/fl/tensor/backend/af/mem/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 set(
   MEMORY_SOURCES

--- a/flashlight/fl/tensor/backend/jit/CMakeLists.txt
+++ b/flashlight/fl/tensor/backend/jit/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 # ----------------------------- Sources -----------------------------
 

--- a/flashlight/fl/tensor/backend/jit/eval/CMakeLists.txt
+++ b/flashlight/fl/tensor/backend/jit/eval/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 # ----------------------------- Sources -----------------------------
 target_sources(

--- a/flashlight/fl/tensor/backend/jit/ir/CMakeLists.txt
+++ b/flashlight/fl/tensor/backend/jit/ir/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 # ----------------------------- Sources -----------------------------
 target_sources(

--- a/flashlight/fl/tensor/backend/onednn/CMakeLists.txt
+++ b/flashlight/fl/tensor/backend/onednn/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 # ----------------------------- OneDNN -----------------------------
 

--- a/flashlight/fl/tensor/backend/stub/CMakeLists.txt
+++ b/flashlight/fl/tensor/backend/stub/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 target_sources(
   flashlight

--- a/flashlight/fl/test/CMakeLists.txt
+++ b/flashlight/fl/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 set(DIR ${FL_CORE_DIR}/test)
 set(LIBS flashlight ${CMAKE_DL_LIBS})

--- a/flashlight/lib/CMakeLists.txt
+++ b/flashlight/lib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 # --------------------------- Lib Options  ---------------------------
 # Option to allow users to essentially be opt-opt. You can still selectively

--- a/flashlight/lib/audio/CMakeLists.txt
+++ b/flashlight/lib/audio/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 # ------------------------- Components -------------------------
 add_library(

--- a/flashlight/lib/audio/feature/CMakeLists.txt
+++ b/flashlight/lib/audio/feature/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 # ----------------------------- Dependencies -----------------------------
 # CBLAS

--- a/flashlight/lib/audio/test/CMakeLists.txt
+++ b/flashlight/lib/audio/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 set(DIR ${CMAKE_CURRENT_LIST_DIR})
 set(LIBS fl_lib_audio)

--- a/flashlight/lib/sequence/CMakeLists.txt
+++ b/flashlight/lib/sequence/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 # ------------------------- Components -------------------------
 

--- a/flashlight/lib/sequence/criterion/CMakeLists.txt
+++ b/flashlight/lib/sequence/criterion/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 target_sources(
   fl_lib_sequence

--- a/flashlight/lib/set/CMakeLists.txt
+++ b/flashlight/lib/set/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 
 add_library(

--- a/flashlight/pkg/CMakeLists.txt
+++ b/flashlight/pkg/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 fl_dependent_option(
   FL_BUILD_ALL_PKGS

--- a/flashlight/pkg/halide/CMakeLists.txt
+++ b/flashlight/pkg/halide/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 if (NOT (FL_USE_ARRAYFIRE AND FL_ARRAYFIRE_USE_CUDA))
   message(FATAL_ERROR "Flashlight Halide integration "

--- a/flashlight/pkg/runtime/CMakeLists.txt
+++ b/flashlight/pkg/runtime/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 find_package(GLOG REQUIRED)
 if (GLOG_FOUND)

--- a/flashlight/pkg/runtime/amp/CMakeLists.txt
+++ b/flashlight/pkg/runtime/amp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 target_sources(
   fl_pkg_runtime

--- a/flashlight/pkg/runtime/common/CMakeLists.txt
+++ b/flashlight/pkg/runtime/common/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 target_sources(
   fl_pkg_runtime

--- a/flashlight/pkg/runtime/plugin/CMakeLists.txt
+++ b/flashlight/pkg/runtime/plugin/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 target_sources(
   fl_pkg_runtime

--- a/flashlight/pkg/runtime/plugin/plugincompiler/CMakeLists.txt
+++ b/flashlight/pkg/runtime/plugin/plugincompiler/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 # Detect if we're doing an in-source or an out-of-source build
 set(FL_PLUGIN_LINK_TARGET)

--- a/flashlight/pkg/runtime/test/CMakeLists.txt
+++ b/flashlight/pkg/runtime/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 set(DIR ${CMAKE_CURRENT_LIST_DIR})
 set(LIBS fl_pkg_runtime)

--- a/flashlight/pkg/speech/CMakeLists.txt
+++ b/flashlight/pkg/speech/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 cmake_dependent_option(
   FL_BUILD_APP_ASR_SFX_SOX

--- a/flashlight/pkg/speech/augmentation/CMakeLists.txt
+++ b/flashlight/pkg/speech/augmentation/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 # ------------------------ libsox ------------------------
 # Add the include dir and the libraries that are required for

--- a/flashlight/pkg/speech/common/CMakeLists.txt
+++ b/flashlight/pkg/speech/common/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 target_sources(
   fl_pkg_speech

--- a/flashlight/pkg/speech/criterion/CMakeLists.txt
+++ b/flashlight/pkg/speech/criterion/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 # ---------------------------- Backend-specific -----------------------------
 if (FL_USE_CUDA)

--- a/flashlight/pkg/speech/data/CMakeLists.txt
+++ b/flashlight/pkg/speech/data/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 # ----------------------------- Dependencies -----------------------------
 find_package(SndFile)

--- a/flashlight/pkg/speech/decoder/CMakeLists.txt
+++ b/flashlight/pkg/speech/decoder/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 target_sources(
   fl_pkg_speech

--- a/flashlight/pkg/speech/runtime/CMakeLists.txt
+++ b/flashlight/pkg/speech/runtime/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 target_sources(
   fl_pkg_speech

--- a/flashlight/pkg/speech/test/CMakeLists.txt
+++ b/flashlight/pkg/speech/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 set(DIR ${CMAKE_CURRENT_LIST_DIR})
 # TODO remove dependency on runtime components for these tests

--- a/flashlight/pkg/text/CMakeLists.txt
+++ b/flashlight/pkg/text/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 add_library(
   fl_pkg_text

--- a/flashlight/pkg/text/data/CMakeLists.txt
+++ b/flashlight/pkg/text/data/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 target_sources(
   fl_pkg_text

--- a/flashlight/pkg/text/test/CMakeLists.txt
+++ b/flashlight/pkg/text/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 set(DIR ${CMAKE_CURRENT_LIST_DIR})
 set(LIBS fl_pkg_text)

--- a/flashlight/pkg/vision/CMakeLists.txt
+++ b/flashlight/pkg/vision/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 add_library(fl_pkg_vision "")
 

--- a/flashlight/pkg/vision/criterion/CMakeLists.txt
+++ b/flashlight/pkg/vision/criterion/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 # ----------------------------- NN Modules -----------------------------
 target_sources(

--- a/flashlight/pkg/vision/dataset/CMakeLists.txt
+++ b/flashlight/pkg/vision/dataset/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 set(stb_INSTALL_PATH ${FL_INSTALL_INC_DIR}/stb)
 find_package(stb)

--- a/flashlight/pkg/vision/models/CMakeLists.txt
+++ b/flashlight/pkg/vision/models/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 target_sources(
   fl_pkg_vision

--- a/flashlight/pkg/vision/nn/CMakeLists.txt
+++ b/flashlight/pkg/vision/nn/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 target_sources(
   fl_pkg_vision

--- a/flashlight/pkg/vision/tensor/CMakeLists.txt
+++ b/flashlight/pkg/vision/tensor/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 if (FL_USE_ARRAYFIRE)
   include(${CMAKE_CURRENT_LIST_DIR}/backend/af/CMakeLists.txt)

--- a/flashlight/pkg/vision/tensor/backend/af/CMakeLists.txt
+++ b/flashlight/pkg/vision/tensor/backend/af/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 target_sources(
   flashlight

--- a/flashlight/pkg/vision/test/CMakeLists.txt
+++ b/flashlight/pkg/vision/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 set(DIR ${CMAKE_CURRENT_LIST_DIR})
 set(LIBS fl_pkg_vision)


### PR DESCRIPTION
Summary:
Upgrade CMake minumum to version 3.16 to take advantage of modern CMake features found in version 3.16, which ships standard on Ubuntu 20.04.

This diff should solve T133531700.

Differential Revision: D40234025

