### PR TITLE
Cover all ops in JIT frontend

### DIFF
--- a/flashlight/fl/tensor/backend/jit/CMakeLists.txt
+++ b/flashlight/fl/tensor/backend/jit/CMakeLists.txt
@@ -11,5 +11,6 @@ target_sources(
   PRIVATE
   ${CMAKE_CURRENT_LIST_DIR}/JitBackend.cpp
   ${CMAKE_CURRENT_LIST_DIR}/JitTensorBase.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/ShapeInference.cpp
   ${CMAKE_CURRENT_LIST_DIR}/Utils.cpp
 )

--- a/flashlight/fl/tensor/backend/jit/JitBackend.cpp
+++ b/flashlight/fl/tensor/backend/jit/JitBackend.cpp
@@ -8,17 +8,51 @@
 #include "flashlight/fl/tensor/backend/jit/JitBackend.h"
 
 #include <cassert>
+#include <iostream>
+#include <sstream>
 #include <stdexcept>
 
 #include "flashlight/fl/tensor/TensorBase.h"
 #include "flashlight/fl/tensor/backend/jit/JitTensorBase.h"
+#include "flashlight/fl/tensor/backend/jit/ShapeInference.h"
 #include "flashlight/fl/tensor/backend/jit/ir/ScalarNode.h"
