### PR TITLE
Fix Tensor docs gen, upgrade sphinx/breathe vers

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,7 +475,7 @@ make -j$(nproc)
 If Flashlight is installed in a custom location using a `CMAKE_INSTALL_PREFIX`, passing `-Dflashlight_DIR=[install prefix]/share/flashlight/cmake` as an argument to your `cmake` command can help CMake find Flashlight.
 
 ### Building and Running Flashlight with Docker
-Flashlight and its dependencies can also be built with the provided Dockerfiles — see the accompanying [Docker documentation](.docker) for more information.
+Flashlight and its dependencies can also be built with the provided Dockerfiles; see the accompanying [Docker documentation](.docker) for more information.
 
 ### Contributing and Contact
 Contact: vineelkpratap@fb.com, awni@fb.com, jacobkahn@fb.com, qiantong@fb.com, antares@fb.com, padentomasello@fb.com,

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,32 +4,31 @@
 
 To build the documentation, follow the steps below.
 
-### Setup (do once)
+### Setup
 
-Install [Doxygen](http://www.doxygen.nl/manual/install.html).
+First, install [Doxygen](http://www.doxygen.nl/manual/install.html).
 
-Install sphinx, breathe and the theme using the `requirements.txt` file in `docs/`:
-
-```
+Install Sphinx, Breathe and the theme using the `requirements.txt` file in `docs`:
+```bash
+cd docs
 pip install -r requirements.txt
 ```
 
-### Build
+### Building
 
-From `docs/`:
-
-```
-doxygen && make html
-```
-
-If you run into issues rebuilding the docs, run `make clean` before building again.
-
-### View the Docs
-
-Run a server in `docs/build/html`:
-
-```
-python -m http.server <port>
+From `docs`, run:
+```bash
+doxygen
+make html
 ```
 
-Point browser to `http://localhost:<port>`.
+If you run into issues rebuilding docs, run `make clean` before building again.
+
+### Viewing
+
+After buildling, from the `docs` directory, run a local server to view artifacts:
+```bash
+python -m http.server <port> --directory build/html
+```
+
+Point your browser to `http://localhost:<port>` to view.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-sphinx==2.0.1
-breathe==4.13
-sphinx_rtd_theme
+breathe==4.35.0
+Sphinx==6.1.3
+sphinx-rtd-theme==1.2.0

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -5,59 +5,62 @@ import subprocess
 
 import sphinx_rtd_theme
 
-read_the_docs_build = os.environ.get('READTHEDOCS', None) == 'True'
+read_the_docs_build = os.environ.get("READTHEDOCS", None) == "True"
 if read_the_docs_build:
-    subprocess.call('cd ..; doxygen', shell=True)
+    subprocess.call("cd ..; doxygen", shell=True)
 
 # -- Project information -----------------------------------------------------
 
-project = 'flashlight'
-copyright = '2018, Flashlight Contributors'
-author = 'Flashlight Contributors'
-version = 'v0.1'
+project = "flashlight"
+copyright = "2018, Flashlight Contributors"
+author = "Flashlight Contributors"
+version = "v0.1"
 
 # -- General configuration ---------------------------------------------------
 
-extensions = [
-    'sphinx.ext.githubpages',
-    'sphinx.ext.graphviz',
-    'breathe'
-]
+extensions = ["sphinx.ext.githubpages", "sphinx.ext.graphviz", "breathe"]
 
-breathe_projects = {"flashlight" : "../build/xml"}
+breathe_projects = {"flashlight": "../build/xml"}
 breathe_default_project = "flashlight"
-templates_path = ['_templates']
-source_suffix = '.rst'
-master_doc = 'index'
-highlight_language = 'c++'
-pygments_style = 'sphinx'
+templates_path = ["_templates"]
+source_suffix = ".rst"
+master_doc = "index"
+highlight_language = "c++"
+pygments_style = "sphinx"
 
 # -- Options for HTML output -------------------------------------------------
 
+
 def setup(app):
-    app.add_stylesheet("css/styles.css")
+    app.add_css_file("css/styles.css")
+
 
 html_theme = "sphinx_rtd_theme"
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-html_static_path = ['_static']
+html_static_path = ["_static"]
+html_theme_options = {
+    "analytics_id": "G-NC8KPYMD2M",
+    "analytics_anonymize_ip": True,
+}
 
 # -- Options for HTMLHelp output ---------------------------------------------
 
-htmlhelp_basename = 'flashlightdoc'
+htmlhelp_basename = "flashlightdoc"
 
 # -- Options for LaTeX output ------------------------------------------------
 
-latex_elements = {
-}
+latex_elements = {}
 
 latex_documents = [
-    (master_doc, 'flashlight.tex', 'flashlight Documentation',
-     'Flashlight Contributors', 'manual'),
+    (
+        master_doc,
+        "flashlight.tex",
+        "flashlight Documentation",
+        "Flashlight Contributors",
+        "manual",
+    ),
 ]
 
 # -- Options for manual page output ------------------------------------------
 
-man_pages = [
-    (master_doc, 'flashlight', 'flashlight Documentation',
-     [author], 1)
-]
+man_pages = [(master_doc, "flashlight", "flashlight Documentation", [author], 1)]

--- a/docs/source/debugging.rst
+++ b/docs/source/debugging.rst
@@ -25,13 +25,11 @@ Printing Info
   ``std::cout << "myTensor" << myTensor << std::endl;``) or printed to
   standard out by using ``fl::print()``.
 
-By including ArrayFire headers `<arrayfire/arrayfire.h>` directly, one has
+By including ArrayFire headers ``<arrayfire/arrayfire.h>`` directly, one has
 access to useful debugging functions:
-- ``af::info()`` and ``af::deviceInfo()`` can provide info about ArrayFire
-  version, GPU devices, compute capabilities, etc.
+- ``af::info()`` and ``af::deviceInfo()`` can provide info about ArrayFire version, GPU devices, compute capabilities, etc.
 - ``af::printMemInfo()`` can be useful in debugging OOMs.
-- ``af::print()`` can be used to inspect arrays. Note: the 1st argument should
-  be a message/name, and the 2nd argument shoudld be an array, not Variable:
+- ``af::print()`` can be used to inspect arrays. Note: the 1st argument should be a message/name, and the 2nd argument shoudld be an array, not Variable:
 
 ::
 

--- a/docs/source/logging.rst
+++ b/docs/source/logging.rst
@@ -1,4 +1,4 @@
 Logging
-======
+=======
 
 .. doxygengroup:: logging

--- a/flashlight/fl/tensor/TensorBase.h
+++ b/flashlight/fl/tensor/TensorBase.h
@@ -70,8 +70,9 @@ std::unique_ptr<TensorAdapterBase> releaseAdapterUnsafe(Tensor& t);
  * changes.`TensorAdapterBase` implementations may differ across tensor
  * libraries, hardware-specific libraries or compilers and DSLs.
  *
- * TODO:fl::Tensor {doc} more documentation. NOTE: this API will break
- * frequently and is not yet stable.
+ * \todo: Improve documentation throughout.
+ *
+ * \warning This API may break and is not yet stable.
  */
 class Tensor {
   // The tensor adapter for the tensor
@@ -96,8 +97,8 @@ class Tensor {
    * For internal use only. Tensor implementations should define when and where
    * deep copies happen based on their dataflow graph abstractions.
    *
-   * TODO(jacobkahn) -- remove me! Rely on copy-on-write and fix bad refcount
-   * bumping.
+   * \todo slated for removal. Rely on copy-on-write and fix bad refcount
+   * issues.
    */
   Tensor shallowCopy() const;
   // shallowCopy() above is used in DevicePtr given that it doesn't mutate
@@ -167,7 +168,7 @@ class Tensor {
    * @param[in] colIdx the the column indices of the sparse array
    * @param[in] storageType the storage type of the underlying tensor
    *
-   * TODO(jacobkahn): expand this API with getters, isSparse() as needed, etc.
+   * \todo Expand this API with getters as needed.
    */
   Tensor(
       const Dim nRows,
@@ -586,9 +587,10 @@ class Tensor {
   void* getContext() const;
 
   /**
-   * Returns a string representation of a Tensor. NOTE: This is
-   * backend-dependent. See Flashlight's serialization utilities for ways to
-   * serialize Tensors that are portable across Tensor backends.
+   * Returns a string representation of a Tensor.
+   *
+   * \note This is backend-dependent. See Flashlight's serialization utilities
+   * for ways to serialize Tensors that are portable across Tensor backends.
    *
    * @return a string representation of the Tensor.
    */
@@ -719,7 +721,9 @@ arange(const Shape& shape, const Dim seqDim = 0, const dtype type = dtype::f32);
  * Creates a sequence with the range `[0, dims.elements())` sequentially in the
  * shape given by dims, then tiles the result along the specified tile
  * dimensions.
- * TODO: this is an AF-specific function.
+ *
+ * \todo an optimized version of this function is implemented only with the
+ * ArrayFire backend.
  *
  * @param[in] dims the dimensions of the range
  * @param[in] tileDims the dimensions along which to tile
@@ -932,6 +936,8 @@ Tensor rint(const Tensor& tensor);
  * @return the resulting tensor
  */
 Tensor absolute(const Tensor& tensor);
+
+// \copydoc absolute
 inline Tensor abs(const Tensor& tensor) {
   return absolute(tensor);
 }
@@ -968,18 +974,61 @@ Tensor flip(const Tensor& tensor, const unsigned dim);
  * Clip (limit) the values of a tensor. Given some interval of values, set
  * values outside of that interval to be the boundaries of the interval. All
  * values larger than the max become the max, and all values smaller than the
- * min become the min.
+ * min become the min. Minimum and maximum values are determined element-wise in
+ * the input `low` and `high` input tensors.
  *
- * TODO: consider requiring broadcasting behavior/enforcing in a test
+ * \todo Require, enforce, and document broadcasting behavior in testing.
  *
  * @param[in] tensor the tensor to clip
- * @param[in] low a tensor containing
- * @param[in] high
+ * @param[in] low a tensor containing minimum values used element-wise in
+ * clipping
+ * @param[in] high a tensor containing maximum values used element-wise in
+ * clipping
  * @return a tensor with all values clipped between high and low
  */
 Tensor clip(const Tensor& tensor, const Tensor& low, const Tensor& high);
+
+/**
+ * Clip (limit) the values of a tensor. Given some interval of values, set
+ * values outside of that interval to be the boundaries of the interval. All
+ * values larger than the max become the max, and all values smaller than the
+ * min become the min. Minimum values are determined element-wise in
+ * the `low` input tensor and the upper bound scalar.
+ *
+ * @param[in] tensor the tensor to clip
+ * @param[in] low a tensor containing minimum values used element-wise in
+ * clipping
+ * @param[in] high a scalar to use as the maximum value in clipping
+ * @return a tensor with all values clipped between high and low
+ */
 Tensor clip(const Tensor& tensor, const Tensor& low, const double& high);
+
+/**
+ * Clip (limit) the values of a tensor. Given some interval of values, set
+ * values outside of that interval to be the boundaries of the interval. All
+ * values larger than the max become the max, and all values smaller than the
+ * min become the min. Minimum values are given by the lower bound scalar and
+ * element-wise in the `high` input tensor.
+ *
+ * @param[in] tensor the tensor to clip
+ * @param[in] low a scalar to use as the minimum value in clipping
+ * @param[in] high a tensor containing maximum values used element-wise in
+ * clipping
+ * @return a tensor with all values clipped between high and low
+ */
 Tensor clip(const Tensor& tensor, const double& low, const Tensor& high);
+
+/**
+ * Clip (limit) the values of a tensor. Given some interval of values, set
+ * values outside of that interval to be the boundaries of the interval. All
+ * values larger than the max become the max, and all values smaller than the
+ * min become the min. Minimum values are determined by the passed scalars.
+ *
+ * @param[in] tensor the tensor to clip
+ * @param[in] low a scalar to use as the minimum value in clipping
+ * @param[in] high a scalar to use as the maximum value in clipping
+ * @return a tensor with all values clipped between high and low
+ */
 Tensor clip(const Tensor& tensor, const double& low, const double& high);
 
 /**
@@ -1066,7 +1115,37 @@ Tensor triu(const Tensor& tensor);
  * true and elements of y where condition is false.
  */
 Tensor where(const Tensor& condition, const Tensor& x, const Tensor& y);
+
+/**
+ * Conditionally return elements from a tensor or passed scalar based on a
+ * condition.
+ *
+ * @param[in] condition a tensor that, where true, uses the scalar value x,
+ * else positional values from y. This tensor must be of type dtype::b8 else
+ * an exception is thrown.
+ * @param[in] x the tensor from which values are chosen for true values in the
+ * condition
+ * @param[in] y the scalar returned for false values in the condition
+ *
+ * @return the resulting tensor that contains elements of x where condition is
+ * true and the scalar value y where the condition is false.
+ */
 Tensor where(const Tensor& condition, const Tensor& x, const double& y);
+
+/**
+ * Conditionally return elements from a scalar or passed tensor based on a
+ * condition.
+ *
+ * @param[in] condition a tensor that, where true, uses values from x
+ * positionally, else the scalar value y. This tensor must be of type dtype::b8
+ * else an exception is thrown.
+ * @param[in] x the scalar returned for true values in the condition
+ * @param[in] y the tensor from which values are chosen for false values in the
+ * condition
+ *
+ * @return the resulting tensor that contains elements of x where condition is
+ * true and the scalar value y where the condition is false.
+ */
 Tensor where(const Tensor& condition, const double& x, const Tensor& y);
 
 /*!
@@ -1135,6 +1214,7 @@ Tensor argsort(
     const SortMode sortMode = SortMode::Ascending);
 
 /************************** Binary Operators ***************************/
+// \cond DOXYGEN_DO_NOT_DOCUMENT
 #define FL_BINARY_OP_LITERAL_TYPE_DECL(OP, FUNC, TYPE) \
   Tensor FUNC(TYPE lhs, const Tensor& rhs);            \
   Tensor FUNC(const Tensor& lhs, TYPE rhs);            \
@@ -1183,31 +1263,68 @@ FL_BINARY_OP_DECL(>>, rShift);
 #undef FL_BINARY_OP_DECL
 #undef FL_BINARY_OP_LITERALS_DECL
 #undef FL_BINARY_OP_LITERAL_TYPE_DECL
+// \endcond
 
 /**
  * Returns the element-wise minimum of tensor elements.
  *
- * TODO: consider requiring broadcasting behavior/enforcing in a test
+ * \todo Require, enforce, and document broadcasting behavior in testing.
  *
  * @param[in] lhs left hand side tensor for the minimum
  * @param[in] rhs right hand side tensor for the minimum
  * @return a tensor containing the minimum values in each tensor
  */
 Tensor minimum(const Tensor& lhs, const Tensor& rhs);
+
+/**
+ * Returns the element-wise minimum of tensor elements with some scalar.
+ *
+ * @param[in] lhs the tensor
+ * @param[in] rhs a scalar value
+ * @return a tensor containing the minimum values element-wise with the tensor
+ * and a scalar.
+ */
 Tensor minimum(const Tensor& lhs, const double& rhs);
+
+/**
+ * Returns the element-wise minimum of tensor elements with some scalar.
+ *
+ * @param[in] lhs a scalar value
+ * @param[in] rhs the tensor
+ * @return a tensor containing the minimum values element-wise with the tensor
+ * and a scalar.
+ */
 Tensor minimum(const double& lhs, const Tensor& rhs);
 
 /**
  * Returns the element-wise maximum of tensor elements.
  *
- * TODO: consider requiring broadcasting behavior/enforcing in a test
+ * \todo Require, enforce, and document broadcasting behavior in testing.
  *
  * @param[in] lhs left hand side tensor for the minimum
  * @param[in] rhs right hand side tensor for the minimum
  * @return a tensor containing the maximum values in each tensor
  */
 Tensor maximum(const Tensor& lhs, const Tensor& rhs);
+
+/**
+ * Returns the element-wise maximum of tensor elements with some scalar.
+ *
+ * @param[in] lhs the tensor
+ * @param[in] rhs a scalar value
+ * @return a tensor containing the maximum values element-wise with the tensor
+ * and a scalar.
+ */
 Tensor maximum(const Tensor& lhs, const double& rhs);
+
+/**
+ * Returns the element-wise maximum of tensor elements with some scalar.
+ *
+ * @param[in] lhs a scalar value
+ * @param[in] rhs the tensor
+ * @return a tensor containing the maximum values element-wise with the tensor
+ * and a scalar.
+ */
 Tensor maximum(const double& lhs, const Tensor& rhs);
 
 /**
@@ -1219,7 +1336,25 @@ Tensor maximum(const double& lhs, const Tensor& rhs);
  * @return a tensor containing the exponentiated values
  */
 Tensor power(const Tensor& lhs, const Tensor& rhs);
+
+/**
+ * Returns the element-wise exponentiation of tensors raised to some scalar
+ * power.
+ *
+ * @param[in] lhs the base tensor
+ * @param[in] rhs a scalar exponent
+ * @return a tensor containing the exponentiated values
+ */
 Tensor power(const Tensor& lhs, const double& rhs);
+
+/**
+ * Returns the element-wise exponentiation of a scalar raised element-wise to
+ * values from a tensor.
+ *
+ * @param[in] lhs a scalar base
+ * @param[in] rhs the tensor containing exponent values
+ * @return a tensor containing the exponentiated values
+ */
 Tensor power(const double& lhs, const Tensor& rhs);
 
 /******************************* BLAS ********************************/


### PR DESCRIPTION
See title. Add missing blocks for several tensor ops, convert TODOs and warnings into doxygen compatible blocks, and remove arithmetic binary overloads which polluted the tensor docs.

Also upgrade Sphinx, Breathe, and sphinx-rtd-theme versions for better compatibility/generation.

Test plan: Docs build + visual inspection