### PR TITLE
Remove std::result_of_t uses

### DIFF
--- a/flashlight/fl/common/Utils.h
+++ b/flashlight/fl/common/Utils.h
@@ -48,7 +48,7 @@ std::string prettyStringCount(size_t count);
  * multiplying by `factor` each retry. At most `maxIters` calls are made.
  */
 template <class Fn, class... Args>
-typename std::result_of_t<Fn(Args...)> retryWithBackoff(
+typename std::invoke_result<Fn, Args...>::type retryWithBackoff(
     std::chrono::duration<double> initial,
     double factor,
     int64_t maxIters,

--- a/flashlight/fl/common/threadpool/ThreadPool.h
+++ b/flashlight/fl/common/threadpool/ThreadPool.h
@@ -56,7 +56,7 @@ class ThreadPool {
    */
   template <class F, class... Args>
   auto enqueue(F&& f, Args&&... args)
-      -> std::future<typename std::result_of_t<F(Args...)>>;
+      -> std::future<typename std::invoke_result<F, Args...>::type>;
   ///  destructor joins all threads.
   ~ThreadPool();
 
@@ -101,8 +101,8 @@ inline ThreadPool::ThreadPool(
 
 template <class F, class... Args>
 auto ThreadPool::enqueue(F&& f, Args&&... args)
-    -> std::future<typename std::result_of_t<F(Args...)>> {
-  using return_type = typename std::result_of_t<F(Args...)>;
+    -> std::future<typename std::invoke_result<F, Args...>::type> {
+  using return_type = typename std::invoke_result<F, Args...>::type;
 
   auto task = std::make_shared<std::packaged_task<return_type()>>(
       std::bind(std::forward<F>(f), std::forward<Args>(args)...));

--- a/flashlight/fl/test/common/UtilsTest.cpp
+++ b/flashlight/fl/test/common/UtilsTest.cpp
@@ -44,7 +44,7 @@ static std::function<int(void)> makeSucceedsAfterMs(double ms) {
 }
 
 template <class Fn>
-std::future<typename std::result_of_t<Fn()>> retryAsync(
+std::future<typename std::invoke_result<Fn>::type> retryAsync(
     std::chrono::duration<double> initial,
     double factor,
     int64_t iters,


### PR DESCRIPTION
See title. Deprecated in C++ 17, [removed in C++ 20](https://en.cppreference.com/w/cpp/types/result_of) in favor of `std::invoke_result`

Fixes https://github.com/flashlight/flashlight/issues/1089

Test plan: CI, local build