-
-#define FL_JIT_BACKEND_UNIMPLEMENTED \
-  throw std::invalid_argument(       \
-      "JitBackend::" + std::string(__func__) + " - unimplemented.");
+#include "flashlight/fl/tensor/backend/jit/ir/ValueNode.h"
 
 namespace fl {
+
+namespace {
+
+std::vector<Node*> tensorsToNodes(const std::vector<Tensor>& tensors) {
+  std::vector<Node*> nodes;
+  // JitTensor copy is ~free, but whatever
+  for (const auto& tensor : tensors) {
+    nodes.push_back(toJitTensorBase(tensor).node());
+  }
+  return nodes;
+}
+
+template <typename... T>
+std::vector<Node*> tensorsToNodes(const T&... tensors) {
+  std::vector<Node*> nodes;
+  // JitTensor copy is ~free, but whatever
+  for (const auto& tensor : {&tensors...}) {
+    nodes.push_back(toJitTensorBase(*tensor).node());
+  }
+  return nodes;
+}
+
+template <>
+std::vector<Node*> tensorsToNodes() {
+  return {};
+}
+
+const Tensor& materialize(Tensor tensor) {
+  auto& jitTensor = toJitTensorBase(tensor);
+  jitTensor.eval();
+  return jitTensor.node()->getResult().value();
+}
+
+} // namespace
 
 JitBackend::JitBackend(
     TensorBackend& wrappedBackend,
@@ -38,55 +72,61 @@ void JitBackend::eval(const Tensor& tensor) {
   wrappedBackend_.eval(jitTensor.node()->getResult().value()); // "deep" eval
 }
 
-bool JitBackend::supportsDataType(const fl::dtype& /* dtype */) const {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+bool JitBackend::supportsDataType(const fl::dtype& dtype) const {
+  return wrappedBackend_.supportsDataType(dtype);
 }
 
 void JitBackend::getMemMgrInfo(
-    const char* /* msg */,
-    const int /* deviceId */,
-    std::ostream* /* ostream */) {
-  // Can be a noop if no memory manager is implemented.
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+    const char* msg,
+    const int deviceId,
+    std::ostream* ostream) {
+  return wrappedBackend_.getMemMgrInfo(msg, deviceId, ostream);
 }
 
-void JitBackend::setMemMgrLogStream(std::ostream* /* stream */) {
-  // Can be a noop if no memory manager is implemented.
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+void JitBackend::setMemMgrLogStream(std::ostream* stream) {
+  return wrappedBackend_.setMemMgrLogStream(stream);
 }
 
-void JitBackend::setMemMgrLoggingEnabled(const bool /* enabled */) {
-  // Can be a noop if no memory manager is implemented.
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+void JitBackend::setMemMgrLoggingEnabled(const bool enabled) {
+  return wrappedBackend_.setMemMgrLoggingEnabled(enabled);
 }
 
-void JitBackend::setMemMgrFlushInterval(const size_t /* interval */) {
-  // Can be a noop if no memory manager is implemented.
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+void JitBackend::setMemMgrFlushInterval(const size_t interval) {
+  return wrappedBackend_.setMemMgrFlushInterval(interval);
 }
 
 /* -------------------------- Rand Functions -------------------------- */
 
-void JitBackend::setSeed(const int /* seed */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+void JitBackend::setSeed(const int seed) {
+  wrappedBackend_.setSeed(seed);
 }
 
-Tensor JitBackend::randn(const Shape& /* shape */, dtype /* type */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+Tensor JitBackend::randn(const Shape& shape, dtype type) {
+  return jitTensorCreator_(CustomNode::create(
+      "randn",
+      tensorsToNodes(),
+      Shape(shape),
+      [this, shape, type](const std::vector<const Tensor*>& /* inputs */) {
+        return wrappedBackend_.randn(shape, type);
+      }));
 }
 
-Tensor JitBackend::rand(const Shape& /* shape */, dtype /* type */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+Tensor JitBackend::rand(const Shape& shape, dtype type) {
+  return jitTensorCreator_(CustomNode::create(
+      "rand",
+      tensorsToNodes(),
+      Shape(shape),
+      [this, shape, type](const std::vector<const Tensor*>& /* inputs */) {
+        return wrappedBackend_.rand(shape, type);
+      }));
 }
 
 /* --------------------------- Tensor Operators --------------------------- */
 
 /******************** Tensor Creation Functions ********************/
 #define FL_JIT_BACKEND_CREATE_FUN_LITERAL_DEF_STUB(TYPE)                      \
-  Tensor JitBackend::fromScalar(TYPE /* value */, const dtype /* type */) {   \
-    throw std::invalid_argument(                                              \
-        "JitBackend::fromScalar - not implemented for type " +                \
-        std::string(#TYPE));                                                  \
+  Tensor JitBackend::fromScalar(TYPE value, const dtype type) {               \
+    return full(Shape{}, value, type);                                        \
   }                                                                           \
   Tensor JitBackend::full(const Shape& shape, TYPE value, const dtype type) { \
     return fullWithType(shape, value, type);                                  \
@@ -110,196 +150,295 @@ Tensor JitBackend::fullWithType(const Shape& shape, T value, dtype type) {
   return jitTensorCreator_(ScalarNode::create(shape, type, value));
 }
 
-Tensor JitBackend::identity(const Dim /* dim */, const dtype /* type */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+Tensor JitBackend::identity(const Dim dim, const dtype type) {
+  return jitTensorCreator_(
+      ValueNode::create(wrappedBackend_.identity(dim, type)));
 }
 
-Tensor JitBackend::arange(
-    const Shape& /* shape */,
-    const Dim /* seqDim */,
-    const dtype /* type */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+Tensor
+JitBackend::arange(const Shape& shape, const Dim seqDim, const dtype type) {
+  return jitTensorCreator_(CustomNode::create(
+      "arange",
+      tensorsToNodes(),
+      Shape(shape),
+      [this, shape, seqDim, type](
+          const std::vector<const Tensor*>& /* inputs */) {
+        return wrappedBackend_.arange(shape, seqDim, type);
+      }));
 }
 
-Tensor JitBackend::iota(
-    const Shape& /* dims */,
-    const Shape& /* tileDims */,
-    const dtype /* type */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+Tensor
+JitBackend::iota(const Shape& dims, const Shape& tileDims, const dtype type) {
+  return jitTensorCreator_(
+      ValueNode::create(wrappedBackend_.iota(dims, tileDims, type)));
 }
 
 /************************ Shaping and Indexing *************************/
-Tensor JitBackend::reshape(
-    const Tensor& /* tensor */,
-    const Shape& /* shape */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+Tensor JitBackend::reshape(const Tensor& tensor, const Shape& shape) {
+  if (tensor.shape().elements() != shape.elements()) {
+    std::ostringstream oss;
+    oss << "[JitBackend::reshape] Cannot reshape from " << tensor.shape()
+        << " to " << shape;
+    throw std::invalid_argument(oss.str());
+  }
+  return jitTensorCreator_(CustomNode::create(
+      "reshape",
+      tensorsToNodes(tensor),
+      Shape(shape),
+      [this, shape](const std::vector<const Tensor*>& inputs) {
+        return wrappedBackend_.reshape(*inputs.at(0), shape);
+      }));
 }
 
-Tensor JitBackend::transpose(
-    const Tensor& /* tensor */,
-    const Shape& /* axes */ /* = {} */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+Tensor JitBackend::transpose(const Tensor& tensor, const Shape& axes = {}) {
+  return jitTensorCreator_(CustomNode::create(
+      "transpose",
+      tensorsToNodes(tensor),
+      inferTransposeOutputShape(tensor.shape(), axes),
+      [this, axes](const std::vector<const Tensor*>& inputs) {
+        return wrappedBackend_.transpose(*inputs.at(0), axes);
+      }));
 }
 
-Tensor JitBackend::tile(const Tensor& /* tensor */, const Shape& /* shape */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+Tensor JitBackend::tile(const Tensor& tensor, const Shape& tileDims) {
+  return jitTensorCreator_(CustomNode::create(
+      "tile",
+      tensorsToNodes(tensor),
+      inferTileOutputShape(tensor.shape(), tileDims),
+      [this, tileDims](const std::vector<const Tensor*>& inputs) {
+        return wrappedBackend_.tile(*inputs[0], tileDims);
+      }));
 }
 
 Tensor JitBackend::concatenate(
-    const std::vector<Tensor>& /* tensors */,
-    const unsigned /* axis */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+    const std::vector<Tensor>& tensors,
+    const unsigned axisToConcat) {
+  return jitTensorCreator_(CustomNode::create(
+      "concatenate",
+      tensorsToNodes(tensors),
+      inferConcatenateOutputShape(tensors, axisToConcat),
+      [this, axisToConcat](const std::vector<const Tensor*>& inputs) {
+        // TODO use shallowcopy here
+        std::vector<Tensor> inputTensors;
+        for (const auto* inputPtr : inputs) {
+          inputTensors.emplace_back(inputPtr->copy());
+        }
+        return wrappedBackend_.concatenate(inputTensors, axisToConcat);
+      }));
 }
 
-Tensor JitBackend::nonzero(const Tensor& /* tensor */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+Tensor JitBackend::nonzero(const Tensor& tensor) {
+  // NOTE must materialize since we can't infer output shape
+  const auto& tensorResult = materialize(tensor);
+  return jitTensorCreator_(
+      ValueNode::create(wrappedBackend_.nonzero(tensorResult)));
 }
 
 Tensor JitBackend::pad(
-    const Tensor& /* input */,
-    const std::vector<std::pair<int, int>>& /* padWidths */,
-    const PadType /* type */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+    const Tensor& input,
+    const std::vector<std::pair<int, int>>& padWidths,
+    const PadType type) {
+  return jitTensorCreator_(CustomNode::create(
+      "pad",
+      tensorsToNodes(input),
+      inferPadOutputShape(input.shape(), padWidths),
+      [this, padWidths, type](const std::vector<const Tensor*>& inputs) {
+        return wrappedBackend_.pad(*inputs.at(0), padWidths, type);
+      }));
 }
 
 /************************** Unary Operators ***************************/
 
-Tensor JitBackend::exp(const Tensor& /* tensor */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+#define FL_JIT_BACKEND_UNARY_FALLBACK_IMPL(OP)             \
+  {                                                        \
+    return jitTensorCreator_(CustomNode::create(           \
+        #OP,                                               \
+        tensorsToNodes(tensor),                            \
+        Shape(tensor.shape()),                             \
+        [this](const std::vector<const Tensor*>& inputs) { \
+          return wrappedBackend_.OP(*inputs.at(0));        \
+        }));                                               \
+  }
+
+Tensor JitBackend::exp(const Tensor& tensor) {
+  FL_JIT_BACKEND_UNARY_FALLBACK_IMPL(exp);
 }
 
-Tensor JitBackend::log(const Tensor& /* tensor */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+Tensor JitBackend::log(const Tensor& tensor) {
+  FL_JIT_BACKEND_UNARY_FALLBACK_IMPL(log);
 }
 
-Tensor JitBackend::negative(const Tensor& /* tensor */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+Tensor JitBackend::negative(const Tensor& tensor) {
+  FL_JIT_BACKEND_UNARY_FALLBACK_IMPL(negative);
 }
 
-Tensor JitBackend::logicalNot(const Tensor& /* tensor */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+Tensor JitBackend::logicalNot(const Tensor& tensor) {
+  FL_JIT_BACKEND_UNARY_FALLBACK_IMPL(logicalNot);
 }
 
-Tensor JitBackend::log1p(const Tensor& /* tensor */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+Tensor JitBackend::log1p(const Tensor& tensor) {
+  FL_JIT_BACKEND_UNARY_FALLBACK_IMPL(log1p);
 }
 
-Tensor JitBackend::sin(const Tensor& /* tensor */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+Tensor JitBackend::sin(const Tensor& tensor) {
+  FL_JIT_BACKEND_UNARY_FALLBACK_IMPL(sin);
 }
 
-Tensor JitBackend::cos(const Tensor& /* tensor */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+Tensor JitBackend::cos(const Tensor& tensor) {
+  FL_JIT_BACKEND_UNARY_FALLBACK_IMPL(cos);
 }
 
-Tensor JitBackend::sqrt(const Tensor& /* tensor */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+Tensor JitBackend::sqrt(const Tensor& tensor) {
+  FL_JIT_BACKEND_UNARY_FALLBACK_IMPL(sqrt);
 }
 
-Tensor JitBackend::tanh(const Tensor& /* tensor */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+Tensor JitBackend::tanh(const Tensor& tensor) {
+  FL_JIT_BACKEND_UNARY_FALLBACK_IMPL(tanh);
 }
 
-Tensor JitBackend::floor(const Tensor& /* tensor */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+Tensor JitBackend::floor(const Tensor& tensor) {
+  FL_JIT_BACKEND_UNARY_FALLBACK_IMPL(floor);
 }
 
-Tensor JitBackend::ceil(const Tensor& /* tensor */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+Tensor JitBackend::ceil(const Tensor& tensor) {
+  FL_JIT_BACKEND_UNARY_FALLBACK_IMPL(ceil);
 }
 
-Tensor JitBackend::rint(const Tensor& /* tensor */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+Tensor JitBackend::rint(const Tensor& tensor) {
+  FL_JIT_BACKEND_UNARY_FALLBACK_IMPL(rint);
 }
 
-Tensor JitBackend::absolute(const Tensor& /* tensor */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+Tensor JitBackend::absolute(const Tensor& tensor) {
+  FL_JIT_BACKEND_UNARY_FALLBACK_IMPL(absolute);
 }
 
-Tensor JitBackend::sigmoid(const Tensor& /* tensor */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+Tensor JitBackend::sigmoid(const Tensor& tensor) {
+  FL_JIT_BACKEND_UNARY_FALLBACK_IMPL(sigmoid);
 }
 
-Tensor JitBackend::erf(const Tensor& /* tensor */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+Tensor JitBackend::erf(const Tensor& tensor) {
+  FL_JIT_BACKEND_UNARY_FALLBACK_IMPL(erf);
 }
 
-Tensor JitBackend::flip(const Tensor& /* tensor */, const unsigned /* dim */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+Tensor JitBackend::flip(const Tensor& tensor, const unsigned dim) {
+  return jitTensorCreator_(CustomNode::create(
+      "flip",
+      tensorsToNodes(tensor),
+      Shape(tensor.shape()),
+      [this, dim](const std::vector<const Tensor*>& inputs) {
+        return wrappedBackend_.flip(*inputs.at(0), dim);
+      }));
 }
 
-Tensor JitBackend::clip(
-    const Tensor& /* tensor */,
-    const Tensor& /* low */,
-    const Tensor& /* high */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+Tensor
+JitBackend::clip(const Tensor& tensor, const Tensor& low, const Tensor& high) {
+  return jitTensorCreator_(CustomNode::create(
+      "clip",
+      tensorsToNodes(tensor, low, high),
+      Shape(tensor.shape()),
+      [this](const std::vector<const Tensor*>& inputs) {
+        return wrappedBackend_.clip(
+            *inputs.at(0), *inputs.at(1), *inputs.at(2));
+      }));
 }
 
-Tensor JitBackend::roll(
-    const Tensor& /* tensor */,
-    const int /* shift */,
-    const unsigned /* axis */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+Tensor
+JitBackend::roll(const Tensor& tensor, const int shift, const unsigned axis) {
+  return jitTensorCreator_(CustomNode::create(
+      "roll",
+      tensorsToNodes(tensor),
+      Shape(tensor.shape()),
+      [this, shift, axis](const std::vector<const Tensor*>& inputs) {
+        return wrappedBackend_.roll(*inputs.at(0), shift, axis);
+      }));
 }
 
-Tensor JitBackend::isnan(const Tensor& /* tensor */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+Tensor JitBackend::isnan(const Tensor& tensor) {
+  FL_JIT_BACKEND_UNARY_FALLBACK_IMPL(isnan);
 }
 
-Tensor JitBackend::isinf(const Tensor& /* tensor */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+Tensor JitBackend::isinf(const Tensor& tensor) {
+  FL_JIT_BACKEND_UNARY_FALLBACK_IMPL(isinf);
 }
 
-Tensor JitBackend::sign(const Tensor& /* tensor */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+Tensor JitBackend::sign(const Tensor& tensor) {
+  FL_JIT_BACKEND_UNARY_FALLBACK_IMPL(sign);
 }
 
-Tensor JitBackend::tril(const Tensor& /* tensor */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+Tensor JitBackend::tril(const Tensor& tensor) {
+  FL_JIT_BACKEND_UNARY_FALLBACK_IMPL(tril);
 }
 
-Tensor JitBackend::triu(const Tensor& /* tensor */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+Tensor JitBackend::triu(const Tensor& tensor) {
+  FL_JIT_BACKEND_UNARY_FALLBACK_IMPL(triu);
 }
+#undef FL_JIT_BACKEND_UNARY_FALLBACK_IMPL
 
-Tensor JitBackend::where(
-    const Tensor& /* condition */,
-    const Tensor& /* x */,
-    const Tensor& /* y */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+Tensor
+JitBackend::where(const Tensor& condition, const Tensor& x, const Tensor& y) {
+  return jitTensorCreator_(CustomNode::create(
+      "where",
+      tensorsToNodes(condition, x, y),
+      Shape(condition.shape()),
+      [this](const std::vector<const Tensor*>& inputs) {
+        return wrappedBackend_.where(
+            *inputs.at(0), *inputs.at(1), *inputs.at(2));
+      }));
 }
 
 void JitBackend::topk(
-    Tensor& /* values */,
-    Tensor& /* indices */,
-    const Tensor& /* input */,
-    const unsigned /* k */,
-    const Dim /* axis */,
-    const SortMode /* sortMode */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+    Tensor& values,
+    Tensor& indices,
+    const Tensor& input,
+    const unsigned k,
+    const Dim axis,
+    const SortMode sortMode) {
+  const auto& inputResult = materialize(input);
+  auto valuesResult = this->full({1}, 0, dtype::s32);
+  auto indicesResult = this->full({1}, 0, dtype::s32);
+  wrappedBackend_.topk(
+      valuesResult, indicesResult, inputResult, k, axis, sortMode);
+  values = jitTensorCreator_(ValueNode::create(std::move(valuesResult)));
+  indices = jitTensorCreator_(ValueNode::create(std::move(indicesResult)));
 }
 
-Tensor JitBackend::sort(
-    const Tensor& /* input */,
-    const Dim /* axis */,
-    const SortMode /* sortMode */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+Tensor
+JitBackend::sort(const Tensor& input, const Dim axis, const SortMode sortMode) {
+  return jitTensorCreator_(CustomNode::create(
+      "sort",
+      tensorsToNodes(input),
+      Shape(input.shape()),
+      [this, axis, sortMode](const std::vector<const Tensor*>& inputs) {
+        return wrappedBackend_.sort(*inputs.at(0), axis, sortMode);
+      }));
 }
 
 void JitBackend::sort(
-    Tensor& /* values */,
-    Tensor& /* indices */,
-    const Tensor& /* input */,
-    const Dim /* axis */,
-    const SortMode /* sortMode */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+    Tensor& values,
+    Tensor& indices,
+    const Tensor& input,
+    const Dim axis,
+    const SortMode sortMode) {
+  const auto& inputResult = materialize(input);
+  auto valuesResult = this->full({1}, 0, dtype::s32);
+  auto indicesResult = this->full({1}, 0, dtype::s32);
+  wrappedBackend_.sort(
+      valuesResult, indicesResult, inputResult, axis, sortMode);
+  values = jitTensorCreator_(ValueNode::create(std::move(valuesResult)));
+  indices = jitTensorCreator_(ValueNode::create(std::move(indicesResult)));
 }
 
 Tensor JitBackend::argsort(
-    const Tensor& /* input */,
-    const Dim /* axis */,
-    const SortMode /* sortMode */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+    const Tensor& input,
+    const Dim axis,
+    const SortMode sortMode) {
+  return jitTensorCreator_(CustomNode::create(
+      "argsort",
+      tensorsToNodes(input),
+      Shape(input.shape()),
+      [this, axis, sortMode](const std::vector<const Tensor*>& inputs) {
+        return wrappedBackend_.argsort(*inputs.at(0), axis, sortMode);
+      }));
 }
 
 /************************** Binary Operators ***************************/
@@ -312,14 +451,20 @@ Tensor JitBackend::createBinopJitTensor(
   return jitTensorCreator_(BinaryNode::create(lhsNode, rhsNode, op));
 }
 
-#define FL_JIT_BINARY_OP_TYPE_DEF(FUNC, TYPE)                   \
-  Tensor JitBackend::FUNC(const Tensor& a, TYPE rhs) {          \
-    const auto dtype = dtype_traits<std::decay_t<TYPE>>::ctype; \
-    return FUNC(a, this->full(a.shape(), rhs, dtype));          \
-  }                                                             \
-  Tensor JitBackend::FUNC(TYPE lhs, const Tensor& a) {          \
-    const auto dtype = dtype_traits<std::decay_t<TYPE>>::ctype; \
-    return FUNC(this->full(a.shape(), lhs, dtype), a);          \
+// TODO remove once onednn backend supports horizontal broadcast
+template <typename T>
+Tensor JitBackend::createScalarTensor(unsigned ndim, T val) {
+  Shape literalShape(std::vector<Dim>(ndim, 1));
+  auto type = dtype_traits<T>::fl_type;
+  return full(literalShape, val, type);
+}
+
+#define FL_JIT_BINARY_OP_TYPE_DEF(FUNC, TYPE)          \
+  Tensor JitBackend::FUNC(const Tensor& a, TYPE rhs) { \
+    return FUNC(a, createScalarTensor(a.ndim(), rhs)); \
+  }                                                    \
+  Tensor JitBackend::FUNC(TYPE lhs, const Tensor& a) { \
+    return FUNC(createScalarTensor(a.ndim(), lhs), a); \
   }
 
 #define FL_JIT_BINARY_OP_LITERALS_DEF(FUNC)                   \
@@ -380,134 +525,196 @@ Tensor JitBackend::power(const Tensor& lhs, const Tensor& rhs) {
 /************************** BLAS ***************************/
 
 Tensor JitBackend::matmul(
-    const Tensor& /* lhs */,
-    const Tensor& /* rhs */,
-    MatrixProperty /* lhsProp */,
-    MatrixProperty /* rhsProp */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+    const Tensor& lhs,
+    const Tensor& rhs,
+    MatrixProperty lhsProp,
+    MatrixProperty rhsProp) {
+  return jitTensorCreator_(CustomNode::create(
+      "matmul",
+      tensorsToNodes(lhs, rhs),
+      inferMatmulOutputShape(lhs.shape(), rhs.shape(), lhsProp, rhsProp),
+      [this, lhsProp, rhsProp](const std::vector<const Tensor*>& inputs) {
+        return wrappedBackend_.matmul(
+            *inputs.at(0), *inputs.at(1), lhsProp, rhsProp);
+      }));
 }
 
 /************************** Reductions ***************************/
 
+#define FL_JIT_BACKEND_REDUCTION_FALLBACK_IMPL(OP)                         \
+  {                                                                        \
+    return jitTensorCreator_(CustomNode::create(                           \
+        #OP,                                                               \
+        tensorsToNodes(input),                                             \
+        inferReductionOutputShape(input.shape(), axes, keepDims),          \
+        [this, axes, keepDims](const std::vector<const Tensor*>& inputs) { \
+          return wrappedBackend_.OP(*inputs.at(0), axes, keepDims);        \
+        }));                                                               \
+  }
+
 Tensor JitBackend::amin(
-    const Tensor& /* input */,
-    const std::vector<int>& /* axes */,
-    const bool /* keepDims */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+    const Tensor& input,
+    const std::vector<int>& axes,
+    const bool keepDims) {
+  FL_JIT_BACKEND_REDUCTION_FALLBACK_IMPL(amin);
 }
 
 Tensor JitBackend::amax(
-    const Tensor& /* input */,
-    const std::vector<int>& /* axes */,
-    const bool /* keepDims */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+    const Tensor& input,
+    const std::vector<int>& axes,
+    const bool keepDims) {
+  FL_JIT_BACKEND_REDUCTION_FALLBACK_IMPL(amax);
 }
 
 void JitBackend::min(
-    Tensor& /* values */,
-    Tensor& /* indices */,
-    const Tensor& /* input */,
-    const unsigned /* axis */,
-    const bool /* keepDims */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+    Tensor& values,
+    Tensor& indices,
+    const Tensor& input,
+    const unsigned axis,
+    const bool keepDims) {
+  // TODO generalize IR to support nodes with 2 outputs? Need to investigate its
+  // benefit on optimization
+  const auto& inputResult = materialize(input);
+  auto valuesResult = this->wrappedBackend_.full({}, 0, dtype::s32);
+  auto indicesResult = this->wrappedBackend_.full({}, 0, dtype::s32);
+  wrappedBackend_.min(valuesResult, indicesResult, inputResult, axis, keepDims);
+  values = jitTensorCreator_(ValueNode::create(std::move(valuesResult)));
+  indices = jitTensorCreator_(ValueNode::create(std::move(indicesResult)));
 }
 
 void JitBackend::max(
-    Tensor& /* values */,
-    Tensor& /* indices */,
-    const Tensor& /* input */,
-    const unsigned /* axis */,
-    const bool /* keepDims */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+    Tensor& values,
+    Tensor& indices,
+    const Tensor& input,
+    const unsigned axis,
+    const bool keepDims) {
+  const auto& inputResult = materialize(input);
+  auto valuesResult = this->wrappedBackend_.full({}, 0, dtype::s32);
+  auto indicesResult = this->wrappedBackend_.full({}, 0, dtype::s32);
+  wrappedBackend_.max(valuesResult, indicesResult, inputResult, axis, keepDims);
+  values = jitTensorCreator_(ValueNode::create(std::move(valuesResult)));
+  indices = jitTensorCreator_(ValueNode::create(std::move(indicesResult)));
 }
 
 Tensor JitBackend::sum(
-    const Tensor& /* input */,
-    const std::vector<int>& /* axes */,
-    const bool /* keepDims */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+    const Tensor& input,
+    const std::vector<int>& axes,
+    const bool keepDims) {
+  FL_JIT_BACKEND_REDUCTION_FALLBACK_IMPL(sum);
 }
 
-Tensor JitBackend::cumsum(
-    const Tensor& /* input */,
-    const unsigned /* axis */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+Tensor JitBackend::cumsum(const Tensor& input, const unsigned axis) {
+  return jitTensorCreator_(CustomNode::create(
+      "cumsum",
+      tensorsToNodes(input),
+      Shape(input.shape()),
+      [this, axis](const std::vector<const Tensor*>& inputs) {
+        return wrappedBackend_.cumsum(*inputs.at(0), axis);
+      }));
 }
 
 Tensor JitBackend::argmax(
-    const Tensor& /* input */,
-    const unsigned /* axis */,
-    const bool /* keepDims */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+    const Tensor& input,
+    const unsigned axis,
+    const bool keepDims) {
+  return jitTensorCreator_(CustomNode::create(
+      "argmax",
+      tensorsToNodes(input),
+      inferReductionOutputShape(
+          input.shape(), {static_cast<int>(axis)}, keepDims),
+      [this, axis, keepDims](const std::vector<const Tensor*>& inputs) {
+        return wrappedBackend_.argmax(*inputs.at(0), axis, keepDims);
+      }));
 }
 
 Tensor JitBackend::argmin(
-    const Tensor& /* input */,
-    const unsigned /* axis */,
-    const bool /* keepDims */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+    const Tensor& input,
+    const unsigned axis,
+    const bool keepDims) {
+  return jitTensorCreator_(CustomNode::create(
+      "argmax",
+      tensorsToNodes(input),
+      inferReductionOutputShape(
+          input.shape(), {static_cast<int>(axis)}, keepDims),
+      [this, axis, keepDims](const std::vector<const Tensor*>& inputs) {
+        return wrappedBackend_.argmin(*inputs.at(0), axis, keepDims);
+      }));
 }
 
 Tensor JitBackend::mean(
-    const Tensor& /* input */,
-    const std::vector<int>& /* axes */,
-    const bool /* keepDims */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+    const Tensor& input,
+    const std::vector<int>& axes,
+    const bool keepDims) {
+  FL_JIT_BACKEND_REDUCTION_FALLBACK_IMPL(mean);
 }
 
 Tensor JitBackend::median(
-    const Tensor& /* input */,
-    const std::vector<int>& /* axes */,
-    const bool /* keepDims */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+    const Tensor& input,
+    const std::vector<int>& axes,
+    const bool keepDims) {
+  FL_JIT_BACKEND_REDUCTION_FALLBACK_IMPL(median);
 }
 
 Tensor JitBackend::var(
-    const Tensor& /* input */,
-    const std::vector<int>& /* axes */,
-    const bool /* bias */,
-    const bool /* keepDims */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+    const Tensor& input,
+    const std::vector<int>& axes,
+    const bool bias,
+    const bool keepDims) {
+  return jitTensorCreator_(CustomNode::create(
+      "var",
+      tensorsToNodes(input),
+      inferReductionOutputShape(input.shape(), axes, keepDims),
+      [this, axes, bias, keepDims](const std::vector<const Tensor*>& inputs) {
+        return wrappedBackend_.var(*inputs.at(0), axes, bias, keepDims);
+      }));
 }
 
 Tensor JitBackend::std(
-    const Tensor& /* input */,
-    const std::vector<int>& /* axes */,
-    const bool /* keepDims */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+    const Tensor& input,
+    const std::vector<int>& axes,
+    const bool keepDims) {
+  FL_JIT_BACKEND_REDUCTION_FALLBACK_IMPL(std);
 }
 
 Tensor JitBackend::norm(
-    const Tensor& /* input */,
-    const std::vector<int>& /* axes */,
-    double /* p */ /* = 2 */,
-    const bool /* keepDims */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+    const Tensor& input,
+    const std::vector<int>& axes,
+    double p /* = 2 */,
+    const bool keepDims) {
+  return jitTensorCreator_(CustomNode::create(
+      "norm",
+      tensorsToNodes(input),
+      inferReductionOutputShape(input.shape(), axes, keepDims),
+      [this, axes, p, keepDims](const std::vector<const Tensor*>& inputs) {
+        return wrappedBackend_.norm(*inputs.at(0), axes, p, keepDims);
+      }));
 }
 
 Tensor JitBackend::countNonzero(
-    const Tensor& /* input */,
-    const std::vector<int>& /* axes */,
-    const bool /* keepDims */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+    const Tensor& input,
+    const std::vector<int>& axes,
+    const bool keepDims) {
+  FL_JIT_BACKEND_REDUCTION_FALLBACK_IMPL(countNonzero);
 }
 
 Tensor JitBackend::any(
-    const Tensor& /* input */,
-    const std::vector<int>& /* axes */,
-    const bool /* keepDims */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+    const Tensor& input,
+    const std::vector<int>& axes,
+    const bool keepDims) {
+  FL_JIT_BACKEND_REDUCTION_FALLBACK_IMPL(any);
 }
 
 Tensor JitBackend::all(
-    const Tensor& /* input */,
-    const std::vector<int>& /* axes */,
-    const bool /* keepDims */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+    const Tensor& input,
+    const std::vector<int>& axes,
+    const bool keepDims) {
+  FL_JIT_BACKEND_REDUCTION_FALLBACK_IMPL(all);
 }
 
-void JitBackend::print(const Tensor& /* tensor */) {
-  FL_JIT_BACKEND_UNIMPLEMENTED;
+void JitBackend::print(const Tensor& tensor) {
+  std::cout << "JitTensor" << std::endl
+            << toJitTensorBase(const_cast<Tensor&>(tensor)).toString()
+            << std::endl;
 }
 
 } // namespace fl

--- a/flashlight/fl/tensor/backend/jit/JitBackend.h
+++ b/flashlight/fl/tensor/backend/jit/JitBackend.h
@@ -27,6 +27,9 @@ class JitBackend : public TensorBackend {
   Tensor
   createBinopJitTensor(const Tensor& lhs, const Tensor& rhs, BinaryOp op);
 
+  template <typename T>
+  Tensor createScalarTensor(unsigned ndim, T val);
+
  public:
   JitBackend(
       TensorBackend& wrappedBackend,

--- a/flashlight/fl/tensor/backend/jit/JitTensorBase.h
+++ b/flashlight/fl/tensor/backend/jit/JitTensorBase.h
@@ -33,6 +33,9 @@ class JitTensorBase : public TensorAdapterBase {
   // return the wrapped tensor, not a JitTensorBase
   const Tensor& getTensorOrEvalNode() const;
 
+  // convenience method to construct new JitTensor from a data node
+  Tensor fromDataNode(Node* node) const;
+
  protected:
   // this allows us to create an instance of derived class
   virtual Tensor fromSharedData(

--- a/flashlight/fl/tensor/backend/jit/ShapeInference.cpp
+++ b/flashlight/fl/tensor/backend/jit/ShapeInference.cpp
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "flashlight/fl/tensor/backend/jit/ShapeInference.h"
+
+#include <cassert>
+#include <numeric>
+#include <sstream>
+#include <unordered_set>
+
+namespace fl {
+
+Shape inferReductionOutputShape(
+    const Shape& inputShape,
+    const std::vector<int>& axes,
+    bool keepDims) {
+  // NOTE the tensor API requires this, see reduction tests
+  if (inputShape.ndim() == 0) {
+    return inputShape;
+  }
+  for (const auto axis : axes) {
+    if (axis < 0 || axis >= inputShape.ndim()) {
+      std::ostringstream oss;
+      oss << "[inferReductionOutputShape] Invalid axis for reduction: " << axis
+          << " for tensor of shape: " << inputShape;
+      throw std::invalid_argument(oss.str());
+    }
+  }
+  std::unordered_set<int> axesToReduce;
+  if (axes.empty()) {
+    for (int aixs = 0; aixs < inputShape.ndim(); aixs++) {
+      axesToReduce.insert(aixs);
+    }
+  } else {
+    axesToReduce.insert(axes.begin(), axes.end());
+  }
+  std::vector<Dim> outputDims;
+  for (int axis = 0; axis < inputShape.ndim(); axis++) {
+    if (axesToReduce.find(axis) != axesToReduce.end()) {
+      if (keepDims) {
+        outputDims.push_back(1);
+      }
+    } else {
+      outputDims.push_back(inputShape.dim(axis));
+    }
+  }
+  return Shape(outputDims);
+}
+
+std::vector<Shape> broadcastShapesToMaxRank(
+    const std::vector<Tensor>& tensors,
+    const unsigned minOutputRank) {
+  assert(!tensors.empty());
+  std::vector<Shape> shapes;
+  int maxRank = minOutputRank;
+  for (const auto& tensor : tensors) {
+    if (tensor.ndim() == 0) {
+      // TODO investigate semantics for concatnating empty tensor
+      throw std::runtime_error(
+          "[broadcastShapesToMaxRank] Currently doesn't support empty tensor");
+    }
+    maxRank = std::max(maxRank, tensor.ndim());
+  }
+  for (const auto& tensor : tensors) {
+    auto dims = tensor.shape().get();
+    dims.insert(dims.end(), maxRank - dims.size(), 1);
+    shapes.push_back(Shape(dims));
+  }
+  return shapes;
+}
+
+Shape inferTransposeOutputShape(const Shape& inputShape, const Shape& axes) {
+  const auto inputRank = inputShape.ndim();
+  std::vector<Dim> outputDims = inputShape.get();
+  std::vector<Dim> oldToNewAxes = axes.get();
+  if (axes.ndim() == 0) { // default, reverse all axes
+    oldToNewAxes.resize(inputRank);
+    std::reverse(outputDims.begin(), outputDims.end());
+    std::iota(oldToNewAxes.begin(), oldToNewAxes.end(), 0);
+    std::reverse(oldToNewAxes.begin(), oldToNewAxes.end());
+  } else if (axes.ndim() == inputRank) {
+    for (int axis = 0; axis < axes.ndim(); axis++) {
+      outputDims[axis] = inputShape.dim(oldToNewAxes[axis]);
+    }
+  } else {
+    std::ostringstream oss;
+    oss << "[JitBackend::transpose] Invalid axes: " << axes
+        << " for shape: " << inputShape;
+    throw std::runtime_error(oss.str());
+  }
+  return Shape(outputDims);
+}
+
+Shape inferTileOutputShape(const Shape& inputShape, const Shape& tileDims) {
+  std::vector<Dim> paddedTensorDims = inputShape.get();
+  std::vector<Dim> paddedTileDims = tileDims.get();
+  const auto inputRank = inputShape.ndim();
+  const auto tileRank = tileDims.ndim();
+  if (inputRank > tileRank) {
+    const auto diff = inputRank - tileRank;
+    paddedTileDims.insert(paddedTileDims.end(), diff, 1);
+  } else {
+    const auto diff = tileRank - inputRank;
+    paddedTensorDims.insert(paddedTensorDims.end(), diff, 1);
+  }
+  std::vector<Dim> outputDims;
+  for (unsigned i = 0; i < paddedTensorDims.size(); i++) {
+    outputDims.push_back(paddedTensorDims[i] * paddedTileDims[i]);
+  }
+  return Shape(outputDims);
+}
+
+Shape inferConcatenateOutputShape(
+    const std::vector<Tensor>& tensors,
+    const unsigned axisToConcat) {
+  // TODO need a nice way to construct empty tensor for wrapped backend
+  if (tensors.empty()) {
+    throw std::runtime_error(
+        "[inferConcatenateOutputShape] Nothing to concatenate");
+  }
+  const auto shapes = broadcastShapesToMaxRank(tensors, axisToConcat + 1);
+  const unsigned outputRank = shapes.front().ndim();
+  if (axisToConcat >= outputRank) {
+    std::ostringstream oss;
+    oss << "[inferConcatenateOutputShape] Axis too big: " << axisToConcat;
+    throw std::runtime_error(oss.str());
+  }
+  std::vector<Dim> outputDims;
+  for (unsigned axis = 0; axis < outputRank; axis++) {
+    Dim concatenatedDim = 0;
+    if (axis == axisToConcat) {
+      for (const auto& shape : shapes) {
+        concatenatedDim += shape.dim(axis);
+      }
+    } else {
+      concatenatedDim = shapes.front().dim(axis);
+    }
+    outputDims.push_back(concatenatedDim);
+  }
+  return Shape(outputDims);
+}
+
+Shape inferPadOutputShape(
+    const Shape& inputShape,
+    const std::vector<std::pair<int, int>>& padWidths) {
+  std::vector<Dim> outputDims = inputShape.get();
+  if (padWidths.size() > static_cast<size_t>(inputShape.ndim())) {
+    throw std::runtime_error("[inferPadOutputShape] too many paddings");
+  }
+  for (unsigned axis = 0; axis < padWidths.size(); axis++) {
+    const auto& [beforeDim, afterDim] = padWidths[axis];
+    outputDims[axis] += beforeDim + afterDim;
+  }
+  return Shape(outputDims);
+}
+
+Shape inferMatmulOutputShape(
+    const Shape& lhsShape,
+    const Shape& rhsShape,
+    MatrixProperty lhsProp,
+    MatrixProperty rhsProp) {
+  std::vector<Dim> lhsDims = lhsShape.get();
+  std::vector<Dim> rhsDims = rhsShape.get();
+  const auto lhsRank = lhsDims.size();
+  const auto rhsRank = rhsDims.size();
+  const bool isLhsScalarOrVector = lhsRank <= 1;
+  const bool isRhsScalarOrVector = rhsRank <= 1;
+  if (isLhsScalarOrVector) { // pad to (1 x 1/K)
+    lhsDims.insert(lhsDims.end(), 2 - lhsRank, 1);
+    std::reverse(lhsDims.begin(), lhsDims.end());
+  } else if (lhsProp == MatrixProperty::Transpose) {
+    std::swap(lhsDims[0], lhsDims[1]);
+  }
+  if (isRhsScalarOrVector) { // pad to (1/K x 1)
+    rhsDims.insert(rhsDims.end(), 2 - rhsRank, 1);
+  } else if (rhsProp == MatrixProperty::Transpose) {
+    std::swap(rhsDims[0], rhsDims[1]);
+  }
+  // shape compatibility check
+  bool onlyOneIsBatched = lhsRank >= 3 ^ rhsRank >= 3;
+  if (!(lhsDims.at(1) == rhsDims.at(0) &&
+        (onlyOneIsBatched ||
+         std::equal(
+             lhsDims.begin() + 2,
+             lhsDims.end(),
+             rhsDims.begin() + 2,
+             rhsDims.end())))) {
+    std::ostringstream oss;
+    oss << "Cannot perform matmul for tensors of shapes: " << lhsShape
+        << " and " << rhsShape;
+    throw std::invalid_argument(oss.str());
+  }
+  // take dims from bigger rank in case batch broadcasting occurred
+  std::vector<Dim> outputDims;
+  if (lhsRank > rhsRank) {
+    outputDims = lhsDims;
+    outputDims[1] = rhsDims[1];
+  } else {
+    outputDims = rhsDims;
+    outputDims[0] = lhsDims[0];
+  }
+  Shape outputShape(outputDims);
+  if (isLhsScalarOrVector || isRhsScalarOrVector) {
+    outputShape = {outputShape.elements()};
+  }
+  return outputShape;
+}
+
+} // namespace fl

--- a/flashlight/fl/tensor/backend/jit/ShapeInference.h
+++ b/flashlight/fl/tensor/backend/jit/ShapeInference.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "flashlight/fl/tensor/Shape.h"
+#include "flashlight/fl/tensor/TensorBase.h"
+
+// TODO refactor all this with logic in other backends (AF & OneDNN), and move
+// to a `common` folder all backend implementations can access and reuse.
+namespace fl {
+
+Shape inferReductionOutputShape(
+    const Shape& inputShape,
+    const std::vector<int>& axes,
+    bool keepDims);
+
+std::vector<Shape> broadcastShapesToMaxRank(
+    const std::vector<Tensor>& tensors,
+    const unsigned minOutputRank);
+
+Shape inferTransposeOutputShape(const Shape& inputShape, const Shape& axes);
+
+Shape inferTileOutputShape(const Shape& inputShape, const Shape& tileDims);
+
+Shape inferConcatenateOutputShape(
+    const std::vector<Tensor>& tensors,
+    const unsigned axisToConcat);
+
+Shape inferPadOutputShape(
+    const Shape& inputShape,
+    const std::vector<std::pair<int, int>>& padWidths);
+
+Shape inferMatmulOutputShape(
+    const Shape& lhsShape,
+    const Shape& rhsShape,
+    MatrixProperty lhsProp,
+    MatrixProperty rhsProp);
+
+} // namespace fl

--- a/flashlight/fl/tensor/backend/jit/Utils.h
+++ b/flashlight/fl/tensor/backend/jit/Utils.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#pragma once
+
 #include <vector>
 
 #include "flashlight/fl/tensor/backend/jit/ir/Node.h"

--- a/flashlight/fl/test/tensor/jit/JitNodeTest.cpp
+++ b/flashlight/fl/test/tensor/jit/JitNodeTest.cpp
@@ -125,24 +125,23 @@ TEST(JitNodeTest, IndexNodeMetaData) {
   delete node;
 }
 
-// TODO bring this back after supporting `JitTensor::type()`
-//TEST(JitNodeTest, IndexNodeSameShapeTensorIndices) {
-//  const Shape shape({5, 6, 7});
-//  const auto c0 = ScalarNode::create(shape, dtype::f32, 0);
-//  const auto t1 =
-//      JitTensor<DefaultTensorType_t>().backend().full(shape, 1, dtype::f32);
-//  const auto c1 = toJitTensorBase(t1).node();
-//  std::vector<Index> indices{t1};
-//  const auto node = IndexNode::create(c0, indices);
-//  ASSERT_EQ(node->inputs(), NodeList({c0, c1})); // includes tensor index
-//  ASSERT_EQ(node->indexedNode(), c0);
-//  ASSERT_EQ(node->indices().size(), 1); // can't check equality easily...
-//  // if tensor index has same shape as indexed tensor, output shape is simply
-//  // the flattened tensor shape
-//  ASSERT_EQ(node->shape(), Shape({210}));
-//  // node is owned locally (didn't transition to shared ownership)
-//  delete node;
-//}
+TEST(JitNodeTest, IndexNodeSameShapeTensorIndices) {
+  const Shape shape({5, 6, 7});
+  const auto c0 = ScalarNode::create(shape, dtype::f32, 0);
+  const auto t1 =
+      JitTensor<DefaultTensorType_t>().backend().full(shape, 1, dtype::f32);
+  const auto c1 = toJitTensorBase(t1).node();
+  std::vector<Index> indices{t1};
+  const auto node = IndexNode::create(c0, indices);
+  ASSERT_EQ(node->inputs(), NodeList({c0, c1})); // includes tensor index
+  ASSERT_EQ(node->indexedNode(), c0);
+  ASSERT_EQ(node->indices().size(), 1); // can't check equality easily...
+  // if tensor index has same shape as indexed tensor, output shape is simply
+  // the flattened tensor shape
+  ASSERT_EQ(node->shape(), Shape({210}));
+  // node is owned locally (didn't transition to shared ownership)
+  delete node;
+}
 
 TEST(JitNodeTest, IndexNodeDifferentShapeTensorIndices) {
   const auto c0 = ScalarNode::create({5, 6, 7}, dtype::f32, 0);


### PR DESCRIPTION
### Summary
As title. This enables 
1. applying JIT to _almost_ any existing application
2. capturing maximal graph (which will become immensely helpful with the upcoming GraphVizPrinter & performance profiling).

The changes are quite simple -- just apply `CustomNode` to inject evaluation logic for all the remaining ops, and shape inference for certain ops.

There are small TODOs I dropped and minor changes I plan to send out in a few upcoming PRs, but they are pretty niche, and shouldn't affect overall applicability of the JIT.

### Test Plan (required)

I manually used `fl::setDefaultTensorType<JitTensor<DefaultTensorType_t>>` in all existing tensor tests, e.g., `TensorBaseTest` to make sure things are correct (except for about 5% due to the TODOs I mentioned above).