### PR TITLE
Expose non R-value releaseAdapter

### DIFF
--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -879,6 +879,10 @@ std::unique_ptr<TensorAdapterBase> releaseAdapter(Tensor&& t) {
   return t.releaseAdapter();
 }
 
+std::unique_ptr<TensorAdapterBase> releaseAdapter(Tensor t) {
+  return t.releaseAdapter();
+}
+
 bool areTensorTypesEqual(const Tensor& a, const Tensor& b) {
   return a.type() == b.type();
 }

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -879,7 +879,7 @@ std::unique_ptr<TensorAdapterBase> releaseAdapter(Tensor&& t) {
   return t.releaseAdapter();
 }
 
-std::unique_ptr<TensorAdapterBase> releaseAdapterUnsafe(Tensor t) {
+std::unique_ptr<TensorAdapterBase> releaseAdapterUnsafe(Tensor& t) {
   return t.releaseAdapter();
 }
 

--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -879,7 +879,7 @@ std::unique_ptr<TensorAdapterBase> releaseAdapter(Tensor&& t) {
   return t.releaseAdapter();
 }
 
-std::unique_ptr<TensorAdapterBase> releaseAdapter(Tensor t) {
+std::unique_ptr<TensorAdapterBase> releaseAdapterUnsafe(Tensor t) {
   return t.releaseAdapter();
 }
 

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -56,6 +56,7 @@ enum class StorageType { Dense = 0, CSR = 1, CSC = 2, COO = 3 };
 namespace detail {
 
 std::unique_ptr<TensorAdapterBase> releaseAdapter(Tensor&& t);
+std::unique_ptr<TensorAdapterBase> releaseAdapter(Tensor t);
 
 } // namespace detail
 
@@ -116,6 +117,7 @@ class Tensor {
 
   std::unique_ptr<TensorAdapterBase> releaseAdapter();
   friend std::unique_ptr<TensorAdapterBase> detail::releaseAdapter(Tensor&& t);
+  friend std::unique_ptr<TensorAdapterBase> detail::releaseAdapter(Tensor t);
 
  public:
   explicit Tensor(std::unique_ptr<TensorAdapterBase> adapter);

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -56,7 +56,7 @@ enum class StorageType { Dense = 0, CSR = 1, CSC = 2, COO = 3 };
 namespace detail {
 
 std::unique_ptr<TensorAdapterBase> releaseAdapter(Tensor&& t);
-std::unique_ptr<TensorAdapterBase> releaseAdapter(Tensor t);
+std::unique_ptr<TensorAdapterBase> releaseAdapterUnsafe(Tensor t);
 
 } // namespace detail
 
@@ -117,7 +117,8 @@ class Tensor {
 
   std::unique_ptr<TensorAdapterBase> releaseAdapter();
   friend std::unique_ptr<TensorAdapterBase> detail::releaseAdapter(Tensor&& t);
-  friend std::unique_ptr<TensorAdapterBase> detail::releaseAdapter(Tensor t);
+  friend std::unique_ptr<TensorAdapterBase> detail::releaseAdapterUnsafe(
+      Tensor t);
 
  public:
   explicit Tensor(std::unique_ptr<TensorAdapterBase> adapter);

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -56,7 +56,7 @@ enum class StorageType { Dense = 0, CSR = 1, CSC = 2, COO = 3 };
 namespace detail {
 
 std::unique_ptr<TensorAdapterBase> releaseAdapter(Tensor&& t);
-std::unique_ptr<TensorAdapterBase> releaseAdapterUnsafe(Tensor t);
+std::unique_ptr<TensorAdapterBase> releaseAdapterUnsafe(Tensor& t);
 
 } // namespace detail
 
@@ -118,7 +118,7 @@ class Tensor {
   std::unique_ptr<TensorAdapterBase> releaseAdapter();
   friend std::unique_ptr<TensorAdapterBase> detail::releaseAdapter(Tensor&& t);
   friend std::unique_ptr<TensorAdapterBase> detail::releaseAdapterUnsafe(
-      Tensor t);
+      Tensor& t);
 
  public:
   explicit Tensor(std::unique_ptr<TensorAdapterBase> adapter);


### PR DESCRIPTION
Related to https://github.com/facebookresearch/shumai/issues/50

### Summary

Allows the deletion of all underlying adapter values without destroying the Tensor object itself.