### PR TITLE
Reduce GPU instance size on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ version: 2.1
 gpu: &gpu
   machine:
     image: ubuntu-2004-cuda-11.4:202110-01
-  resource_class: gpu.nvidia.large
+  resource_class: gpu.nvidia.medium
 
 orbs:
   win: circleci/windows@5.0.0
@@ -18,7 +18,7 @@ executors:
   linux:
     machine:
       image: ubuntu-2004-cuda-11.4:202110-01
-    resource_class: gpu.nvidia.large
+    resource_class: gpu.nvidia.medium
   windows:
     machine:
       image: windows-server-2019-nvidia:stable


### PR DESCRIPTION
See title. Move away from a `gpu.nvidia.large` to `gpu.nvidia.medium`.

<!-- readthedocs-preview fl start -->
----
:books: Documentation preview :books:: https://fl--1140.org.readthedocs.build/en/1140/

<!-- readthedocs-preview fl end -->