### PR TITLE
Automatically build a distributed backend based on tensor backend

### DIFF
--- a/flashlight/fl/distributed/CMakeLists.txt
+++ b/flashlight/fl/distributed/CMakeLists.txt
@@ -3,12 +3,32 @@ cmake_minimum_required(VERSION 3.16)
 option(FL_BUILD_DISTRIBUTED
   "Build distributed computation capabilities with Flashlight" ON)
 
-option(FL_USE_NCCL "Build with NCCL for distributed computation" OFF)
-option(FL_USE_GLOO "Build with Gloo for distributed computation" OFF)
+# Determine default build options
+if (APPLE)
+  # nccl has no macOS support (no CUDA)
+  set(_build_nccl_default FALSE)
+  # no gloo on macOS (https://github.com/facebookincubator/gloo/issues/262)
+  set(_build_gloo_default FALSE)
+else()
+  # Default building distributed backends to ON if using corresponding compute
+  # environment is enabled
+  set(_build_nccl_default ${FL_USE_CUDA})
+  set(_build_gloo_default ${FL_USE_CPU})
+endif()
+
+option(FL_USE_NCCL "Build with NCCL for distributed computation" ${_build_nccl_default})
+option(FL_USE_GLOO "Build with Gloo for distributed computation" ${_build_gloo_default})
 
 # TODO: relax this
 if (FL_USE_NCCL AND FL_USE_GLOO)
   message(STATUS "Cannot build multiple distributed backends simultaneously")
+endif()
+
+# If no distributed backend is enabled, don't build distributed (build stub)
+if (FL_BUILD_DISTRIBUTED AND NOT (FL_USE_NCCL OR FL_USE_GLOO))
+  message(WARNING "FL_BUILD_DISTRIBUTED is enabled but no distributed"
+    " backend was selected. Setting FL_BUILD_DISTRIBUTED to OFF.")
+  set(FL_BUILD_DISTRIBUTED OFF)
 endif()
 
 # Build option behavior is as follows:
@@ -23,23 +43,6 @@ endif()
 if (NOT FL_BUILD_DISTRIBUTED)
   # A stub impl that throws/executes noops for most distributed ops
   set(FL_DISTRIBUTED_STUB ON)
-else()
-  # If using CUDA, enable NCCL, else build with Gloo
-  if (FL_USE_CUDA)
-    message(STATUS
-      "CUDA support in Flashlight is enabled. Will build with NCCL support.")
-    set(FL_USE_NCCL ON)
-  elseif (FL_USE_CPU)
-    message(STATUS
-      "CPU support in Flashlight is enabled. Will build with Gloo support.")
-    set(FL_USE_GLOO ON)
-  elseif(FL_USE_TENSOR_STUB)
-    message(WARNING "Building detected using ONLY the tensor stub backend. "
-      "Disabling distributed support and building ONLY the "
-      "distributed stub backend.")
-    set(FL_BUILD_DISTRIBUTED OFF)
-    set(FL_DISTRIBUTED_STUB ON)
-  endif()
 endif()
 
 # Always build distributed API sources, even if building the stub backend.

--- a/flashlight/fl/distributed/CMakeLists.txt
+++ b/flashlight/fl/distributed/CMakeLists.txt
@@ -11,39 +11,57 @@ if (FL_USE_NCCL AND FL_USE_GLOO)
   message(STATUS "Cannot build multiple distributed backends simultaneously")
 endif()
 
-if (FL_BUILD_DISTRIBUTED)
-  # If using CUDA, enable NCCL, else build with Gloo
-  if (FL_USE_CUDA)
-    set(FL_USE_NCCL ON)
-  elseif (FL_USE_CPU)
-    set(FL_USE_GLOO ON)
-  endif()
-else()
+# Build option behavior is as follows:
+# - if FL_BUILD_DISTRIBUTED is OFF, do nothing and build the distributed
+#   stub backend. Build the distributed stub backend if building the
+#   tensor stub backend.
+# - if FL_BUILD_DISTRIBUTED is ON, defer to other build options to
+#   find and build other distributed training implementations:
+# - first, try to build the distributed backend(s) that correspond to the
+#   base runtime/compute environment (e.g. CUDA). Do so for all backends
+#   that are not explicitly disabled (e.g. FL_USE_X=OFF)
+if (NOT FL_BUILD_DISTRIBUTED)
   # A stub impl that throws/executes noops for most distributed ops
   set(FL_DISTRIBUTED_STUB ON)
-endif ()
-
-# Build sources only in distributed mode. Distributed headers will be included
-# regardless but usage of the APIs will fail to link if not enabled.
-# TODO: conditionally install headers?
-if (FL_BUILD_DISTRIBUTED OR FL_DISTRIBUTED_STUB)
-  target_sources(
-    flashlight
-    PRIVATE
-    ${CMAKE_CURRENT_LIST_DIR}/DistributedApi.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/FileStore.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/reducers/InlineReducer.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/reducers/CoalescingReducer.cpp
-    )
+else()
+  # If using CUDA, enable NCCL, else build with Gloo
+  if (FL_USE_CUDA)
+    message(STATUS
+      "CUDA support in Flashlight is enabled. Will build with NCCL support.")
+    set(FL_USE_NCCL ON)
+  elseif (FL_USE_CPU)
+    message(STATUS
+      "CPU support in Flashlight is enabled. Will build with Gloo support.")
+    set(FL_USE_GLOO ON)
+  elseif(FL_USE_TENSOR_STUB)
+    message(WARNING "Building detected using ONLY the tensor stub backend. "
+      "Disabling distributed support and building ONLY the "
+      "distributed stub backend.")
+    set(FL_BUILD_DISTRIBUTED OFF)
+    set(FL_DISTRIBUTED_STUB ON)
+  endif()
 endif()
 
