### PR TITLE
Fix backend targets not getting linked in cmake

### DIFF
--- a/flashlight/fl/tensor/backend/af/CMakeLists.txt
+++ b/flashlight/fl/tensor/backend/af/CMakeLists.txt
@@ -58,9 +58,15 @@ if (NOT (${_AF_CUDA} OR ${_AF_CPU} OR ${_AF_OPENCL}))
 
   # Exactly one ArrayFire target is found, but no options are specified.
   # Set the option based on the found target.
-  set(${FL_ARRAYFIRE_USE_CUDA}   TARGET ArrayFire::afcuda)
-  set(${FL_ARRAYFIRE_USE_CPU}    TARGET ArrayFire::afcpu)
-  set(${FL_ARRAYFIRE_USE_OPENCL} TARGET ArrayFire::afopencl)
+  if (TARGET ArrayFire::afcuda)
+    set(FL_ARRAYFIRE_USE_CUDA ON)
+  endif()
+  if (TARGET ArrayFire::afcpu)
+    set(FL_ARRAYFIRE_USE_CPU ON)
+  endif()
+  if (TARGET ArrayFire::afopencl)
+    set(FL_ARRAYFIRE_USE_OPENCL ON)
+  endif()
 endif()
 
 if (${FL_ARRAYFIRE_USE_CUDA})


### PR DESCRIPTION
### Summary
closes #1033

It seems the backend libraries were not getting linked in cmake as the method for detecting if a target existed was (as far as I know) invalid cmake syntax.

I suspect the CI and other projects using Flashlight are manually defining `FL_ARRAYFIRE_USE_CUDA` as cmake args, so this issue is not commonly encountered.

### Test Plan (required)
I pulled and ran the `flml/flashlight:cuda-base-consolidation-latest` image via docker and ran cmake with the following arguments:

```
cmake .. -DCMAKE_BUILD_TYPE=Debug \
  -DFL_USE_ONEDNN=OFF \
  -DFL_BACKEND=CUDA \
  -DFL_BUILD_ALL_APPS=ON \
  -DFL_BUILD_ALL_PKGS=ON
```

I could then successfully build and link Flashlight and almost all other apps/tests.