### PR TITLE
Update .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,12 +5,16 @@
 # Required
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 # Build documentation with Sphinx
 sphinx:
   configuration: docs/source/conf.py
 
 # Python version and requirements for build
 python:
-  version: 3.7
   install:
     - requirements: docs/requirements.txt


### PR DESCRIPTION
Enable docs build with PRs on RTD. Update to use the new [build schema](https://docs.readthedocs.io/en/stable/config-file/v2.html#build-os) and deprecate old properties. Python 3.10 (or something somewhat modern) is required for newer versions of Sphinx/Breathe.

Test plan: CI