### PR TITLE
Improve CUDA RT linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,18 +104,6 @@ target_compile_definitions(flashlight
   FL_BUILD_PROFILING=$<BOOL:${FL_BUILD_PROFILING}>
   )
 
-if (FL_USE_CUDA)
-  enable_language(CUDA)
-  # TODO: switch to CMAKE_CUDA_RUNTIME_LIBRARY when requiring CMake >= 3.17
-  find_library(CUDART_LIBRARY cudart ${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES})
-  target_include_directories(
-    flashlight
-    PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}>
-    )
-  target_link_libraries(flashlight PUBLIC ${CUDART_LIBRARY})
-endif()
-
 if (FL_CODE_COVERAGE)
   add_coverage_to_target(TARGET flashlight)
 endif()

--- a/flashlight/fl/CMakeLists.txt
+++ b/flashlight/fl/CMakeLists.txt
@@ -22,8 +22,11 @@ endif()
 target_link_libraries(flashlight PUBLIC $<BUILD_INTERFACE:cereal::cereal>)
 
 # -------------------------------- Components --------------------------------
-# Tensor -- resolve backends and compute runtimes first
+# Tensor -- resolve backends first
 include(${CMAKE_CURRENT_LIST_DIR}/tensor/CMakeLists.txt)
+
+# Runtime
+include(${CMAKE_CURRENT_LIST_DIR}/runtime/CMakeLists.txt)
 
 # Common
 include(${CMAKE_CURRENT_LIST_DIR}/common/CMakeLists.txt)
@@ -45,9 +48,6 @@ include(${CMAKE_CURRENT_LIST_DIR}/nn/CMakeLists.txt)
 
 # Optim
 include(${CMAKE_CURRENT_LIST_DIR}/optim/CMakeLists.txt)
-
-# Runtime
-include(${CMAKE_CURRENT_LIST_DIR}/runtime/CMakeLists.txt)
 
 # ----------------------- Examples and Tests ------------------------
 

--- a/flashlight/fl/runtime/CMakeLists.txt
+++ b/flashlight/fl/runtime/CMakeLists.txt
@@ -11,6 +11,23 @@ target_sources(
   )
 
 if (FL_USE_CUDA)
+  # Find cudart library
+  if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.17)
+    target_link_libraries(flashlight PUBLIC $<BUILD_INTERFACE:CUDA::cudart>)
+  else()
+    # TODO: switch to CMAKE_CUDA_RUNTIME_LIBRARY when requiring CMake >= 3.17
+    find_library(CUDART_LIBRARY cudart PATHS ${CUDA_LIBRARIES} ${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES})
+    if (NOT CUDART_LIBRARY)
+      message(FATAL_ERROR "Could not find cudart library - required if using CUDA")
+    endif()
+    target_include_directories(
+      flashlight
+      PUBLIC
+      $<BUILD_INTERFACE:${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}>
+      )
+    target_link_libraries(flashlight PUBLIC ${CUDART_LIBRARY})
+  endif()
+
   target_sources(
     flashlight
     PRIVATE

--- a/flashlight/fl/tensor/CMakeLists.txt
+++ b/flashlight/fl/tensor/CMakeLists.txt
@@ -86,9 +86,25 @@ target_sources(
 cmake_dependent_option(FL_BUILD_PROFILING
   "Enable profiling with Flashlight" OFF
   "FL_USE_CUDA" OFF)
+
 if (FL_USE_CUDA)
-  target_link_libraries(flashlight PUBLIC ${CUDA_LIBRARIES})
-  target_include_directories(flashlight PUBLIC ${CUDA_INCLUDE_DIRS})
+  include(CheckLanguage)
+  check_language(CUDA)
+  if (CMAKE_CUDA_COMPILER)
+    enable_language(CUDA)
+  else()
+    message(FATAL_ERROR "CUDA is enabled but no CUDA compiler was found")
+  endif()
+
+  # Link CUDA components
+  if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.17)
+    find_package(CUDAToolkit REQUIRED cublas)
+    target_link_libraries(flashlight PRIVATE CUDA::cublas)
+  else()
+    # Remove old branch when requiring CMake >= 3.17
+    target_link_libraries(flashlight PRIVATE ${CUDA_LIBRARIES})
+    target_include_directories(flashlight PRIVATE ${CUDA_INCLUDE_DIRS})
+  endif()
 
   if (FL_BUILD_PROFILING)
     # Try to find NVTX


### PR DESCRIPTION
- Build the `runtime` subcomponent before `common` and other components since it sets required configuration variables for related downstream compilation
- Explicitly link `cudart` in the `runtime` module since the consuming code is contained therein
- on some platforms, due to AF headers, cublas needs to be explicitly linked. This can be moved to `tensor/backend/af` down the road to keep the top level linking cleaner
- Use the new imported and portable `CUDA::cudart` `IMPORTED` target where possible, only falling back to `find_library` components when using a sufficiently old CMake version
Test plan: CI + local test