### PR TITLE
Fix gtest build with MSVC

### DIFF
--- a/cmake/BuildGoogleTest.cmake
+++ b/cmake/BuildGoogleTest.cmake
@@ -11,5 +11,8 @@ FetchContent_Declare(
   GIT_TAG        ${gtest_TAG}
 )
 
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE) # for Windows
+# For Windows
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+set(gmock_force_shared_crt ON CACHE BOOL "" FORCE)
+
 FetchContent_MakeAvailable(googletest)

--- a/cmake/TestUtils.cmake
+++ b/cmake/TestUtils.cmake
@@ -49,7 +49,7 @@ function(build_test)
     PUBLIC
     ${GTEST_IMPORTED_TARGETS}
     ${build_test_LIBS}
-     ${CMAKE_THREAD_LIBS_INIT}
+    ${CMAKE_THREAD_LIBS_INIT}
     )
   target_include_directories(
     ${target}
@@ -61,5 +61,13 @@ function(build_test)
     PUBLIC
     ${build_test_PREPROC}
     )
+  if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    target_compile_definitions(
+      ${target}
+      PUBLIC
+      GTEST_LINKED_AS_SHARED_LIBRARY=$<BOOL:${BUILD_SHARED_LIBS}>
+      GMOCK_LINKED_AS_SHARED_LIBRARY=$<BOOL:${BUILD_SHARED_LIBS}>
+    )
+  endif()
   gtest_add_tests(TARGET ${target})
 endfunction(build_test)


### PR DESCRIPTION
Unblocks building and running tests with Windows + MSVC.

Needs these shared crt options enabled to work when building shared libs/dlls, and needs compiler defs given some transitive header inclusion is sketchy.

Test plan: local test + toy Windows CI baseline