### PR TITLE
expose hasAdapter

### DIFF
--- a/flashlight/fl/tensor/TensorBase.cpp
+++ b/flashlight/fl/tensor/TensorBase.cpp
@@ -98,6 +98,10 @@ bool Tensor::isEmpty() const {
   return elements() == 0;
 }
 
+bool Tensor::hasAdapter() const {
+  return impl_.get() != nullptr;
+}
+
 size_t Tensor::bytes() const {
   return elements() * getTypeSize(type());
 }

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -304,6 +304,13 @@ class Tensor {
   bool isEmpty() const;
 
   /**
+   * Returns true if the tensor has an associated underlying adapter.
+   *
+   * @return true if the tensor has a valid adapter
+   */
+  bool hasAdapter() const;
+
+  /**
    * Get the tensor size in bytes.
    *
    * @return the size of the tensor in bytes.

--- a/flashlight/fl/test/tensor/TensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/TensorBaseTest.cpp
@@ -149,6 +149,13 @@ TEST(TensorBaseTest, Metadata) {
   ASSERT_FALSE(e.isLocked());
 }
 
+TEST(TensorBaseTest, hasAdapter) {
+  Tensor a = fromScalar(3.14, fl::dtype::f32);
+  ASSERT_TRUE(a.hasAdapter());
+  detail::releaseAdapterUnsafe(a);
+  ASSERT_FALSE(a.hasAdapter());
+}
+
 TEST(TensorBaseTest, fromScalar) {
   Tensor a = fromScalar(3.14, fl::dtype::f32);
   ASSERT_EQ(a.elements(), 1);


### PR DESCRIPTION
### Summary
This will make it possible to check if we've already released the underlying data of a tensor without freeing it.
