### PR TITLE
Add namespace_packages to setup.py

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -19,7 +19,6 @@ from setuptools.command.build_ext import build_ext
 
 # Environment variables:
 # - `USE_CUDA=0` disables building CUDA components
-# - `USE_KENLM=0` disables building KenLM
 # - `USE_MKL=1` enables MKL (may cause errors)
 # By default build with USE_CUDA=1, USE_KENLM=1, USE_MKL=0
 
@@ -113,12 +112,8 @@ setup(
     author_email="oncall+fair_speech@xmail.facebook.com",
     description="Flashlight bindings for python",
     long_description="",
-    packages=[
-        "flashlight",
-        "flashlight.lib",
-        "flashlight.lib.audio",
-        "flashlight.lib.sequence",
-    ],
+    namespace_packages=["flashlight", "flashlight.lib"],
+    packages=["flashlight.lib.audio", "flashlight.lib.sequence"],
     ext_modules=[
         CMakeExtension("flashlight.lib.audio.feature"),
         CMakeExtension("flashlight.lib.sequence.criterion"),


### PR DESCRIPTION
See title. Prevents breakage when installing multiple `flashlight.lib` modules from different repos.

### Test Plan (required) Local test on a clean Ubuntu box with Python 3.10

```
git clone https://github.com/flashlight/flashlight.git
cd flashlight
wget https://gist.githubusercontent.com/jacobkahn/f345a94974838c89df6b07f77824fca5/raw/65c3ca05961a92a08fbe1e2629a9290774baf6fd/diff.out
git apply diff.out
USE_CUDA=0 USE_MKL=0 pip install -e bindings/python
python -c "import flashlight.lib.sequence" # succeeds
```
and
```
git clone https://github.com/flashlight/text && cd text
cd bindings/python
python3 setup.py install
python -c "import flashlight.lib.text" # succeeds
```

Fixes https://github.com/flashlight/flashlight/issues/1025