### PR TITLE
CMake Hygiene post-lib removal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ wheels/
 *.lo
 *.o
 *.obj
+*.dylib
 
 # Compiled Static libraries
 *.lai

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,11 +11,9 @@ if(CCACHE_PROGRAM)
   set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
 endif()
 
-set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
-option(FL_CODE_COVERAGE "Enable coverage reporting" OFF)
 
 # Default directories for installation
 set(FL_INSTALL_INC_DIR "include" CACHE PATH "Install path for headers")
@@ -47,11 +45,17 @@ include(InternalUtils)
 # ----------------------------- Configuration -----------------------------
 
 option(FL_BUILD_TESTS "Build tests" ON)
+option(FL_CODE_COVERAGE "Enable coverage reporting" OFF)
 option(FL_BUILD_EXAMPLES "Build examples" ON)
 option(FL_BUILD_EXPERIMENTAL "Build internal experimental components" OFF)
 option(FL_BUILD_SCRIPTS "Build internal scripts for wav2letter++" OFF)
 option(FL_BUILD_RECIPES "Build recipes" ON)
 option(FL_BUILD_STANDALONE "Build standalone installation" ON)
+
+if (FL_BUILD_TESTS)
+  enable_testing()
+  include(TestUtils)
+endif()
 
 # External project configuration
 option(FL_TEXT_REQUIRE_KENLM "Require KenLM in the Flashlight text build" OFF)
@@ -69,131 +73,58 @@ option(FL_USE_CPU    "Build CPU support for Flashlight backends"  OFF)
 option(FL_USE_OPENCL "Build OpenCL support for Flashlight backends" OFF)
 option(FL_USE_MKL    "Build MKL support for Flashlight backends" OFF)
 
-# -------------------- Locate Backend-specific Dependencies --------------------
-find_package(CUDA 9.2 QUIET) # CUDA 9.2 is required for >= ArrayFire 3.6.1
-if (CUDA_FOUND)
-  message(STATUS "CUDA found (library: ${CUDA_LIBRARIES} include: ${CUDA_INCLUDE_DIRS})")
-endif()
+# The CUDA standard is still C++14 to enable interopability with
+# slightly older and still well-supported versions of CUDA/nvcc
+# (e.g. CUDA < 11). This will be bumped to 17 once CUDA 11 is
+# required.
+set(CMAKE_CUDA_STANDARD 14)
+set(CMAKE_CUDA_STANDARD_REQUIRED ON)
 
-find_package(OpenCL)
-if (OpenCL_FOUND)
-  message(STATUS "OpenCL found (library: ${OpenCL_LIBRARIES} include: ${OpenCL_INCLUDE_DIRS})")
-endif()
+# --------------------------- Core ---------------------------
+add_library(flashlight)
 
-# CUDA/nvcc setup
-if (CUDA_FOUND)
+# Internal includes are implicitly defined as <flashlight...>
+target_include_directories(
+  flashlight
+  PUBLIC
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+)
+
+set(FL_CORE_DIR "${FL_ROOT_DIR}/fl")
+include(${FL_CORE_DIR}/CMakeLists.txt)
+list(APPEND INSTALLABLE_TARGETS flashlight)
+# flashlight core components keep their relative paths with respect to project
+setup_install_headers(${FL_CORE_DIR} ${FL_INSTALL_INC_DIR_HEADER_LOC})
+# FL_USE_* variables are set in flashlight/fl/tensor/CMakeLists.txt based on
+# backend registration
+target_compile_definitions(flashlight
+  PUBLIC
+  FL_BACKEND_CPU=$<BOOL:${FL_USE_CPU}>
+  FL_BACKEND_CUDA=$<BOOL:${FL_USE_CUDA}>
+  FL_BUILD_PROFILING=$<BOOL:${FL_BUILD_PROFILING}>
+  )
+
+if (FL_USE_CUDA)
   enable_language(CUDA)
-  # The CUDA standard is still C++14 to enable interopability with
-  # slightly older and still well-supported versions of CUDA/nvcc
-  # (e.g. CUDA < 11). This will be bumped to 17 once CUDA 11 is
-  # required.
-  set(CMAKE_CUDA_STANDARD 14)
-  set(CMAKE_CUDA_STANDARD_REQUIRED ON)
-  include(${CMAKE_MODULE_PATH}/CUDAUtils.cmake)
-  set_cuda_arch_nvcc_flags()
-
-  # remove me when upgrading CMake versions
-  # (i.e. add -fPIC to nvcc flags if needed)
-  if (CMAKE_POSITION_INDEPENDENT_CODE)
-    cuda_enable_position_independent_code()
-  endif ()
+  # TODO: switch to CMAKE_CUDA_RUNTIME_LIBRARY when requiring CMake >= 3.17
+  find_library(CUDART_LIBRARY cudart ${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES})
+  target_include_directories(
+    flashlight
+    PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}>
+    )
+  target_link_libraries(flashlight PUBLIC ${CUDART_LIBRARY})
 endif()
 
-# ------------------------ Tests ------------------------
+if (FL_CODE_COVERAGE)
+  add_coverage_to_target(TARGET flashlight)
+endif()
 
