### PR TITLE
Add distributed comms library baselines to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,7 +195,7 @@ commands:
             equal: ["windows", << parameters.platform >>]
           steps:
             - run:
-                name: "Install cuDNN 8.5.0.96 for CUDA 11.2"
+                name: "Install cuDNN 8.1.1.33 for CUDA 11.2"
                 command: |
                   cd $HOME
                   export CUDNN_ZIP=cudnn-11.2-windows-x64-v8.1.1.33.zip
@@ -203,6 +203,55 @@ commands:
                   unzip $CUDNN_ZIP && rm $CUDNN_ZIP
                   cp -r cuda/* "$CUDA_ROOT"
                   rm -rf cuda/
+
+  install-mpi:
+    parameters:
+      platform:
+        type: string
+    steps:
+      - when:
+          condition:
+            equal: ["linux", << parameters.platform >>]
+          steps:
+            - run:
+                name: "Install OpenMPI"
+                command: |
+                  sudo apt update
+                  sudo apt install -y openmpi-bin libopenmpi-dev
+      - when:
+          condition:
+            equal: ["windows", << parameters.platform >>]
+          steps:
+            - run:
+                name: "Install Microsoft MPI"
+                command: |
+                  cd $HOME
+                  export MS_MPI_SETUP=msmpisetup.exe
+                  export MS_MPI_SDK=msmpisdk.msi
+                  wget --quiet https://github.com/microsoft/Microsoft-MPI/releases/download/v10.1.1/$MS_MPI_SETUP
+                  wget --quiet https://github.com/microsoft/Microsoft-MPI/releases/download/v10.1.1/$MS_MPI_SDK
+                  ./msmpisetup.exe -unattend
+                  sleep 7 # wait for the installer to finish
+                  msiexec //quiet //i msmpisdk.msi
+
+  install-nccl:
+    parameters:
+      platform:
+        type: string
+    steps:
+      - when:
+          condition:
+            equal: ["linux", << parameters.platform >>]
+          steps:
+            - run:
+                name: "Install NCCL 2.7.8 for CUDA 11.1"
+                command: |
+                  cd /tmp
+                  export NCCL2_DEB=libnccl2_2.7.8-1+cuda11.1_amd64.deb
+                  export LIBNCCL_DEV_DEB=libnccl-dev_2.7.8-1+cuda11.1_amd64.deb
+                  wget --quiet https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu2004/x86_64/$NCCL2_DEB
+                  wget --quiet https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu2004/x86_64/$LIBNCCL_DEV_DEB
+                  sudo dpkg -i $NCCL2_DEB $LIBNCCL_DEV_DEB
 
   install-onednn:
     parameters:
@@ -254,6 +303,8 @@ commands:
         type: string
       autograd_backend:
         type: string
+      distributed_backend:
+        type: string
     steps:
       - install-build-dependencies:
           platform: << parameters.platform >>
@@ -270,6 +321,21 @@ commands:
             equal: ["cudnn", << parameters.autograd_backend >>]
           steps:
             - install-cudnn:
+                platform: << parameters.platform >>
+      - when:
+          condition:
+            not:
+              or:
+                - equal: ["", << parameters.distributed_backend >>]
+                - equal: ["Stub", << parameters.distributed_backend >>]
+          steps:
+            - install-mpi:
+                platform: << parameters.platform >>
+      - when:
+          condition:
+            equal: ["nccl", << parameters.distributed_backend >>]
+          steps:
+            - install-nccl:
                 platform: << parameters.platform >>
       - when:
           condition:
@@ -324,6 +390,8 @@ commands:
         type: string
       autograd_backend:
         type: string
+      distributed_backend:
+        type: string
       build_parallelism:
         type: string
         default: ""
@@ -338,7 +406,8 @@ commands:
               -DFL_ARRAYFIRE_USE_CPU=$([ "<< parameters.platform >>" == "macos-arm" ] || [ "<< parameters.platform >>" == "linux-arm" ] && echo "ON" || echo "OFF") \
               -DFL_USE_CUDNN=$([ "<< parameters.autograd_backend >>" == "cudnn" ] && echo "ON" || echo "OFF") \
               -DFL_USE_ONEDNN=$([ "<< parameters.backend >>" == "onednn" ] || [ "<< parameters.autograd_backend >>" == "onednn" ] && echo "ON" || echo "OFF") \
-              -DFL_BUILD_DISTRIBUTED=OFF \
+              -DFL_USE_NCCL=$(([ "<< parameters.platform >>" == "linux" ] || [ "<< parameters.platform >>" == "windows" ]) && [ "<< parameters.distributed_backend >>" == "nccl" ] && echo "ON" || echo "OFF") \
+              -DFL_USE_GLOO=OFF \
               -DFL_USE_BACKWARD_CPP=ON \
               -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON
             cmake --build build --parallel << parameters.build_parallelism >>
@@ -387,6 +456,9 @@ jobs:
         type: string
       autograd_backend:
         type: string
+      distributed_backend:
+        type: string
+        default: ""
       build_parallelism:
         type: string
         default: ""
@@ -397,10 +469,12 @@ jobs:
           platform: << parameters.platform >>
           backend: << parameters.backend >>
           autograd_backend: << parameters.autograd_backend >>
+          distributed_backend: << parameters.distributed_backend >>
       - build-flashlight-core:
           platform: << parameters.platform >>
           backend: << parameters.backend >>
           autograd_backend: << parameters.backend >>
+          distributed_backend: << parameters.distributed_backend >>
           build_parallelism: << parameters.build_parallelism >>
       - persist_to_workspace:
           root: .
@@ -415,12 +489,15 @@ jobs:
         type: string
       autograd_backend:
         type: string
+      distributed_backend:
+        type: string
     executor: << parameters.platform >>
     steps:
       - install-all-dependencies:
           platform: << parameters.platform >>
           backend: << parameters.backend >>
           autograd_backend: << parameters.autograd_backend >>
+          distributed_backend: << parameters.distributed_backend >>
       # attach the project root and build directory
       - attach_workspace:
           at: .
@@ -438,6 +515,8 @@ jobs:
         type: string
       autograd_backend:
         type: string
+      distributed_backend:
+        type: string
       build_parallelism:
         type: string
         default: ""
@@ -447,6 +526,7 @@ jobs:
           platform: << parameters.platform >>
           backend: << parameters.backend >>
           autograd_backend: << parameters.autograd_backend >>
+          distributed_backend: << parameters.distributed_backend >>
       - install-pkg-dependencies:
           pkg: << parameters.pkg >>
           platform: << parameters.platform >>
@@ -477,12 +557,15 @@ jobs:
         type: string
       autograd_backend:
         type: string
+      distributed_backend:
+        type: string
     executor: << parameters.platform >>
     steps:
       - install-all-dependencies:
           platform: << parameters.platform >>
           backend: << parameters.backend >>
           autograd_backend: << parameters.autograd_backend >>
+          distributed_backend: << parameters.distributed_backend >>
       - install-pkg-dependencies:
           pkg: << parameters.pkg >>
           platform: << parameters.platform >>
@@ -505,6 +588,9 @@ jobs:
       autograd_backend:
         type: string
         default: cudnn
+      distributed_backend:
+        type: string
+        default: nccl
       build_parallelism:
         type: string
         default: ""
@@ -514,6 +600,7 @@ jobs:
           platform: << parameters.platform >>
           backend: << parameters.backend >>
           autograd_backend: << parameters.autograd_backend >>
+          distributed_backend: << parameters.distributed_backend >>
       - install-pkg-dependencies:
           pkg: << parameters.pkg >>
           platform: << parameters.platform >>
@@ -535,23 +622,31 @@ workflows:
   build-and-test:
     jobs:
       - build-flashlight-core:
-          name: build-flashlight-core-<< matrix.platform >>-CUDA-<< matrix.backend >>+<< matrix.autograd_backend >>
+          name: build-flashlight-core-<< matrix.platform >>-CUDA-<< matrix.backend >>+<< matrix.autograd_backend >>+<< matrix.distributed_backend >>
           matrix:
             parameters:
               platform: [linux, windows]
               backend: [arrayfire]
               autograd_backend: [cudnn]
+              distributed_backend: ["", nccl]
+            exclude:
+              # No NCCL support on Windows
+              - platform: windows
+                backend: arrayfire
+                autograd_backend: cudnn
+                distributed_backend: nccl
 
       - test-flashlight-core:
-          name: test-flashlight-core-<< matrix.platform >>-CUDA-<< matrix.backend >>+<< matrix.autograd_backend >>
+          name: test-flashlight-core-<< matrix.platform >>-CUDA-<< matrix.backend >>+<< matrix.autograd_backend >>+<< matrix.distributed_backend >>
           matrix:
             # Not running all tests with all configurations yet
             parameters:
               platform: [linux]
               backend: [arrayfire]
               autograd_backend: [cudnn]
+              distributed_backend: [nccl]
           requires:
-            - build-flashlight-core-<< matrix.platform >>-CUDA-<< matrix.backend >>+<< matrix.autograd_backend >>
+            - build-flashlight-core-<< matrix.platform >>-CUDA-<< matrix.backend >>+<< matrix.autograd_backend >>+<< matrix.distributed_backend >>
 
       - build-flashlight-core:
           name: build-flashlight-core-<< matrix.platform >>-CPU-<< matrix.backend >>+<< matrix.autograd_backend >>
@@ -568,40 +663,43 @@ workflows:
                 build_parallelism: "8"
 
       - build-flashlight-pkg:
-          name: build-flashlight-pkg-<< matrix.pkg>>-<< matrix.platform >>-CUDA-<< matrix.backend >>+<< matrix.autograd_backend >>
+          name: build-flashlight-pkg-<< matrix.pkg>>-<< matrix.platform >>-CUDA-<< matrix.backend >>+<< matrix.autograd_backend >>+<< matrix.distributed_backend >>
           matrix:
             parameters:
               pkg: [runtime, speech, vision, text]
               platform: [linux]
               backend: [arrayfire]
               autograd_backend: [cudnn]
+              distributed_backend: [nccl]
               build_parallelism: ["8"]
           requires:
-            - build-flashlight-core-<< matrix.platform >>-CUDA-<< matrix.backend >>+<< matrix.autograd_backend >>
+            - build-flashlight-core-<< matrix.platform >>-CUDA-<< matrix.backend >>+<< matrix.autograd_backend >>+<< matrix.distributed_backend >>
 
       # only run pkg builds and tests for best-supported platforms for now
       - test-flashlight-pkg:
-          name: test-flashlight-pkg-<< matrix.pkg>>-<< matrix.platform >>-CUDA-<< matrix.backend >>+<< matrix.autograd_backend >>
+          name: test-flashlight-pkg-<< matrix.pkg>>-<< matrix.platform >>-CUDA-<< matrix.backend >>+<< matrix.autograd_backend >>+<< matrix.distributed_backend >>
           matrix:
             parameters:
               pkg: [runtime, speech, vision, text]
               platform: [linux]
               backend: [arrayfire]
               autograd_backend: [cudnn]
+              distributed_backend: [nccl]
           requires:
-            - build-flashlight-pkg-<< matrix.pkg >>-<< matrix.platform >>-CUDA-<< matrix.backend >>+<< matrix.autograd_backend >>
+            - build-flashlight-pkg-<< matrix.pkg >>-<< matrix.platform >>-CUDA-<< matrix.backend >>+<< matrix.autograd_backend >>+<< matrix.distributed_backend >>
 
       # only run app builds for best-supported platforms for now
       - build-flashlight-apps-for-pkg:
-          name: build-flashlight-apps-for-pkg-<< matrix.pkg>>-<< matrix.platform >>-CUDA-<< matrix.backend >>+<< matrix.autograd_backend >>
+          name: build-flashlight-apps-for-pkg-<< matrix.pkg>>-<< matrix.platform >>-CUDA-<< matrix.backend >>+<< matrix.autograd_backend >>+<< matrix.distributed_backend >>
           matrix:
             parameters:
               pkg: [runtime, speech, vision, text]
               platform: [linux]
               backend: [arrayfire]
               autograd_backend: [cudnn]
+              distributed_backend: [nccl]
               build_parallelism: ["8"]
           requires:
-            - build-flashlight-pkg-<< matrix.pkg >>-<< matrix.platform >>-CUDA-<< matrix.backend >>+<< matrix.autograd_backend >>
+            - build-flashlight-pkg-<< matrix.pkg >>-<< matrix.platform >>-CUDA-<< matrix.backend >>+<< matrix.autograd_backend >>+<< matrix.distributed_backend >>
 
       # TODO: eventually add macOS and Linux arm64 baselines for pkg/app

--- a/.github/actions/install_core_deps/action.yml
+++ b/.github/actions/install_core_deps/action.yml
@@ -5,8 +5,11 @@ inputs:
     required: true
     description: "Tensor backend to install"
   autograd_backend:
-    required: true
+    required: false
     description: "Autograd backend backend to install"
+  distributed_backend:
+    required: false
+    description: "Distributed backend dependencies to install."
 
 runs:
   using: "composite"
@@ -45,3 +48,10 @@ runs:
         channels: conda-forge
         extra-specs: onednn=2.7.2
       if: inputs.backend == 'oneDNN' || inputs.autograd_backend == 'oneDNN'
+    # MPI
+    - name: "Install OpenMPI (Linux)"
+      run: |
+        sudo apt update
+        sudo apt install -y openmpi-bin libopenmpi-dev
+      if: runner.os == 'Linux' && inputs.distributed_backend != '' && inputs.distributed_backend != 'Stub'
+      shell: bash -l {0}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,13 +4,29 @@ on: [push, pull_request]
 
 jobs:
   build_core:
-    name: "Build on ${{ matrix.os }} | tensor: ${{ matrix.backend }} | autograd: ${{ matrix.autograd_backend }}"
+    name: "Build on ${{ matrix.os }} | tensor: ${{ matrix.backend }} | autograd: ${{ matrix.autograd_backend }} | distributed: ${{ matrix.distributed_backend }}"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-20.04, windows-2022, macOS-12]
         backend: [ArrayFire, oneDNN, Stub]
         autograd_backend: [oneDNN]
+        distributed_backend: [Stub]
+        exclude:
+          # no Gloo support on macOS and Windows
+          - os: macOS-12
+            distributed_backend: Gloo
+          - os: windows-2022
+            distributed_backend: Gloo
+        include:
+          - os: ubuntu-20.04
+            backend: oneDNN
+            autograd_backend: oneDNN
+            distributed_backend: Gloo
+          # Configuration using only stubs and no autograd backend
+          - os: ubuntu-20.04
+            backend: Stub
+            distributed_backend: Stub
     defaults:
       run:
         shell: bash -l {0}
@@ -20,10 +36,9 @@ jobs:
 
       - uses: ./.github/actions/install_core_deps
         with:
-          runner: ${{ matrix.os }}
-          os: ${{ runner.os }}
           backend: ${{ matrix.backend }}
           autograd_backend: ${{ matrix.autograd_backend }}
+          distributed_backend: ${{ matrix.distributed_backend }}
 
       - name: "Configure Flashlight"
         run: |
@@ -32,7 +47,8 @@ jobs:
             -DFL_ARRAYFIRE_USE_CPU=${{ matrix.backend == 'ArrayFire' && 'ON' || 'OFF'  }} \
             -DFL_USE_ONEDNN=${{ (matrix.backend == 'oneDNN' || matrix.autograd_backend == 'oneDNN') && 'ON' || 'OFF'  }} \
             -DFL_USE_TENSOR_STUB=${{ matrix.backend == 'Stub' && 'ON' || 'OFF'  }} \
-            -DFL_BUILD_DISTRIBUTED=OFF \
+            -DFL_USE_NCCL=OFF \
+            -DFL_USE_GLOO=${{ matrix.distributed_backend == 'Gloo' && 'ON' || 'OFF'  }} \
             -DFL_USE_BACKWARD_CPP=ON \
             -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON
       - name: "Build Flashlight"


### PR DESCRIPTION
Add NCCL and Gloo baselines to CI. Gloo is built from source via CMake `FetchContent` since it doesn't have a standard install procedure.

Test plan: CI

<!-- readthedocs-preview fl start -->
----
:books: Documentation preview :books:: https://fl--1134.org.readthedocs.build/en/1134/

<!-- readthedocs-preview fl end -->