### PR TITLE
Implement simple shape inference

### DIFF
--- a/flashlight/fl/tensor/backend/jit/JitTensorBase.cpp
+++ b/flashlight/fl/tensor/backend/jit/JitTensorBase.cpp
@@ -64,7 +64,7 @@ TensorBackendType JitTensorBase::backendType() const {
 }
 
 const Shape& JitTensorBase::shape() {
-  FL_JIT_TENSOR_UNIMPLEMENTED;
+  return node()->shape();
 }
 
 fl::dtype JitTensorBase::type() {

--- a/flashlight/fl/tensor/backend/jit/ir/BinaryNode.cpp
+++ b/flashlight/fl/tensor/backend/jit/ir/BinaryNode.cpp
@@ -6,14 +6,53 @@
  */
 
 #include "flashlight/fl/tensor/backend/jit/ir/BinaryNode.h"
+#include <sstream>
+#include <stdexcept>
 
 namespace fl {
 
-BinaryNode::BinaryNode(Node* lhs, Node* rhs, BinaryOp op)
-    : NodeTrait({lhs, rhs}), op_(op) {}
+namespace {
+
+/**
+ * Rule:
+ *    LHS: (r1, ..., rn)
+ *    RHS: (l1, ..., ln)
+ *  where ri == li, or 1 ∈ (ri, li)
+ *  output shape: (max(r1, l1), ..., max(rn, ln))
+ * TODO allow different # of dimensions.
+ */
+std::optional<Shape> getBinopOutputShape(const Shape& lhs, const Shape& rhs) {
+  if (lhs.ndim() != rhs.ndim()) {
+    return std::nullopt;
+  }
+  // check and accumulate output dimensions
+  auto ndim = lhs.ndim();
+  std::vector<Dim> dstDims;
+  for (auto i = 0; i < ndim; ++i) {
+    auto lhsDim = lhs.dim(i);
+    auto rhsDim = rhs.dim(i);
+    if (lhsDim != rhsDim && lhsDim != 1 && rhsDim != 1) {
+      return std::nullopt;
+    }
+    dstDims.push_back(std::max(lhsDim, rhsDim));
+  }
+  return Shape(dstDims);
+}
+
+} // namespace
+
+BinaryNode::BinaryNode(Node* lhs, Node* rhs, BinaryOp op, const Shape& shape)
+    : NodeTrait({lhs, rhs}, shape), op_(op) {}
 
 BinaryNode* BinaryNode::create(Node* lhs, Node* rhs, BinaryOp op) {
-  return new BinaryNode(lhs, rhs, op);
+  const auto outputShapeOpt = getBinopOutputShape(lhs->shape(), rhs->shape());
+  if (!outputShapeOpt.has_value()) {
+    std::ostringstream oss;
+    oss << "[BinaryNode::create] Invalid shapes: " << lhs->shape() << " and "
+        << rhs->shape();
+    throw std::runtime_error(oss.str());
+  }
+  return new BinaryNode(lhs, rhs, op, outputShapeOpt.value());
 }
 
 BinaryOp BinaryNode::op() const {

--- a/flashlight/fl/tensor/backend/jit/ir/BinaryNode.h
+++ b/flashlight/fl/tensor/backend/jit/ir/BinaryNode.h
@@ -27,7 +27,7 @@ class BinaryNode : public NodeTrait<BinaryNode> {
   static constexpr unsigned kRhsIdx = 1;
 
   // intentionally kept private to control allocation
-  BinaryNode(Node* lhs, Node* rhs, BinaryOp op);
+  BinaryNode(Node* lhs, Node* rhs, BinaryOp op, const Shape& shape);
 
  public:
   static constexpr NodeType nodeType = NodeType::Binary;

--- a/flashlight/fl/tensor/backend/jit/ir/CustomNode.cpp
+++ b/flashlight/fl/tensor/backend/jit/ir/CustomNode.cpp
@@ -14,17 +14,19 @@ namespace fl {
 CustomNode::CustomNode(
     std::string&& name,
     std::vector<Node*>&& inputs,
+    const Shape& shape,
     EvalFunc&& evalFunc)
-    : NodeTrait(std::move(inputs)),
+    : NodeTrait(std::move(inputs), shape),
       name_(name),
       evalFunc_(std::move(evalFunc)) {}
 
 CustomNode* CustomNode::create(
     std::string&& name,
     std::vector<Node*>&& inputs,
+    const Shape& shape,
     EvalFunc&& evalFunc) {
   return new CustomNode(
-      std::move(name), std::move(inputs), std::move(evalFunc));
+      std::move(name), std::move(inputs), shape, std::move(evalFunc));
 }
 
 const std::string& CustomNode::name() const {

--- a/flashlight/fl/tensor/backend/jit/ir/CustomNode.h
+++ b/flashlight/fl/tensor/backend/jit/ir/CustomNode.h
@@ -32,6 +32,7 @@ class CustomNode : public NodeTrait<CustomNode> {
   CustomNode(
       std::string&& name,
       std::vector<Node*>&& inputs,
+      const Shape& shape,
       EvalFunc&& evalFunc);
 
  public:
@@ -40,6 +41,7 @@ class CustomNode : public NodeTrait<CustomNode> {
   static CustomNode* create(
       std::string&& debugName,
       std::vector<Node*>&& inputs,
+      const Shape& shape,
       EvalFunc&& evalFunc);
 
   const std::string& name() const;

--- a/flashlight/fl/tensor/backend/jit/ir/Node.cpp
+++ b/flashlight/fl/tensor/backend/jit/ir/Node.cpp
@@ -45,7 +45,8 @@ void Node::resetInput(unsigned inputIdx) {
   oldInput->decRefCount();
 }
 
-Node::Node(std::vector<Node*>&& inputs) {
+Node::Node(std::vector<Node*>&& inputs, const Shape& shape)
+  : inputs_(inputs), shape_(shape) {
   inputs_.resize(inputs.size());
   inputUseIters_.resize(inputs.size());
   for (unsigned inputIdx = 0; inputIdx < inputs.size(); inputIdx++) {
@@ -70,6 +71,10 @@ const std::vector<Node*>& Node::inputs() const {
 void Node::setInput(unsigned inputIdx, Node* newInput) {
   resetInput(inputIdx);
   setInputImpl(inputIdx, newInput);
+}
+
+const Shape& Node::shape() const {
+  return shape_;
 }
 
 const UseList& Node::uses() const {

--- a/flashlight/fl/tensor/backend/jit/ir/Node.h
+++ b/flashlight/fl/tensor/backend/jit/ir/Node.h
@@ -41,6 +41,7 @@ class Node {
   std::vector<Node*> inputs_;
   std::vector<UseList::iterator> inputUseIters_;
   UseList uses_;
+  const Shape shape_;
   unsigned refCount_{0};
 
   // present if this node has been evaluated
@@ -57,7 +58,7 @@ class Node {
 
  protected:
   // A constructor that sets up all the metadata
-  Node(std::vector<Node*>&& inputs);
+  Node(std::vector<Node*>&& inputs, const Shape& shape);
 
   // Help enforce internal consistency.
   Node* getInput(unsigned inputIdx) const;
@@ -68,6 +69,9 @@ class Node {
   // Inputs
   const std::vector<Node*>& inputs() const;
   void setInput(unsigned inputIdx, Node* newInput);
+
+  // Shape
+  const Shape& shape() const;
 
   // Uses
   const UseList& uses() const;
@@ -115,7 +119,8 @@ class Node {
 template <typename Derived>
 class NodeTrait : public Node {
  public:
-  NodeTrait(std::vector<Node*>&& inputs) : Node(std::move(inputs)) {}
+  NodeTrait(std::vector<Node*>&& inputs, const Shape& shape)
+    : Node(std::move(inputs), std::move(shape)) {}
 
   NodeType type() const override {
     return Derived::nodeType;

--- a/flashlight/fl/tensor/backend/jit/ir/ScalarNode.cpp
+++ b/flashlight/fl/tensor/backend/jit/ir/ScalarNode.cpp
@@ -13,11 +13,7 @@ ScalarNode::ScalarNode(
     const Shape& shape,
     const fl::dtype type,
     const ScalarType scalar)
-    : NodeTrait({}), shape_(shape), dtype_(type), scalar_(scalar) {}
-
-const Shape& ScalarNode::shape() const {
-  return shape_;
-}
+    : NodeTrait({}, shape), dtype_(type), scalar_(scalar) {}
 
 dtype ScalarNode::dataType() const {
   return dtype_;

--- a/flashlight/fl/tensor/backend/jit/ir/ScalarNode.h
+++ b/flashlight/fl/tensor/backend/jit/ir/ScalarNode.h
@@ -22,7 +22,6 @@ class ScalarNode : public NodeTrait<ScalarNode> {
   // these types can hold all types scalars FL support, w/o loss of precision
   using ScalarType = std::variant<long long, double, unsigned long long>;
 
-  const Shape shape_;
   const dtype dtype_;
   const ScalarType scalar_; // value used for initialization
 
@@ -55,7 +54,7 @@ class ScalarNode : public NodeTrait<ScalarNode> {
     throw std::runtime_error("[ScalarNode::create] Unknown dtype");
   }
 
-  const Shape& shape() const;
+  // metadata
   dtype dataType() const;
 
   // cast to T

--- a/flashlight/fl/tensor/backend/jit/ir/ValueNode.cpp
+++ b/flashlight/fl/tensor/backend/jit/ir/ValueNode.cpp
@@ -9,7 +9,7 @@
 
 namespace fl {
 
-ValueNode::ValueNode(Tensor&& value) : NodeTrait({}) {
+ValueNode::ValueNode(Tensor&& value) : NodeTrait({}, value.shape()) {
   setResult(std::move(value));
 }
 

--- a/flashlight/fl/test/tensor/jit/JitEvaluatorTest.cpp
+++ b/flashlight/fl/test/tensor/jit/JitEvaluatorTest.cpp
@@ -72,7 +72,7 @@ TEST_F(JitEvaluatorTest, evalCustomNode) {
   const auto c2 = ScalarNode::create(shape, dtype, 2);
   const auto c3 = ScalarNode::create(shape, dtype, 3);
   const auto custom = CustomNode::create(
-      "addThenMul", {c1, c2, c3}, [](const std::vector<const Tensor*> inputs) {
+      "addThenMul", {c1, c2, c3}, shape, [](const std::vector<const Tensor*> inputs) {
         return (*inputs[0] + *inputs[1]) * *inputs[2];
       });
   evaluator_.eval(custom);

--- a/flashlight/fl/test/tensor/jit/JitOneDnnOpFusionTest.cpp
+++ b/flashlight/fl/test/tensor/jit/JitOneDnnOpFusionTest.cpp
@@ -117,7 +117,7 @@ TEST_F(JitOneDnnOpFusionTest, nonFusableRoot) {
   const auto mul = BinaryNode::create(c1, c2, BinaryOp::Mul);
   const auto add = BinaryNode::create(mul, c3, BinaryOp::Add);
   const auto custom = CustomNode::create(
-      "identity", {add}, [](const std::vector<const Tensor*>& inputs) {
+      "identity", {add}, shape, [](const std::vector<const Tensor*>& inputs) {
         return *inputs[0];
       });
   // c1  c2
@@ -209,10 +209,12 @@ TEST_F(JitOneDnnOpFusionTest, nestedFusableChains) {
   ASSERT_EQ(fusedCustomNode->inputs(), NodeList({c2, c3, c4}));
   ASSERT_EQ(fusedCustomNode->uses(), UseValList({{fusedCustomRoot, 1}}));
   ASSERT_EQ(fusedCustomNode->getRefCount(), 1);
+  ASSERT_EQ(fusedCustomNode->shape(), shape);
   ASSERT_TRUE(fusedCustomNode->isCustom());
   ASSERT_EQ(fusedCustomRoot->inputs(), NodeList({c1, fusedCustomNode, c5}));
   ASSERT_EQ(fusedCustomRoot->uses(), UseValList({}));
   ASSERT_EQ(fusedCustomRoot->getRefCount(), 0);
+  ASSERT_EQ(fusedCustomRoot->shape(), shape);
   ASSERT_TRUE(fusedCustomRoot->isCustom());
   // root node is owned locally (didn't transition to shared ownership)
   delete fusedCustomRoot;

--- a/flashlight/fl/test/tensor/jit/JitScalarFoldingTest.cpp
+++ b/flashlight/fl/test/tensor/jit/JitScalarFoldingTest.cpp
@@ -181,7 +181,7 @@ TEST_F(JitScalarFoldingTest, nonFoldableRoot) {
   const auto c3 = ScalarNode::create(shape, dtype, 3);
   const auto div = BinaryNode::create(c6, c3, BinaryOp::Div);
   const auto custom = CustomNode::create(
-      "identity", {div}, [](const std::vector<const Tensor*>& inputs) {
+      "identity", {div}, shape, [](const std::vector<const Tensor*>& inputs) {
       return *inputs[0];
       });
   // c6  c3

--- a/flashlight/fl/test/tensor/jit/JitTensorTest.cpp
+++ b/flashlight/fl/test/tensor/jit/JitTensorTest.cpp
@@ -39,7 +39,7 @@ void testBinaryOp(Op func, BinaryOp op) {
   // c0  c1
   //  \  /
   //  node
-  Shape shape(Shape({2, 2}));
+  Shape shape({2, 2});
   auto dtype = dtype::s32;
   const auto t0 = full(shape, 0, dtype);
   const auto t1 = full(shape, 1, dtype);
@@ -53,6 +53,7 @@ void testBinaryOp(Op func, BinaryOp op) {
   ASSERT_EQ(node->lhs(), c0);
   ASSERT_EQ(node->rhs(), c1);
   ASSERT_EQ(node->op(), op);
+  ASSERT_EQ(node->shape(), shape);
   ASSERT_EQ(c0->uses(), UseValList({{node, 0}}));
   ASSERT_EQ(c1->uses(), UseValList({{node, 1}}));
 }
@@ -69,6 +70,7 @@ TEST_F(JitTensorTest, constructor) {
   ASSERT_EQ(node->inputs(), NodeList({}));
   ASSERT_EQ(node->getRefCount(), 1);
   ASSERT_EQ(node->uses(), UseValList({}));
+  ASSERT_EQ(node->shape(), dataTensor.shape());
   ASSERT_TRUE(node->isValue());
   ASSERT_TRUE(allClose(dataTensor, node->getResult().value()));
 }


### PR DESCRIPTION
Depends on #1049 

### Summary

Populate shape information during construction of JIT graph nodes.

This avoids forcing evaluation if user calls `tensor.shape()` (maybe they don't care about the tensor result at all).

### Test Plan (required)
Unit tests are added

```
make JitNodeTest
```