### PR TITLE
Set smaller build parallelism for CircleCI core build jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -564,6 +564,7 @@ workflows:
               - platform: linux-arm
                 backend: arrayfire
                 autograd_backend: onednn
+                build_parallelism: ["8"]
 
       - build-flashlight-pkg:
           name: build-flashlight-pkg-<< matrix.pkg>>-<< matrix.platform >>-CUDA-<< matrix.backend >>+<< matrix.autograd_backend >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -324,6 +324,9 @@ commands:
         type: string
       autograd_backend:
         type: string
+      build_parallelism:
+        type: string
+        default: ""
     steps:
       - run:
           name: "Build Flashlight"
@@ -337,7 +340,7 @@ commands:
               -DFL_USE_ONEDNN=$([ "<< parameters.backend >>" == "onednn" ] || [ "<< parameters.autograd_backend >>" == "onednn" ] && echo "ON" || echo "OFF") \
               -DFL_BUILD_DISTRIBUTED=OFF \
               -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON
-            cmake --build build --parallel
+            cmake --build build --parallel << parameters.build_parallelism >>
 
   test-flashlight:
     parameters:
@@ -383,6 +386,9 @@ jobs:
         type: string
       autograd_backend:
         type: string
+      build_parallelism:
+        type: string
+        default: ""
     executor: << parameters.platform >>
     steps:
       - checkout
@@ -394,6 +400,7 @@ jobs:
           platform: << parameters.platform >>
           backend: << parameters.backend >>
           autograd_backend: << parameters.backend >>
+          build_parallelism: << parameters.build_parallelism >>
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -559,6 +559,7 @@ workflows:
               platform: [macos-arm, linux-arm]
               backend: [arrayfire, onednn]
               autograd_backend: [onednn]
+              build_parallelism: ["8"]
             exclude:
               - platform: linux-arm
                 backend: arrayfire

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -564,7 +564,7 @@ workflows:
               - platform: linux-arm
                 backend: arrayfire
                 autograd_backend: onednn
-                build_parallelism: ["8"]
+                build_parallelism: "8"
 
       - build-flashlight-pkg:
           name: build-flashlight-pkg-<< matrix.pkg>>-<< matrix.platform >>-CUDA-<< matrix.backend >>+<< matrix.autograd_backend >>


### PR DESCRIPTION
Switching to `macos.m1.medium.gen1` seems to result in OOM/infrastructure fails by default. Reduce build parallelism from CMake's high default to mitigate this

Test plan: CI