-if (FL_BUILD_TESTS)
-  enable_testing()
-  include(TestUtils)
-endif ()
-
-# --------------------------- Core Options  ---------------------------
-
-option(FL_BUILD_CORE "Build flashlight core" ON)
-
-fl_dependent_option(
-  FL_BUILD_CONTRIB
-  "Build and link additional flashlight contrib assets."
-  ON "FL_BUILD_CORE" OFF)
-
-# --------------------------- flashlight ---------------------------
-if (FL_BUILD_CORE)
-  message(STATUS "Will build flashlight core and extensions.")
-
-  # Primary lib target. All non-library code is linked here, including app
-  add_library(flashlight "")
-
-  set_target_properties(
-    flashlight
-    PROPERTIES
-    LINKER_LANGUAGE CXX
-    )
-
-  if (FL_CODE_COVERAGE)
-    add_coverage_to_target(TARGET flashlight)
-  endif()
-
-  # ------------------------ Global External Dependencies ------------------------
-  # If cereal is found in a user-defined location, use it rather than
-  # downloading from source
-  find_package(cereal)
-  if (NOT TARGET cereal AND NOT cereal_FOUND AND FL_BUILD_STANDALONE)
-    message(STATUS "cereal NOT found. Will download from source")
-    set(CEREAL_INSTALL_PATH ${FL_INSTALL_INC_DIR}/cereal)
-    include(${CMAKE_MODULE_PATH}/BuildCereal.cmake)
-    add_dependencies(flashlight cereal)
-    # Move cereal headers at install time
-    install(DIRECTORY ${CEREAL_SOURCE_DIR}/include/cereal/
-      DESTINATION ${CEREAL_INSTALL_PATH}
-      COMPONENT cereal
-      FILES_MATCHING
-      PATTERN "*.hpp"
-      PATTERN "*.h"
-      PATTERN ".git" EXCLUDE
-      )
-    install(FILES ${CEREAL_SOURCE_DIR}/LICENSE ${CEREAL_SOURCE_DIR}/README.md
-      DESTINATION ${CEREAL_INSTALL_PATH}
-      )
-    target_include_directories(flashlight PUBLIC ${cereal_INCLUDE_DIRS})
-  else()
-    message(STATUS "Found cereal")
-    target_link_libraries(flashlight PRIVATE cereal)
-  endif()
-  setup_install_find_module(${CMAKE_MODULE_PATH}/Findcereal.cmake)
-
-  # ------------------------ flashlight Core ------------------------
-  set(FL_CORE_DIR "${FL_ROOT_DIR}/fl")
-  include(${FL_CORE_DIR}/CMakeLists.txt)
-  list(APPEND INSTALLABLE_TARGETS flashlight)
-  # flashlight core components keep their relative paths with respect to project
-  setup_install_headers(${FL_CORE_DIR} ${FL_INSTALL_INC_DIR_HEADER_LOC})
-  # FL_USE_* variables are set in flashlight/fl/tensor/CMakeLists.txt based on
-  # backend registration
-  target_compile_definitions(flashlight
-    PUBLIC
-    FL_BACKEND_CPU=$<BOOL:${FL_USE_CPU}>
-    FL_BACKEND_CUDA=$<BOOL:${FL_USE_CUDA}>
-    FL_BACKEND_OPENCL=$<BOOL:${FL_USE_OPENCL}>
-    FL_BUILD_PROFILING=$<BOOL:${FL_BUILD_PROFILING}>
-    )
-
-  # Check external dependencies match used backend state. If we're required
-  # to link to a backend and it wasn't found, fatal.
-  if (FL_USE_CUDA AND NOT CUDA_FOUND)
-    message(FATAL_ERROR
-      "One or more tensor backends require CUDA to build. CUDA was not found.")
-  endif()
-  if (FL_USE_OPENCL AND NOT OpenCL_FOUND)
-    message(FATAL_ERROR
-      "One or more tensor backends require OpenCL to build. OpenCL was not found.")
-  endif()
-
-endif() # if FL_BUILD_CORE
-
-# --------------------------- Pkgs  ---------------------------
+# --------------------------- Pkgs ---------------------------
 set(FL_PKG_DIR "${FL_ROOT_DIR}/pkg")
 include(${FL_PKG_DIR}/CMakeLists.txt)
 
-# --------------------------- Apps Options  ---------------------------
+# --------------------------- Apps ---------------------------
 set(FL_APPS_DIR "${FL_ROOT_DIR}/app")
 include(${FL_APPS_DIR}/CMakeLists.txt)
 

--- a/cmake/FindCUDNN.cmake
+++ b/cmake/FindCUDNN.cmake
@@ -73,7 +73,6 @@ else()
   # shared lib:
   SET(CUDNN_LIBNAME libcudnn.so${__cudnn_ver_suffix} libcudnn${__cudnn_ver_suffix}.dylib ${__cudnn_lib_win_name})
 endif()
-MESSAGE(STATUS "CUDNN libname: ${CUDNN_LIBNAME}")
 
 find_library(CUDNN_LIBRARY
   NAMES ${CUDNN_LIBNAME}

--- a/cmake/Findcereal.cmake
+++ b/cmake/Findcereal.cmake
@@ -33,7 +33,9 @@ if (NOT TARGET cereal)
     REQUIRED_VARS cereal_INCLUDE_DIRS
     )
 
-  message(STATUS "Found cereal (include: ${cereal_INCLUDE_DIRS})")
+  if (cereal_INCLUDE_DIRS)
+    message(STATUS "Found cereal (include: ${cereal_INCLUDE_DIRS})")
+  endif()
   mark_as_advanced(cereal_FOUND)
   if (cereal_FOUND)
     add_library(cereal INTERFACE IMPORTED)

