### PR TITLE
Implement copy and in place assignment

### DIFF
--- a/flashlight/fl/tensor/backend/jit/JitTensorBase.cpp
+++ b/flashlight/fl/tensor/backend/jit/JitTensorBase.cpp
@@ -15,36 +15,48 @@
 
 namespace fl {
 
-JitTensorBase::JitTensorBase(Node* node) : node_(node) {
-  node_->incRefCount();
-}
+struct JitTensorBase::SharedData {
+  Node* node;
+  SharedData(Node* node) : node(node) {
+    node->incRefCount();
+  }
+  ~SharedData() {
+    node->decRefCount();
+  }
+};
 
-JitTensorBase::~JitTensorBase() {
-  node_->decRefCount();
-}
+JitTensorBase::JitTensorBase(Node* node)
+    : JitTensorBase(std::make_shared<SharedData>(node)) {}
 
-// take care of refcount for old & new nodes
+JitTensorBase::JitTensorBase(std::shared_ptr<SharedData> sharedNode)
+    : sharedNode_(sharedNode) {}
+
+JitTensorBase::~JitTensorBase() {}
+
 void JitTensorBase::replaceNode(Node* newNode) const {
-  if (node_ != newNode) {
-    node_->decRefCount();
+  auto oldNode = node();
+  if (newNode != oldNode) {
     newNode->incRefCount();
-    const_cast<JitTensorBase*>(this)->node_ = newNode;
+    oldNode->decRefCount();
+    sharedNode_->node = newNode;
   }
 }
 
 const Tensor& JitTensorBase::getTensorOrEvalNode() const {
-  if (!node_->getResult().has_value()) {
+  if (!node()->getResult().has_value()) {
     eval();
   }
-  return node_->getResult().value();
+  return node()->getResult().value();
 }
 
 Tensor JitTensorBase::copy() {
-  FL_JIT_TENSOR_UNIMPLEMENTED;
+  // Since a node's computation result is immutable, copy is free.
+  return Tensor(clone());
 }
 
 Tensor JitTensorBase::shallowCopy() {
-  return fromNode(node_);
+  // NOTE IR-captured computation semantics is immutable
+  return fromSharedNode(sharedNode_);
 }
 
 TensorBackendType JitTensorBase::backendType() const {
@@ -138,45 +150,82 @@ std::ostream& JitTensorBase::operator<<(std::ostream& /* ostr */) {
 }
 
 /******************** Assignment Operators ********************/
-#define FL_JIT_TENSOR_ASSIGN_OP_TYPE_STUB(OP, TYPE)           \
-  void JitTensorBase::OP(const TYPE& /* val */) {             \
-    throw std::invalid_argument(                              \
-        "JitTensorBase::" + std::string(#OP) + " for type " + \
-        std::string(#TYPE));                                  \
+// NOTE Think SSA:
+// x += 42
+// ......
+// --->
+// x' = x + 42
+// ...... (uses of x becomes x')
+void JitTensorBase::assign(const Tensor& other) {
+  replaceNode(toJitTensorBase(other).node());
+}
+
+#define FL_JIT_TENSOR_ASSIGN_OP_SCALAR(OP, TYPE)                \
+  void JitTensorBase::OP(const TYPE& scalar) {                  \
+    const auto dtype = dtype_traits<TYPE>::ctype;               \
+    this->assign(backend().full(this->shape(), scalar, dtype)); \
   }
 
-#define FL_JIT_TENSOR_ASSIGN_OP_STUB(OP)                 \
-  FL_JIT_TENSOR_ASSIGN_OP_TYPE_STUB(OP, Tensor);         \
-  FL_JIT_TENSOR_ASSIGN_OP_TYPE_STUB(OP, double);         \
-  FL_JIT_TENSOR_ASSIGN_OP_TYPE_STUB(OP, float);          \
-  FL_JIT_TENSOR_ASSIGN_OP_TYPE_STUB(OP, int);            \
-  FL_JIT_TENSOR_ASSIGN_OP_TYPE_STUB(OP, unsigned);       \
-  FL_JIT_TENSOR_ASSIGN_OP_TYPE_STUB(OP, bool);           \
-  FL_JIT_TENSOR_ASSIGN_OP_TYPE_STUB(OP, char);           \
-  FL_JIT_TENSOR_ASSIGN_OP_TYPE_STUB(OP, unsigned char);  \
-  FL_JIT_TENSOR_ASSIGN_OP_TYPE_STUB(OP, short);          \
-  FL_JIT_TENSOR_ASSIGN_OP_TYPE_STUB(OP, unsigned short); \
-  FL_JIT_TENSOR_ASSIGN_OP_TYPE_STUB(OP, long);           \
-  FL_JIT_TENSOR_ASSIGN_OP_TYPE_STUB(OP, unsigned long);  \
-  FL_JIT_TENSOR_ASSIGN_OP_TYPE_STUB(OP, long long);      \
-  FL_JIT_TENSOR_ASSIGN_OP_TYPE_STUB(OP, unsigned long long);
+#define FL_JIT_TENSOR_ASSIGN_BINOP_TENSOR(OP, BINOP) \
+  void JitTensorBase::OP(const Tensor& other) {      \
+    this->assign(this->shallowCopy() BINOP other);   \
+  }
 
-FL_JIT_TENSOR_ASSIGN_OP_STUB(assign); // =
-FL_JIT_TENSOR_ASSIGN_OP_STUB(inPlaceAdd); // +=
-FL_JIT_TENSOR_ASSIGN_OP_STUB(inPlaceSubtract); // -=
-FL_JIT_TENSOR_ASSIGN_OP_STUB(inPlaceMultiply); // *=
-FL_JIT_TENSOR_ASSIGN_OP_STUB(inPlaceDivide); // /=
-#undef FL_JIT_TENSOR_ASSIGN_OP_TYPE
+#define FL_JIT_TENSOR_ASSIGN_BINOP_SCALAR(OP, BINOP, TYPE) \
+  void JitTensorBase::OP(const TYPE& scalar) {             \
+    this->assign(this->shallowCopy() BINOP scalar);        \
+  }
+
+#define FL_JIT_TENSOR_ASSIGN_OP(OP)                   \
+  FL_JIT_TENSOR_ASSIGN_OP_SCALAR(OP, double);         \
+  FL_JIT_TENSOR_ASSIGN_OP_SCALAR(OP, float);          \
+  FL_JIT_TENSOR_ASSIGN_OP_SCALAR(OP, int);            \
+  FL_JIT_TENSOR_ASSIGN_OP_SCALAR(OP, unsigned);       \
+  FL_JIT_TENSOR_ASSIGN_OP_SCALAR(OP, bool);           \
+  FL_JIT_TENSOR_ASSIGN_OP_SCALAR(OP, char);           \
+  FL_JIT_TENSOR_ASSIGN_OP_SCALAR(OP, unsigned char);  \
+  FL_JIT_TENSOR_ASSIGN_OP_SCALAR(OP, short);          \
+  FL_JIT_TENSOR_ASSIGN_OP_SCALAR(OP, unsigned short); \
+  FL_JIT_TENSOR_ASSIGN_OP_SCALAR(OP, long);           \
+  FL_JIT_TENSOR_ASSIGN_OP_SCALAR(OP, unsigned long);  \
+  FL_JIT_TENSOR_ASSIGN_OP_SCALAR(OP, long long);      \
+  FL_JIT_TENSOR_ASSIGN_OP_SCALAR(OP, unsigned long long);
+
+#define FL_JIT_TENSOR_ASSIGN_BINOP(OP, BINOP)                   \
+  FL_JIT_TENSOR_ASSIGN_BINOP_TENSOR(OP, BINOP);                 \
+  FL_JIT_TENSOR_ASSIGN_BINOP_SCALAR(OP, BINOP, double);         \
+  FL_JIT_TENSOR_ASSIGN_BINOP_SCALAR(OP, BINOP, float);          \
+  FL_JIT_TENSOR_ASSIGN_BINOP_SCALAR(OP, BINOP, int);            \
+  FL_JIT_TENSOR_ASSIGN_BINOP_SCALAR(OP, BINOP, unsigned);       \
+  FL_JIT_TENSOR_ASSIGN_BINOP_SCALAR(OP, BINOP, bool);           \
+  FL_JIT_TENSOR_ASSIGN_BINOP_SCALAR(OP, BINOP, char);           \
+  FL_JIT_TENSOR_ASSIGN_BINOP_SCALAR(OP, BINOP, unsigned char);  \
+  FL_JIT_TENSOR_ASSIGN_BINOP_SCALAR(OP, BINOP, short);          \
+  FL_JIT_TENSOR_ASSIGN_BINOP_SCALAR(OP, BINOP, unsigned short); \
+  FL_JIT_TENSOR_ASSIGN_BINOP_SCALAR(OP, BINOP, long);           \
+  FL_JIT_TENSOR_ASSIGN_BINOP_SCALAR(OP, BINOP, unsigned long);  \
+  FL_JIT_TENSOR_ASSIGN_BINOP_SCALAR(OP, BINOP, long long);      \
+  FL_JIT_TENSOR_ASSIGN_BINOP_SCALAR(OP, BINOP, unsigned long long);
+
+FL_JIT_TENSOR_ASSIGN_OP(assign); // =
+FL_JIT_TENSOR_ASSIGN_BINOP(inPlaceAdd, +); // +=
+FL_JIT_TENSOR_ASSIGN_BINOP(inPlaceSubtract, -); // -=
+FL_JIT_TENSOR_ASSIGN_BINOP(inPlaceMultiply, *); // *=
+FL_JIT_TENSOR_ASSIGN_BINOP(inPlaceDivide, /); // /=
+#undef FL_JIT_TENSOR_ASSIGN_OP_SCALAR
+#undef FL_JIT_TENSOR_ASSIGN_BINOP_TENSOR
+#undef FL_JIT_TENSOR_ASSIGN_BINOP_SCALAR
 #undef FL_JIT_TENSOR_ASSIGN_OP
+#undef FL_JIT_TENSOR_ASSIGN_BINOP
 
 Node* JitTensorBase::node() const {
-  return node_;
+  return sharedNode_->node;
 }
 
 void JitTensorBase::eval() const {
-  if (!node_->getResult().has_value()) {
-    replaceNode(optimizer().optimize(node_));
-    evaluator().eval(node_);
+  if (!node()->getResult().has_value()) {
+    replaceNode(optimizer().optimize(node()));
+    evaluator().eval(node());
   }
 }
 

--- a/flashlight/fl/tensor/backend/jit/JitTensorBase.h
+++ b/flashlight/fl/tensor/backend/jit/JitTensorBase.h
@@ -20,7 +20,13 @@ namespace fl {
  * computation graph and delegates to the wrapped backend for execution.
  */
 class JitTensorBase : public TensorAdapterBase {
-  Node* node_;
+ public:
+  // declaration made private to enable `std::make_shared`
+  struct SharedData;
+
+ private:
+  // shared among shallow copies
+  std::shared_ptr<SharedData> sharedNode_;
 
   // take care of refcount for old & new nodes
   // `const` w.r.t. the underlying Tensor this represents.
@@ -31,7 +37,8 @@ class JitTensorBase : public TensorAdapterBase {
 
  protected:
   // this allows us to create an instance of derived class
-  virtual Tensor fromNode(Node* node) const = 0;
+  virtual Tensor fromSharedNode(
+      std::shared_ptr<SharedData> sharedNode) const = 0;
 
   // let derived class manage the wrapped backend
   virtual TensorBackend& wrappedBackend() const = 0;
@@ -42,6 +49,7 @@ class JitTensorBase : public TensorAdapterBase {
 
   // JitTensorBase manages the backend-agnostic JIT node.
   JitTensorBase(Node* node);
+  JitTensorBase(std::shared_ptr<SharedData> sharedNode);
 
  public:
   virtual ~JitTensorBase() override;


### PR DESCRIPTION
### Summary
Use SSA to implement assignment in the lazy JitTensor.

This allows us to capture maximal graph that obeys the computation result of tensors under assignment, based on the lexical order of their definitions.

Lazy computation and assignment doesn't play well with each other. The alternative I considered was in-place node mutation (so assignment corresponds to changing graph), and aggressively evaluate subgraphs that uses the to-be-updated node, because they rely on the "old value". That approaches is complicated, and fails to capture maximal graph.

Granted, SSA IR seems to deprive "buffer reuse" during assignment. But we could add backend evaluator/optimizer logic to recover this; moreover, allowing the backend to make global decision on such buffer reuse could be more optimal (than having programmer making such decision).

### Test Plan
Unit tests are added

```
make JitTensorTest
```
