### PR TITLE
Add CI baseline for Emscripten/WASM build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
     defaults:
       run:
         shell: bash -l {0}
-    # if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'pull_request'
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v3
       

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,6 +95,7 @@ jobs:
             -DFL_USE_TENSOR_STUB=ON \
             -DFL_USE_ARRAYFIRE=OFF \
             -DFL_USE_ONEDNN=OFF \
+            -DFL_USE_CUDNN=OFF \
             -DFL_BUILD_DISTRIBUTED=OFF \
             -DFL_BUILD_EXAMPLES=ON
         

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,3 +70,28 @@ jobs:
       #     cd build
       #     ctest --output-on-failure -j 4
       #   if: matrix.backend == 'ArrayFire' && matrix.autograd_backend == 'oneDNN'
+
+  build_wasm:
+    name: "Build WebAssembly libraries with Emscripten compilers + Flashlight core + stub backend"
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: "Download and setup Emscripten"
+        run: |
+          git clone https://github.com/emscripten-core/emsdk.git
+          cd emsdk
+          ./emsdk install latest
+          ./emsdk activate latest
+          ./emsdk construct_env
+      
+      - name: "Build the Flashlight stub backend with Emscripten C compilers"
+        run: |
+          emcmake cmake -S . -B build -DBUILD_SHARED_LIBS=on \
+            -DFL_USE_TENSOR_STUB=ON \
+            -DFL_BUILD_DISTRIBUTED=OFF \
+            -DFL_BUILD_EXAMPLES=ON
+        

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,9 +91,10 @@ jobs:
       - name: "Build the Flashlight stub backend with Emscripten C compilers"
         run: |
           source ./emsdk/emsdk_env.sh
-          emcmake cmake -S . -B build -DBUILD_SHARED_LIBS=on \
+          emcmake cmake -S . -B build \
             -DFL_USE_TENSOR_STUB=ON \
             -DFL_USE_ARRAYFIRE=OFF \
+            -DFL_USE_ONEDNN=OFF \
             -DFL_BUILD_DISTRIBUTED=OFF \
             -DFL_BUILD_EXAMPLES=ON
         

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,13 +89,13 @@ jobs:
           ./emsdk activate latest
       
       - name: "Build the Flashlight stub backend with Emscripten C compilers"
+        # TODO: build and run tests with wasm once we have a runnable backend
         run: |
-          source ./emsdk/emsdk_env.sh
+          source ./emsdk/emsdk_env.sh # TODO: move me to setup step
           emcmake cmake -S . -B build \
             -DFL_USE_TENSOR_STUB=ON \
             -DFL_USE_ARRAYFIRE=OFF \
             -DFL_USE_ONEDNN=OFF \
             -DFL_USE_CUDNN=OFF \
             -DFL_BUILD_DISTRIBUTED=OFF \
-            -DFL_BUILD_EXAMPLES=ON
-        
+            -DFL_BUILD_EXAMPLES=ON        

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,6 +93,7 @@ jobs:
           source ./emsdk/emsdk_env.sh
           emcmake cmake -S . -B build -DBUILD_SHARED_LIBS=on \
             -DFL_USE_TENSOR_STUB=ON \
+            -DFL_USE_ARRAYFIRE=OFF \
             -DFL_BUILD_DISTRIBUTED=OFF \
             -DFL_BUILD_EXAMPLES=ON
         

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,7 @@ jobs:
     defaults:
       run:
         shell: bash -l {0}
+    # if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v3
       
@@ -86,10 +87,10 @@ jobs:
           cd emsdk
           ./emsdk install latest
           ./emsdk activate latest
-          ./emsdk construct_env
       
       - name: "Build the Flashlight stub backend with Emscripten C compilers"
         run: |
+          source ./emsdk/emsdk_env.sh
           emcmake cmake -S . -B build -DBUILD_SHARED_LIBS=on \
             -DFL_USE_TENSOR_STUB=ON \
             -DFL_BUILD_DISTRIBUTED=OFF \

--- a/flashlight/fl/common/CMakeLists.txt
+++ b/flashlight/fl/common/CMakeLists.txt
@@ -37,6 +37,6 @@ endif()
 # std::filesystem linking -- remove this when requiring gcc >= 9
 if (NOT MSVC)
   find_package(Filesystem REQUIRED COMPONENTS Final Experimental)
-  setup_install_find_module(${CMAKE_MODULE_PATH}/FindFilesystem.cmake)
+  setup_install_find_module(${PROJECT_SOURCE_DIR}/cmake/FindFilesystem.cmake)
   target_link_libraries(flashlight PUBLIC std::filesystem)
 endif()


### PR DESCRIPTION
Add a CI baseline to test building FL with Emscripten to generate WASM binaries.

Fix a straggler `${CMAKE_MODULE_PATH}` alone the way, which broke the build because the CMake toolchain that `emcc` uses appends a bunch paths to `CMAKE_MODULE_PATH`, which broke when we tried to move `FindFilesystem.cmake` at install time to multiple directories.

todo: give better error telemetry with `setup_install_find_module` failing if multiple paths are given or something malformed like happened here

Test plan: CI