--- a/cmake/flashlightConfig.cmake.in
+++ b/cmake/flashlightConfig.cmake.in
@@ -19,9 +19,14 @@
 # ``target_include_directories`` is required.
 #
 
+# Configuration variables
+# These variables are visible to downstream projects to express
+# information about the configuration with which Flashlight was built
+set(FL_BUILD_DISTRIBUTED "@FL_BUILD_DISTRIBUTED@")
+
 # Dependencies
-# If not building standalone, don't try to find upstream deps,
-# as many of these find modules won't exist
+# If not building standalone, don't try to find upstream deps;
+# many of these CMake modules aren't standard
 if (@FL_BUILD_STANDALONE@)
   list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
   include(CMakeFindDependencyMacro)
@@ -93,7 +98,6 @@ endif()
 # Flashlight backend variables for downstream config use
 set(FL_USE_CPU @FL_USE_CPU@)
 set(FL_USE_CUDA @FL_USE_CUDA@)
-set(FL_USE_OPENCL @FL_USE_OPENCL@)
 
 if (@FL_USE_CUDA@)
   enable_language(CUDA)
@@ -104,9 +108,7 @@ endif()
 set(flashlight_LIBRARIES "")
 
 # core
-if (@FL_BUILD_CORE@)
-  set(flashlight_LIBRARIES ${flashlight_LIBRARIES} flashlight::flashlight)
-endif()
+set(flashlight_LIBRARIES ${flashlight_LIBRARIES} flashlight::flashlight)
 
 # pkgs
 if (@FL_BUILD_PKG_RUNTIME@)

--- a/flashlight/app/CMakeLists.txt
+++ b/flashlight/app/CMakeLists.txt
@@ -4,7 +4,7 @@ fl_dependent_option(
   FL_BUILD_ALL_APPS
   "Set all Flashlight apps ON by default"
   OFF
-  "FL_BUILD_CORE;FL_BUILD_CONTRIB;"
+  "FL_BUILD_CONTRIB;"
   OFF)
 
 # --------------------------- ASR  ---------------------------
@@ -12,7 +12,7 @@ fl_dependent_option(
   FL_BUILD_APP_ASR
   "Build asr task for Flashlight"
   ${FL_BUILD_ALL_APPS}
-  "FL_BUILD_CORE;FL_BUILD_CONTRIB;FL_BUILD_PKG_SPEECH;FL_BUILD_PKG_RUNTIME"
+  "FL_BUILD_CONTRIB;FL_BUILD_PKG_SPEECH;FL_BUILD_PKG_RUNTIME"
   OFF)
 if (FL_BUILD_APP_ASR)
   message(STATUS "Building flashlight ASR app")
@@ -28,7 +28,7 @@ fl_dependent_option(
   FL_BUILD_APP_IMGCLASS
   "Build image classification app"
   "${FL_BUILD_ALL_APPS}"
-  "FL_BUILD_CORE;FL_BUILD_CONTRIB;FL_BUILD_PKG_VISION;FL_BUILD_PKG_RUNTIME"
+  "FL_BUILD_CONTRIB;FL_BUILD_PKG_VISION;FL_BUILD_PKG_RUNTIME"
   OFF)
 if (FL_BUILD_APP_IMGCLASS) # imgclass is required to build objdet
   message(STATUS "Building flashlight Image Classification app")
@@ -44,7 +44,7 @@ fl_dependent_option(
   FL_BUILD_APP_LM
   "Build image classification app"
   "${FL_BUILD_ALL_APPS}"
-  "FL_BUILD_CORE;FL_BUILD_CONTRIB;FL_BUILD_PKG_TEXT;FL_BUILD_PKG_RUNTIME"
+  "FL_BUILD_CONTRIB;FL_BUILD_PKG_TEXT;FL_BUILD_PKG_RUNTIME"
   OFF)
 if (FL_BUILD_APP_LM)
   message(STATUS "Building flashlight LM app")
@@ -60,7 +60,7 @@ fl_dependent_option(
   FL_BUILD_APP_OBJDET
   "Build image classification app"
   "${FL_BUILD_ALL_APPS}"
-  "FL_BUILD_CORE;FL_BUILD_CONTRIB;FL_BUILD_PKG_VISION;FL_BUILD_PKG_RUNTIME"
+  "FL_BUILD_CONTRIB;FL_BUILD_PKG_VISION;FL_BUILD_PKG_RUNTIME"
   OFF)
 if (FL_BUILD_APP_OBJDET)
   message(STATUS "Building flashlight Object Detection app")

--- a/flashlight/fl/CMakeLists.txt
+++ b/flashlight/fl/CMakeLists.txt
@@ -1,75 +1,81 @@
 cmake_minimum_required(VERSION 3.16)
 
-# ----------------------------- Setup -----------------------------
-set(FL_CORE_COMPONENT_SRC_DIR "${CMAKE_CURRENT_LIST_DIR}") # module root
+option(FL_BUILD_CONTRIB "Build and link additional non-stabl contrib components" ON)
 
-# -------------------------------- Components --------------------------------
+# Builds optional non-stable components of the FL API
 if (FL_BUILD_CONTRIB)
-  message(STATUS "Will build flashlight contrib assets.")
-  include(${FL_CORE_COMPONENT_SRC_DIR}/contrib/CMakeLists.txt)
+  message(STATUS "Building Flashlight with contrib components.")
+  include(${CMAKE_CURRENT_LIST_DIR}/contrib/CMakeLists.txt)
 endif()
 
