### PR TITLE
Update Dockerfiles (kenlm, gloo, ArrayFire)

### DIFF
--- a/.docker/Dockerfile-CPU-Base
+++ b/.docker/Dockerfile-CPU-Base
@@ -5,12 +5,12 @@
 # OpenMPI          latest       (apt)
 # cmake            3.16.3       (apt)
 # MKL              2020.4-912   (apt)
-# arrayfire        3.7.3        (git, CPU backend)
+# arrayfire        3.8.3        (git, CPU backend)
 # libsndfile       latest       (apt)
 # oneDNN           v2.5.2       (git)
-# Gloo             1da2117      (git)
+# Gloo             56b221c      (git)
 # FFTW             latest       (apt)
-# KenLM            0c4dd4e      (git)
+# KenLM            9af679c      (git)
 # GLOG             latest       (apt)
 # gflags           latest       (apt)
 # python3          latest       (apt)
@@ -65,7 +65,7 @@ FROM cpu_base_builder as cpu_arrayfire
 # ==================================================================
 # arrayfire with CPU backend https://github.com/arrayfire/arrayfire/wiki/
 # ------------------------------------------------------------------
-RUN cd /tmp && git clone --branch v3.7.3 --depth 1 --recursive --shallow-submodules https://github.com/arrayfire/arrayfire.git && \
+RUN cd /tmp && git clone --branch v3.8.3 --depth 1 --recursive --shallow-submodules https://github.com/arrayfire/arrayfire.git && \
     mkdir -p arrayfire/build && cd arrayfire/build && \
     cmake .. -DCMAKE_BUILD_TYPE=Release \
              -DCMAKE_INSTALL_PREFIX=/opt/arrayfire \
@@ -94,7 +94,7 @@ FROM cpu_base_builder as cpu_gloo
 # Gloo https://github.com/facebookincubator/gloo.git
 # ------------------------------------------------------------------
 RUN cd /tmp && git clone https://github.com/facebookincubator/gloo.git && \
-    cd gloo && git checkout 1da2117 && mkdir build && cd build && \
+    cd gloo && git checkout 56b221c0a811491d2dc2a3254b468ad687bbdaab && mkdir build && cd build && \
     cmake .. -DCMAKE_BUILD_TYPE=Release \
              -DCMAKE_INSTALL_PREFIX=/opt/gloo \
              -DUSE_MPI=ON && \
@@ -105,7 +105,7 @@ FROM cpu_base_builder as cpu_kenlm
 # KenLM https://github.com/kpu/kenlm
 # ------------------------------------------------------------------
 RUN cd /tmp && git clone https://github.com/kpu/kenlm.git && \
-    cd kenlm && git checkout 0c4dd4e && \
+    cd kenlm && git checkout 9af679c38477b564c26917a5dcf52d2c86177fb9 && \
     mkdir build && cd build && \
     cmake .. -DCMAKE_BUILD_TYPE=Release \
              -DCMAKE_INSTALL_PREFIX=/opt/kenlm \

--- a/.docker/Dockerfile-CUDA-Base
+++ b/.docker/Dockerfile-CUDA-Base
@@ -7,16 +7,16 @@
 # CuDNN            8-dev
 # cmake            3.16.3       (apt)
 # MKL              2020.4-912   (apt)
-# arrayfire        3.7.3        (git, CUDA backend)
+# arrayfire        3.8.3        (git, CUDA backend)
 # libsndfile       latest       (apt)
 # FFTW             latest       (apt)
-# KenLM            0c4dd4e      (git)
+# KenLM            9af679c      (git)
 # GLOG             latest       (apt)
 # gflags           latest       (apt)
 # python3          latest       (apt)
 # ==================================================================
 
-FROM nvidia/cuda:11.1-cudnn8-devel-ubuntu20.04 as cuda_base_builder
+FROM nvidia/cuda:11.1.1-cudnn8-devel-ubuntu20.04 as cuda_base_builder
 
 # If the driver is not found (during docker build) the cuda driver api need to be linked against the
 # libcuda.so stub located in the lib[64]/stubs directory
@@ -65,7 +65,7 @@ FROM cuda_base_builder as cuda_arrayfire
 # arrayfire with CUDA backend https://github.com/arrayfire/arrayfire/wiki/Build-Instructions-for-Linux#cuda-backend-dependencies
 # ------------------------------------------------------------------
 RUN cd /tmp && \
-    git clone --branch v3.7.3 --depth 1 --recursive --shallow-submodules https://github.com/arrayfire/arrayfire.git && \
+    git clone --branch v3.8.3 --depth 1 --recursive --shallow-submodules https://github.com/arrayfire/arrayfire.git && \
     mkdir -p arrayfire/build && cd arrayfire/build && \
     CXXFLAGS=-DOS_LNX cmake .. -DCMAKE_BUILD_TYPE=Release \
                                -DCMAKE_INSTALL_PREFIX=/opt/arrayfire \
@@ -84,7 +84,7 @@ FROM cuda_base_builder as cuda_kenlm
 # KenLM https://github.com/kpu/kenlm
 # ------------------------------------------------------------------
 RUN cd /tmp && git clone https://github.com/kpu/kenlm.git && \
-    cd kenlm && git checkout 0c4dd4e && \
+    cd kenlm && git checkout 9af679c38477b564c26917a5dcf52d2c86177fb9 && \
     mkdir build && cd build && \
     cmake .. -DCMAKE_BUILD_TYPE=Release \
              -DCMAKE_INSTALL_PREFIX=/opt/kenlm \


### PR DESCRIPTION
Update Docker images/Dockerfiles to point to ArrayFire 3.8.3, a new commit of Gloo, and an installation of KenLM that has a `kenlmConfig.cmake` and thus doesn't have the `libkenlm_util.so` dependency.

Build procedure:
```
sudo nvidia-docker build --tag cuda-base-latest -f .docker/Dockerfile-CUDA-Base /scratch/docker
sudo docker build --tag cpu-base-latest -f .docker/Dockerfile-CPU-Base /scratch/docker
```

Test plan: https://github.com/flashlight/flashlight/pull/1077 uses updated images