+# Always build distributed API sources, even if building the stub backend.
+target_sources(
+  flashlight
+  PRIVATE
+  ${CMAKE_CURRENT_LIST_DIR}/DistributedApi.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/FileStore.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/reducers/InlineReducer.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/reducers/CoalescingReducer.cpp
+  )
+
+# Builds the dependency-free version of the distributed backend
 if (FL_DISTRIBUTED_STUB)
+  # Forces dispatch only to the stub backend
+  # TODO: relax this when tensor-based dispatch is available
   target_sources(
     flashlight
     PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/backend/stub/DistributedBackend.cpp
     )
-endif ()
+endif()
 
 # ----------------------------- Dependencies -----------------------------
 # MPI is required for any distributed support

--- a/flashlight/fl/distributed/CMakeLists.txt
+++ b/flashlight/fl/distributed/CMakeLists.txt
@@ -3,8 +3,10 @@ cmake_minimum_required(VERSION 3.16)
 option(FL_BUILD_DISTRIBUTED
   "Build distributed computation capabilities with Flashlight" ON)
 
-# Determine default build options
-if (APPLE)
+# Determine build option defaults
+if (APPLE OR NOT FL_BUILD_DISTRIBUTED)
+  # If FL_BUILD_DISTRIBUTED is OFF (i.e. it was explicitly disabled since
+  # it defaults to ON), don't build appropriate distributed backends
   # nccl has no macOS support (no CUDA)
   set(_build_nccl_default FALSE)
   # no gloo on macOS (https://github.com/facebookincubator/gloo/issues/262)

--- a/flashlight/fl/tensor/backend/onednn/CMakeLists.txt
+++ b/flashlight/fl/tensor/backend/onednn/CMakeLists.txt
@@ -11,14 +11,18 @@ else()
   message(STATUS "oneDNN found")
 endif()
 
+# TODO: conditionally set this to use OPENCL is the detected
+# DNNL is built with OpenCL support
+fl_set_backend_state(ENABLE CPU) # enables FL_USE_CPU
+
 # ----------------------------- Sources -----------------------------
 find_package(MKL)
 if (NOT MKL_FOUND)
-  message(STATUS "Using std random generator")
-  set(${FL_USE_MKL_RNG}    FALSE)
+  message(STATUS "Using stdlib random number generation")
+  set(${FL_USE_MKL_RNG} FALSE)
 else()
-  set(${FL_USE_MKL_RNG}    TRUE)
-  message(STATUS "MKL found")
+  message(STATUS "MKL found - will use for random number generation")
+  set(${FL_USE_MKL_RNG} TRUE)
 endif()
 
 target_compile_definitions(


### PR DESCRIPTION
New build option behavior for distributed is:
- if `FL_BUILD_DISTRIBUTED` is `OFF`, do nothing and build the distributed stub backend
- if `FL_BUILD_DISTRIBUTED` is `ON`, defer to other build options to find and build other distributed training implementations:
  - if no distributed backends are explicitly specified as `ON` to build, set `FL_BUILD_DISTRIBUTED` to `OFF` and build the stub backend
  - otherwise, default the build implementations to `ON` based on backend support (e.g. NCCL for CUDA)

This ensures that distributed backends are always built matching the corresponding tensor backends if

Test plan: Local test + CI +
```bash
cmake -S . -B build -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Debug \
    -DFL_USE_ARRAYFIRE=OFF \
    -DFL_ARRAYFIRE_USE_CPU=OFF \
    -DFL_USE_ONEDNN=ON \
    -DFL_USE_TENSOR_STUB=OFF -DFL_USE_CUDNN=OFF \ # toggle stub to on
    -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON -DDNNL_DIR=/private/home/jacobkahn/usr/lib/cmake/dnnl
```
^ builds the distributed backend with NCCL, which it tries and succeeds in finding NCCL. Whereas:
```bash
(base) ➜  flashlight git:(distributed_build_option) cmake -S . -B build -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Debug \
    -DFL_USE_ARRAYFIRE=OFF \
    -DFL_ARRAYFIRE_USE_CPU=OFF \
    -DFL_USE_ONEDNN=ON \
    -DFL_USE_TENSOR_STUB=OFF -DFL_USE_CUDNN=OFF \
    -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON -DDNNL_DIR=/private/home/jacobkahn/usr/lib/cmake/dnnl \
    -DFL_USE_NCCL=OFF \
    -DFL_USE_GLOO=OFF
```
shows
```
CMake Warning at flashlight/fl/distributed/CMakeLists.txt:29 (message):
  FL_BUILD_DISTRIBUTED is enabled but no distributed backend was selected.
  Setting FL_BUILD_DISTRIBUTED to OFF.
```

<!-- readthedocs-preview fl start -->
----
:books: Documentation preview :books:: https://fl--1133.org.readthedocs.build/en/1133/

<!-- readthedocs-preview fl end -->