-# Build and link resources from `flashlight/experimental`.
-cmake_dependent_option(FL_BUILD_EXPERIMENTAL
-  "Build and link additional internal flashlight experimental resources." ON
-  "FL_BUILD_CORE" OFF)
-if (FL_BUILD_EXPERIMENTAL)
-  message(STATUS "Will build flashlight experimental assets.")
-  set(FL_EXPERIMENTAL_ROOT_PATH
-    ${FL_CORE_COMPONENT_SRC_DIR}/experimental)
-  include(${FL_EXPERIMENTAL_ROOT_PATH}/CMakeLists.txt)
+# ------------------------ Global External Dependencies ------------------------
+# If cereal is found in a user-defined location, use it rather than
+# downloading from source
+find_package(cereal)
+if (NOT TARGET cereal AND NOT cereal_FOUND AND FL_BUILD_STANDALONE)
+  message(STATUS "cereal NOT found. Will download from source")
+  set(CEREAL_INSTALL_PATH ${FL_INSTALL_INC_DIR}/cereal)
+  include(${CMAKE_MODULE_PATH}/BuildCereal.cmake)
+  add_dependencies(flashlight cereal)
+  # Move cereal headers at install time
+  install(DIRECTORY ${CEREAL_SOURCE_DIR}/include/cereal/
+    DESTINATION ${CEREAL_INSTALL_PATH}
+    COMPONENT cereal
+    FILES_MATCHING
+    PATTERN "*.hpp"
+    PATTERN "*.h"
+    PATTERN ".git" EXCLUDE
+    )
+  install(FILES ${CEREAL_SOURCE_DIR}/LICENSE ${CEREAL_SOURCE_DIR}/README.md
+    DESTINATION ${CEREAL_INSTALL_PATH}
+    )
+  target_include_directories(flashlight PUBLIC ${cereal_INCLUDE_DIRS})
+else()
+  message(STATUS "Found cereal")
+  target_link_libraries(flashlight PRIVATE cereal)
 endif()
-
-# Internal includes are implicitly defined as <flashlight...>
-target_include_directories(
-  flashlight
-  PUBLIC
-  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-)
+setup_install_find_module(${CMAKE_MODULE_PATH}/Findcereal.cmake)
 
 # -------------------------------- Components --------------------------------
 # Tensor -- resolve backends and compute runtimes first
-include(${FL_CORE_COMPONENT_SRC_DIR}/tensor/CMakeLists.txt)
+include(${CMAKE_CURRENT_LIST_DIR}/tensor/CMakeLists.txt)
 
 # Common
-include(${FL_CORE_COMPONENT_SRC_DIR}/common/CMakeLists.txt)
+include(${CMAKE_CURRENT_LIST_DIR}/common/CMakeLists.txt)
 
 # Autograd
-include(${FL_CORE_COMPONENT_SRC_DIR}/autograd/CMakeLists.txt)
+include(${CMAKE_CURRENT_LIST_DIR}/autograd/CMakeLists.txt)
 
 # Dataset
-include(${FL_CORE_COMPONENT_SRC_DIR}/dataset/CMakeLists.txt)
+include(${CMAKE_CURRENT_LIST_DIR}/dataset/CMakeLists.txt)
 
 # Distributed
-include(${FL_CORE_COMPONENT_SRC_DIR}/distributed/CMakeLists.txt)
+include(${CMAKE_CURRENT_LIST_DIR}/distributed/CMakeLists.txt)
 
 # Meter
-include(${FL_CORE_COMPONENT_SRC_DIR}/meter/CMakeLists.txt)
+include(${CMAKE_CURRENT_LIST_DIR}/meter/CMakeLists.txt)
 
 # NN
-include(${FL_CORE_COMPONENT_SRC_DIR}/nn/CMakeLists.txt)
+include(${CMAKE_CURRENT_LIST_DIR}/nn/CMakeLists.txt)
 
 # Optim
-include(${FL_CORE_COMPONENT_SRC_DIR}/optim/CMakeLists.txt)
+include(${CMAKE_CURRENT_LIST_DIR}/optim/CMakeLists.txt)
 
 # Runtime
-include(${FL_CORE_COMPONENT_SRC_DIR}/runtime/CMakeLists.txt)
+include(${CMAKE_CURRENT_LIST_DIR}/runtime/CMakeLists.txt)
 
-# --------------------------- Configure Examples/Tests ---------------------------
+# ----------------------- Examples and Tests ------------------------
 
-# Build tests
 if (FL_BUILD_TESTS)
-  add_subdirectory(${FL_CORE_COMPONENT_SRC_DIR}/test)
+  add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/test)
 endif ()
 
-# Build examples
 if (FL_BUILD_EXAMPLES)
-  set(FL_EXAMPLES_DIR ${FL_CORE_COMPONENT_SRC_DIR}/examples)
+  set(FL_EXAMPLES_DIR ${CMAKE_CURRENT_LIST_DIR}/examples)
   add_subdirectory(${FL_EXAMPLES_DIR})
-  # Installation properties
   install(
     DIRECTORY ${FL_EXAMPLES_DIR}
     DESTINATION ${FL_INSTALL_EXAMPLES_DIR}
     COMPONENT examples
-    )
-endif ()
+  )
+endif()

--- a/flashlight/fl/autograd/CMakeLists.txt
+++ b/flashlight/fl/autograd/CMakeLists.txt
@@ -1,17 +1,11 @@
 cmake_minimum_required(VERSION 3.16)
 
