### PR TITLE
Change CMake version to 0.4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(flashlight LANGUAGES CXX C VERSION 0.4)
+project(flashlight LANGUAGES CXX C VERSION 0.4.0)
 
 include(CTest)
 include(CMakeDependentOption)

--- a/flashlight/fl/examples/CMakeLists.txt
+++ b/flashlight/fl/examples/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(flashlight-examples LANGUAGES CXX C VERSION 0.4)
+project(flashlight-examples LANGUAGES CXX C VERSION 0.4.0)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 


### PR DESCRIPTION
See title. Swap 0.4 to 0.4.0 to keep consistent with always having a patch version and ensue consistency with naming artifacts (i.e. ensure `libflashlight.0.4.0` is named properly).

Test plan: CI