### PR TITLE
[trivial] Fix macOS build

### DIFF
--- a/flashlight/fl/test/autograd/AutogradNormalizationTest.cpp
+++ b/flashlight/fl/test/autograd/AutogradNormalizationTest.cpp
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <array>
 #include <math.h>
 
 #include <gtest/gtest.h>


### PR DESCRIPTION
Apple LLVM is stricter about headers.

Test plan: local build, CI