-# ----------------------------- Autograd -----------------------------
-set(
-  AUTOGRAD_SOURCES
-  ${CMAKE_CURRENT_LIST_DIR}/Variable.cpp
-  ${CMAKE_CURRENT_LIST_DIR}/Functions.cpp
-  ${CMAKE_CURRENT_LIST_DIR}/Utils.cpp
-  )
-
 target_sources(
   flashlight
   PRIVATE
-  ${AUTOGRAD_SOURCES}
+  ${CMAKE_CURRENT_LIST_DIR}/Variable.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/Functions.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/Utils.cpp
   )
 
 include(${CMAKE_CURRENT_LIST_DIR}/tensor/CMakeLists.txt)

--- a/flashlight/fl/autograd/tensor/CMakeLists.txt
+++ b/flashlight/fl/autograd/tensor/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-option(FL_USE_CUDNN "Build ArrayFire tensor backend" OFF)
+option(FL_USE_CUDNN "Build with cuDNN support" OFF)
 
 # Try to find cuDNN
 find_package(CUDNN 7.1) # CUDNN 7.1 works with CUDA 9.2

--- a/flashlight/fl/common/CMakeLists.txt
+++ b/flashlight/fl/common/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.16)
 
-# ----------------------------- Common -----------------------------
-set(
-  COMMON_SRCS
+target_sources(
+  flashlight
+  PRIVATE
   ${CMAKE_CURRENT_LIST_DIR}/Utils.cpp
   ${CMAKE_CURRENT_LIST_DIR}/DevicePtr.cpp
   ${CMAKE_CURRENT_LIST_DIR}/Defines.cpp
@@ -13,24 +13,14 @@ set(
   ${CMAKE_CURRENT_LIST_DIR}/Timer.cpp
 )
 
-target_sources(
-  flashlight
-  PRIVATE
-  ${COMMON_SRCS}
-)
-
-# A native threading library is needed for ThreadPool
-# (see flashlight/common/threadpool/ThreadPool.h)
+# A native threading library
 find_package(Threads REQUIRED)
+target_link_libraries(flashlight PUBLIC Threads::Threads)
 
-target_link_libraries(
-  flashlight
-  PUBLIC
-  ${CMAKE_THREAD_LIBS_INIT} # threading library
-  ${CMAKE_DL_LIBS} # for plugin
-)
+# Dynamic lib loading needed for Plugins
+target_link_libraries(flashlight PUBLIC ${CMAKE_DL_LIBS})
 
-# Remove this when requiring gcc >= 9
+# std::filesystem -- remove this when requiring gcc >= 9
 find_package(Filesystem REQUIRED COMPONENTS Final Experimental)
 setup_install_find_module(${CMAKE_MODULE_PATH}/FindFilesystem.cmake)
 target_link_libraries(flashlight PUBLIC std::filesystem)

--- a/flashlight/fl/contrib/CMakeLists.txt
+++ b/flashlight/fl/contrib/CMakeLists.txt
@@ -1,18 +1,3 @@
 cmake_minimum_required(VERSION 3.16)
 
-# Root dir is `flashlight/contrib`
-set(FL_CONTRIB_ROOT_PATH ${CMAKE_CURRENT_LIST_DIR})
-
-# Include each submodule
-include(${FL_CONTRIB_ROOT_PATH}/modules/CMakeLists.txt)
-
-set(
-  FL_CONTRIB_SOURCES
-  ${FL_CONTRIB_MODULE_SOURCES}
-  )
-
-target_sources(
-  flashlight
-  PRIVATE
-  ${FL_CONTRIB_SOURCES}
-  )
+include(${CMAKE_CURRENT_LIST_DIR}/modules/CMakeLists.txt)

--- a/flashlight/fl/contrib/modules/CMakeLists.txt
+++ b/flashlight/fl/contrib/modules/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 3.16)
 
-set(
-  FL_CONTRIB_MODULE_SOURCES
+target_sources(
+  flashlight
+  PRIVATE
   ${CMAKE_CURRENT_LIST_DIR}/AdaptiveEmbedding.cpp
   ${CMAKE_CURRENT_LIST_DIR}/AsymmetricConv1D.cpp
   ${CMAKE_CURRENT_LIST_DIR}/Conformer.cpp

--- a/flashlight/fl/dataset/CMakeLists.txt
+++ b/flashlight/fl/dataset/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 3.16)
 
-set(
-  DATASET_SOURCES
+target_sources(
+  flashlight
+  PRIVATE
   ${CMAKE_CURRENT_LIST_DIR}/BatchDataset.cpp
   ${CMAKE_CURRENT_LIST_DIR}/BlobDataset.cpp
   ${CMAKE_CURRENT_LIST_DIR}/ConcatDataset.cpp
@@ -15,10 +16,4 @@ set(
   ${CMAKE_CURRENT_LIST_DIR}/ShuffleDataset.cpp
   ${CMAKE_CURRENT_LIST_DIR}/TensorDataset.cpp
   ${CMAKE_CURRENT_LIST_DIR}/TransformDataset.cpp
-  )
-
-target_sources(
-  flashlight
-  PRIVATE
-  ${DATASET_SOURCES}
   )

--- a/flashlight/fl/distributed/CMakeLists.txt
+++ b/flashlight/fl/distributed/CMakeLists.txt
@@ -1,43 +1,30 @@
 cmake_minimum_required(VERSION 3.16)
 
 # Distributed Training Backend
-cmake_dependent_option(FL_BUILD_DISTRIBUTED
-  "Build and link a distributed backend with flashlight" ON
-  "FL_BUILD_CORE" OFF)
-# If building with CUDA, use NCCL to on; if using CPU or OpenCL, use GLOO
-set(USE_NCCL FALSE)
-set(USE_GLOO FALSE)
-if (FL_BUILD_DISTRIBUTED AND NOT FL_DISTRIBUTED_STUB)
+option(FL_BUILD_DISTRIBUTED
+  "Build distributed computation capabilities with Flashlight" ON)
+
+option(FL_USE_NCCL "Build with NCCL for distributed computation" OFF)
+option(FL_USE_GLOO "Build with Gloo for distributed computation" OFF)
+
+# TODO: relax this
+if (FL_USE_NCCL AND FL_USE_GLOO)
+  message(STATUS "Cannot build multiple distributed backends simultaneously")
+endif()
+
+if (FL_BUILD_DISTRIBUTED)
+  # If using CUDA, enable NCCL, else build with Gloo
   if (FL_USE_CUDA)
-    set(USE_NCCL ON)
-  elseif (FL_USE_CPU OR FL_USE_OPENCL)
-    set(USE_GLOO ON)
+    set(FL_USE_NCCL ON)
+  elseif (FL_USE_CPU)
+    set(FL_USE_GLOO ON)
   else()
+    # A stub impl that throws/executes noops for most distributed ops
     set(FL_DISTRIBUTED_STUB ON)
   endif()
 endif ()
 
-set(
-  DISTRIBUTED_SOURCES
-  ${CMAKE_CURRENT_LIST_DIR}/DistributedApi.cpp
-  ${CMAKE_CURRENT_LIST_DIR}/FileStore.cpp
-  ${CMAKE_CURRENT_LIST_DIR}/reducers/InlineReducer.cpp
-  ${CMAKE_CURRENT_LIST_DIR}/reducers/CoalescingReducer.cpp
-  )
-
-# Build sources only in distributed mode. Distributed headers will be included regardless,
-# but usage of the apis will fail to link if not enabled.
-if (FL_BUILD_DISTRIBUTED)
-  target_sources(
-    flashlight
-    PRIVATE
-    ${DISTRIBUTED_SOURCES}
-    )
-endif()
-
-# ----------------------------- Dependencies -----------------------------
-# Gloo
-if (USE_GLOO)
+if (FL_USE_GLOO)
   find_package(Gloo CONFIG)
   if (NOT Gloo_FOUND AND FL_BUILD_STANDALONE)
     message(STATUS "Gloo not found - downloading and building from source")
@@ -46,8 +33,7 @@ if (USE_GLOO)
   endif()
 endif()
 
-# NCCL
-if (USE_NCCL)
+if (FL_USE_NCCL)
   find_package(NCCL REQUIRED)
   if (NCCL_FOUND)
     message(STATUS "NCCL found: (include: ${NCCL_INCLUDE_DIRS} lib: ${NCCL_LIBRARIES}")
@@ -55,70 +41,23 @@ if (USE_NCCL)
   endif()
 endif()
 
-# MPI
-find_package(MPI)
-if (MPI_C_FOUND AND MPI_CXX_FOUND)
-  message(STATUS "MPI_VERSION found: ${MPI_VERSION} ${MPI_C_VERSION_MAJOR}.${MPI_C_VERSION_MINOR}")
-  message(STATUS "MPI_CXX found")
-  message(STATUS "MPI_CXX compile flags: " ${MPI_CXX_COMPILE_FLAGS})
-  message(STATUS "MPI_CXX include path: " ${MPI_CXX_INCLUDE_PATH})
-  message(STATUS "MPI_CXX LINK flags path: " ${MPI_CXX_LINK_FLAGS})
-  message(STATUS "MPI_CXX libraries: " ${MPI_CXX_LIBRARIES})
-
-  message(STATUS "MPI_C found")
-  message(STATUS "MPI_C compile flags: " ${MPI_C_COMPILE_FLAGS})
-  message(STATUS "MPI_C include path: " ${MPI_C_INCLUDE_PATH})
-  message(STATUS "MPI_C LINK flags path: " ${MPI_C_LINK_FLAGS})
-  message(STATUS "MPI_C libraries: " ${MPI_C_LIBRARIES})
-
-  set(MPI_INCLUDE_DIRS ${MPI_CXX_INCLUDE_PATH} ${MPI_INCLUDE_PATH})
-else()
-  message(STATUS "MPI not found")
-  if (FL_BUILD_DISTRIBUTED)
-    message(FATAL_ERROR "MPI_C and MPI_CXX not found; required to build flashlight distributed")
-  endif()
-endif()
-
-# ----------------------------- Backend libs -----------------------------
+# ----------------------------- Dependencies -----------------------------
+# MPI is required for any distributed support
+# TODO: make this and the rendezvous impl configurable
 if (FL_BUILD_DISTRIBUTED)
-  target_link_libraries(
-    flashlight
-    PUBLIC
-    ${MPI_LIBRARIES}
-    )
-
-  target_include_directories(
-    flashlight
-    PUBLIC
-    ${MPI_INCLUDE_DIRS}
-    )
+  find_package(MPI REQUIRED)
+  target_link_libraries(flashlight PUBLIC MPI::MPI_CXX)
 endif ()
 
-# Distributed
-if (USE_NCCL)
-  set(
-    DISTRIBUTED_NCCL_SOURCES
-    ${CMAKE_CURRENT_LIST_DIR}/backend/cuda/DistributedBackend.cpp
-    )
-
+if (FL_USE_NCCL)
   target_sources(
     flashlight
     PRIVATE
-    ${DISTRIBUTED_NCCL_SOURCES}
+    ${CMAKE_CURRENT_LIST_DIR}/backend/cuda/DistributedBackend.cpp
     )
 
-  target_link_libraries(
-    flashlight
-    PRIVATE
-    ${CUDA_LIBRARIES}
-    ${NCCL_LIBRARIES}
-    )
-
-  target_include_directories(
-    flashlight
-    PRIVATE
-    ${NCCL_INCLUDE_DIRS}
-    )
+  target_link_libraries(flashlight PRIVATE ${NCCL_LIBRARIES})
+  target_include_directories(flashlight PRIVATE ${NCCL_INCLUDE_DIRS})
 
   target_compile_definitions(
     flashlight
@@ -127,32 +66,35 @@ if (USE_NCCL)
     )
 endif ()
 
-# Distributed
-if (USE_GLOO)
-  set(
-    DISTRIBUTED_GLOO_SOURCES
-    ${CMAKE_CURRENT_LIST_DIR}/backend/cpu/DistributedBackend.cpp
-    )
-
+if (FL_USE_GLOO)
   target_sources(
     flashlight
     PRIVATE
-    ${DISTRIBUTED_GLOO_SOURCES}
+    ${CMAKE_CURRENT_LIST_DIR}/backend/cpu/DistributedBackend.cpp
     )
 
-  target_link_libraries(
-    flashlight
-    PRIVATE
-    gloo
-    )
+  target_link_libraries(flashlight PRIVATE gloo)
 endif ()
 
-# Distributed
+
+# Build sources only in distributed mode. Distributed headers will be included regardless,
+# but usage of the APIs will fail to link if not enabled.
+# TODO: conditionally install headers?
+if (FL_BUILD_DISTRIBUTED)
+  target_sources(
+    flashlight
+    PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/DistributedApi.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/FileStore.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/reducers/InlineReducer.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/reducers/CoalescingReducer.cpp
+    )
+endif()
+
 if (FL_DISTRIBUTED_STUB)
   target_sources(
     flashlight
     PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/backend/stub/DistributedBackend.cpp
     )
-  message(STATUS "using distributed stub")
 endif ()

--- a/flashlight/fl/examples/CMakeLists.txt
+++ b/flashlight/fl/examples/CMakeLists.txt
@@ -3,9 +3,9 @@ project(flashlight-examples LANGUAGES CXX C VERSION 0.4.0)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# If building in source, we already have these targets.
+# If building in source, we already have the flashlight target
 if (NOT TARGET flashlight)
-  find_package(flashlight)
+  find_package(flashlight CONFIG REQUIRED)
 endif ()
 
 function(build_example SRCFILE)
@@ -29,6 +29,6 @@ build_example(Classification.cpp)
 build_example(Xor.cpp)
 build_example(AdaptiveClassification.cpp)
 
-if (FL_BUILD_DISTRIBUTED OR TARGET flashlight::Distributed)
+if (FL_BUILD_DISTRIBUTED)
   build_example(DistributedTraining.cpp)
 endif ()

--- a/flashlight/fl/meter/CMakeLists.txt
+++ b/flashlight/fl/meter/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 3.16)
 
-set(
-  METER_SOURCES
+target_sources(
+  flashlight
+  PRIVATE
   ${CMAKE_CURRENT_LIST_DIR}/AverageValueMeter.cpp
   ${CMAKE_CURRENT_LIST_DIR}/CountMeter.cpp
   ${CMAKE_CURRENT_LIST_DIR}/EditDistanceMeter.cpp
@@ -9,10 +10,4 @@ set(
   ${CMAKE_CURRENT_LIST_DIR}/MSEMeter.cpp
   ${CMAKE_CURRENT_LIST_DIR}/TimeMeter.cpp
   ${CMAKE_CURRENT_LIST_DIR}/TopKMeter.cpp
-  )
-
-target_sources(
-  flashlight
-  PRIVATE
-  ${METER_SOURCES}
   )

--- a/flashlight/fl/nn/CMakeLists.txt
+++ b/flashlight/fl/nn/CMakeLists.txt
@@ -1,11 +1,10 @@
 cmake_minimum_required(VERSION 3.16)
 
-# ----------------------------- NN Modules -----------------------------
-
-set(
-  NN_SOURCES
+target_sources(
+  flashlight
+  PRIVATE
   ${CMAKE_CURRENT_LIST_DIR}/Init.cpp
-  ${CMAKE_CURRENT_LIST_DIR}/Utils.cpp # utils
+  ${CMAKE_CURRENT_LIST_DIR}/Utils.cpp
   ${CMAKE_CURRENT_LIST_DIR}/modules/Activations.cpp
   ${CMAKE_CURRENT_LIST_DIR}/modules/AdaptiveSoftMax.cpp
   ${CMAKE_CURRENT_LIST_DIR}/modules/BatchNorm.cpp
@@ -30,15 +29,9 @@ set(
   )
 
 if (FL_BUILD_DISTRIBUTED)
-  set(
-    NN_SOURCES
+  target_sources(
+    flashlight
+    PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/DistributedUtils.cpp
-    ${NN_SOURCES}
-  )
-endif ()
-
-target_sources(
-  flashlight
-  PRIVATE
-  ${NN_SOURCES}
-  )
+    )
+endif()

--- a/flashlight/fl/optim/CMakeLists.txt
+++ b/flashlight/fl/optim/CMakeLists.txt
@@ -1,9 +1,8 @@
 cmake_minimum_required(VERSION 3.16)
 
-# ----------------------------- Optim -----------------------------
-
-set(
-  OPTIM_SOURCES
+target_sources(
+  flashlight
+  PRIVATE
   ${CMAKE_CURRENT_LIST_DIR}/Optimizers.cpp
   ${CMAKE_CURRENT_LIST_DIR}/Utils.cpp
   ${CMAKE_CURRENT_LIST_DIR}/AdamOptimizer.cpp
@@ -14,10 +13,4 @@ set(
   ${CMAKE_CURRENT_LIST_DIR}/NovogradOptimizer.cpp
   ${CMAKE_CURRENT_LIST_DIR}/RMSPropOptimizer.cpp
   ${CMAKE_CURRENT_LIST_DIR}/SGDOptimizer.cpp
-  )
-
-target_sources(
-  flashlight
-  PRIVATE
-  ${OPTIM_SOURCES}
   )

--- a/flashlight/fl/test/CMakeLists.txt
+++ b/flashlight/fl/test/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 
 set(DIR ${FL_CORE_DIR}/test)
 set(LIBS flashlight ${CMAKE_DL_LIBS})
+
 build_test(SRC ${DIR}/autograd/AutogradTest.cpp LIBS ${LIBS})
 build_test(SRC ${DIR}/autograd/AutogradReductionTest.cpp LIBS ${LIBS})
 build_test(SRC ${DIR}/autograd/AutogradBinaryOpsTest.cpp LIBS ${LIBS})

--- a/flashlight/pkg/CMakeLists.txt
+++ b/flashlight/pkg/CMakeLists.txt
@@ -4,7 +4,7 @@ fl_dependent_option(
   FL_BUILD_ALL_PKGS
   "Build all flashlight packages"
   OFF
-  "FL_BUILD_CORE;FL_BUILD_CONTRIB"
+  "FL_BUILD_CONTRIB"
   OFF
 )
 
@@ -13,7 +13,7 @@ fl_dependent_option(
   FL_BUILD_PKG_RUNTIME
   "Build runtime package for Flashlight"
   "${FL_BUILD_ALL_PKGS}"
-  "FL_BUILD_CORE;FL_BUILD_CONTRIB"
+  "FL_BUILD_CONTRIB"
   OFF)
 if(FL_BUILD_PKG_RUNTIME)
   set(FL_PKG_RUNTIME_DIR ${FL_PKG_DIR}/runtime)
@@ -29,7 +29,7 @@ fl_dependent_option(
   FL_BUILD_PKG_VISION
   "Build vision package for Flashlight"
   "${FL_BUILD_ALL_PKGS}"
-  "FL_BUILD_CORE;FL_BUILD_CONTRIB"
+  "FL_BUILD_CONTRIB"
   OFF)
 if(FL_BUILD_PKG_VISION)
   set(FL_PKG_VISION_DIR ${FL_PKG_DIR}/vision)
@@ -45,7 +45,7 @@ fl_dependent_option(
   FL_BUILD_PKG_TEXT
   "Build text package for Flashlight"
   "${FL_BUILD_ALL_PKGS}"
-  "FL_BUILD_CORE;FL_BUILD_CONTRIB"
+  "FL_BUILD_CONTRIB"
   OFF)
 if(FL_BUILD_PKG_TEXT)
   set(FL_PKG_TEXT_DIR ${FL_PKG_DIR}/text)
@@ -62,7 +62,7 @@ fl_dependent_option(
   FL_BUILD_PKG_SPEECH
   "Build speech package for Flashlight"
   "${FL_BUILD_ALL_PKGS}"
-  "FL_BUILD_CORE;FL_BUILD_CONTRIB;FL_BUILD_PKG_RUNTIME"
+  "FL_BUILD_CONTRIB;FL_BUILD_PKG_RUNTIME"
   OFF)
 
 if(FL_BUILD_PKG_SPEECH)
@@ -79,7 +79,7 @@ fl_dependent_option(
   FL_BUILD_PKG_HALIDE
   "Build speech package for Flashlight"
   OFF # for right now, don't build halide pkg with all pkgs to make CI easier
-  "FL_BUILD_CORE;FL_BUILD_CONTRIB"
+  "FL_BUILD_CONTRIB"
   OFF)
 if(FL_BUILD_PKG_HALIDE)
   set(FL_PKG_HALIDE_DIR ${FL_PKG_DIR}/halide)


### PR DESCRIPTION
Numerous improvements to Flashlight's CMake config including:
- append to `CMAKE_MODULE_PATH` rather than setting to avoid clobbering downstream projects' path
- use modern CUDA components from CMake > 3.15
- remove `FL_BUILD_CORE` since `flashlight/lib` is gone and the core always builds by default
- remove a bunch of useless shims on source paths
- improvements to distributed build configuration
- modern usage of CMake `FindMPI`

Test plan: CI + build with:
```
cmake .. -DFL_USE_ARRAYFIRE=ON -DFL_ARRAYFIRE_USE_CUDA=ON -DFL_USE_ONEDNN=OFF -DFL_BUILD_TESTS=ON -DFL_BUILD_EXAMPLES=OFF -DArrayFire_DIR=/checkpoint/jacobkahn/usr/share/ArrayFire/cmake -DFL_BUILD_DISTRIBUTED=
ON -DBUILD_SHARED_LIBS=ON -DFL_BUILD_PKG_SPEECH=ON -DFL_BUILD_PKG_RUNTIME=ON
```