### PR TITLE
Remove some uses of deprecated ArrayFire reductions

### DIFF
--- a/flashlight/fl/tensor/backend/af/ArrayFireReductions.cpp
+++ b/flashlight/fl/tensor/backend/af/ArrayFireReductions.cpp
@@ -224,17 +224,18 @@ Tensor ArrayFireBackend::var(
     const std::vector<int>& axes,
     const bool bias,
     const bool keepDims) {
+  af_var_bias biasMode = bias ? AF_VARIANCE_SAMPLE : AF_VARIANCE_POPULATION;
   // Use ArrayFire default for one dimension which may be optimized
   auto& arr = toArray(input);
   // Reduce along all axes returning a singleton tensor
   // TODO: modify this to af::var<af::array> to take advantage of the
   // ArrayFire reduce_all kernels once available
   if (isAllAxisReduction(input, axes)) {
-    double out = af::var<double>(toArray(input), bias);
+    double out = af::var<double>(toArray(input), biasMode);
     return toTensor<ArrayFireTensor>(af::constant(out, 1), /* numDims = */ 0);
   } else if (axes.size() == 1) {
     return toTensor<ArrayFireTensor>(
-        detail::condenseIndices(af::var(arr, bias, axes[0]), keepDims),
+        detail::condenseIndices(af::var(arr, biasMode, axes[0]), keepDims),
         getReducedNumDims(input.ndim(), axes.size(), keepDims));
   } else {
     auto meanArr = mean(input, axes, /* keepDims = */ true);
@@ -263,21 +264,21 @@ Tensor ArrayFireBackend::std(
     const Tensor& input,
     const std::vector<int>& axes,
     const bool keepDims) {
-  // TODO: add a bias parameter and `bias ? AF_VARIANCE_SAMPLE :
-  // AF_VARIANCE_POPULATION` when requiring to a minimum ArrayFire version that
-  // has updated variance and stdev functions
+  const bool bias = false; // TODO: make this configurable
+  af_var_bias biasMode = bias ? AF_VARIANCE_SAMPLE : AF_VARIANCE_POPULATION;
   if (isAllAxisReduction(input, axes)) {
     // TODO: update to af::stdev<af::array> once specialization is available
-    double out = af::stdev<double>(toArray(input));
+    double out = af::stdev<double>(toArray(input), biasMode);
     return toTensor<ArrayFireTensor>(af::constant(out, 1), /* numDims = */ 0);
   } else if (axes.size() == 1) {
     // Use arrayfire default for one dimension which may be optimized
     // TODO: update this? stddev is deprecated.
     return toTensor<ArrayFireTensor>(
-        detail::condenseIndices(af::stdev(toArray(input), axes[0]), keepDims),
+        detail::condenseIndices(
+            af::stdev(toArray(input), biasMode, axes[0]), keepDims),
         getReducedNumDims(input.ndim(), axes.size(), keepDims));
   }
-  return this->sqrt(this->var(input, axes, /* bias = */ false, keepDims));
+  return this->sqrt(this->var(input, axes, /* bias = */ bias, keepDims));
 }
 
 Tensor ArrayFireBackend::norm(

--- a/flashlight/fl/test/tensor/TensorBinaryOpsTest.cpp
+++ b/flashlight/fl/test/tensor/TensorBinaryOpsTest.cpp
@@ -307,40 +307,36 @@ TEST(TensorBinaryOpsTest, BinaryOperatorIncompatibleShapes) {
   auto testTensorIncompatibleShapes = [](dtype type,
                                          const Tensor& lhs,
                                          const Tensor& rhs) {
-    ASSERT_THROW((void)(lhs + rhs), std::invalid_argument) << "dtype: " << type;
-    ASSERT_THROW((void)(lhs - rhs), std::invalid_argument) << "dtype: " << type;
-    ASSERT_THROW((void)(lhs * rhs), std::invalid_argument) << "dtype: " << type;
-    ASSERT_THROW((void)(lhs / rhs), std::invalid_argument) << "dtype: " << type;
-    ASSERT_THROW((void)(lhs == rhs), std::invalid_argument)
+    ASSERT_THROW(Values(lhs + rhs), std::invalid_argument) << "dtype: " << type;
+    ASSERT_THROW(Values(lhs - rhs), std::invalid_argument) << "dtype: " << type;
+    ASSERT_THROW(Values(lhs * rhs), std::invalid_argument) << "dtype: " << type;
+    ASSERT_THROW(Values(lhs / rhs), std::invalid_argument) << "dtype: " << type;
+    ASSERT_THROW(Values(lhs == rhs), std::invalid_argument)
         << "dtype: " << type;
-    ASSERT_THROW((void)(lhs != rhs), std::invalid_argument)
+    ASSERT_THROW(Values(lhs != rhs), std::invalid_argument)
         << "dtype: " << type;
-    ASSERT_THROW((void)(lhs < rhs), std::invalid_argument) << "dtype: " << type;
-    ASSERT_THROW((void)(lhs <= rhs), std::invalid_argument)
+    ASSERT_THROW(Values(lhs < rhs), std::invalid_argument) << "dtype: " << type;
+    ASSERT_THROW(Values(lhs <= rhs), std::invalid_argument)
         << "dtype: " << type;
-    ASSERT_THROW((void)(lhs > rhs), std::invalid_argument) << "dtype: " << type;
-    ASSERT_THROW((void)(lhs >= rhs), std::invalid_argument)
+    ASSERT_THROW(Values(lhs > rhs), std::invalid_argument) << "dtype: " << type;
+    ASSERT_THROW(Values(lhs >= rhs), std::invalid_argument)
         << "dtype: " << type;
-    ASSERT_THROW((void)(lhs || rhs), std::invalid_argument)
+    ASSERT_THROW(Values(lhs || rhs), std::invalid_argument)
         << "dtype: " << type;
-    ASSERT_THROW((void)(lhs && rhs), std::invalid_argument)
+    ASSERT_THROW(Values(lhs && rhs), std::invalid_argument)
         << "dtype: " << type;
     // TODO ArrayFire needs software impl for fp16 modulo on CUDA backend;
     // bring this test back when supported.
     if (type != dtype::f16) {
-      ASSERT_THROW((void)(lhs % rhs), std::invalid_argument)
+      ASSERT_THROW(Values(lhs % rhs), std::invalid_argument)
           << "dtype: " << type;
     }
     // these operators are generally not well-defined for fps
     if (type != dtype::f16 && type != dtype::f32 && type != dtype::f64) {
-      ASSERT_THROW((void)(lhs | rhs), std::invalid_argument)
-          << "dtype: " << type;
-      ASSERT_THROW((void)(lhs ^ rhs), std::invalid_argument)
-          << "dtype: " << type;
-      ASSERT_THROW((void)(lhs << rhs), std::invalid_argument)
-          << "dtype: " << type;
-      ASSERT_THROW((void)(lhs >> rhs), std::invalid_argument)
-          << "dtype: " << type;
+      ASSERT_THROW(lhs | rhs, std::invalid_argument) << "dtype: " << type;
+      ASSERT_THROW(lhs ^ rhs, std::invalid_argument) << "dtype: " << type;
+      ASSERT_THROW(lhs << rhs, std::invalid_argument) << "dtype: " << type;
+      ASSERT_THROW(lhs >> rhs, std::invalid_argument) << "dtype: " << type;
     }
   };
 
@@ -503,7 +499,7 @@ TEST(TensorBinaryOpsTest, powerDouble) {
 }
 
 int main(int argc, char** argv) {
-  ::testing::InitGoogleTest(&argc, argv);
+  InitGoogleTest(&argc, argv);
   fl::init();
   return RUN_ALL_TESTS();
 }

--- a/flashlight/fl/test/tensor/TensorBinaryOpsTest.cpp
+++ b/flashlight/fl/test/tensor/TensorBinaryOpsTest.cpp
@@ -333,10 +333,14 @@ TEST(TensorBinaryOpsTest, BinaryOperatorIncompatibleShapes) {
     }
     // these operators are generally not well-defined for fps
     if (type != dtype::f16 && type != dtype::f32 && type != dtype::f64) {
-      ASSERT_THROW(lhs | rhs, std::invalid_argument) << "dtype: " << type;
-      ASSERT_THROW(lhs ^ rhs, std::invalid_argument) << "dtype: " << type;
-      ASSERT_THROW(lhs << rhs, std::invalid_argument) << "dtype: " << type;
-      ASSERT_THROW(lhs >> rhs, std::invalid_argument) << "dtype: " << type;
+      ASSERT_THROW(Values(lhs | rhs), std::invalid_argument)
+          << "dtype: " << type;
+      ASSERT_THROW(Values(lhs ^ rhs), std::invalid_argument)
+          << "dtype: " << type;
+      ASSERT_THROW(Values(lhs << rhs), std::invalid_argument)
+          << "dtype: " << type;
+      ASSERT_THROW(Values(lhs >> rhs), std::invalid_argument)
+          << "dtype: " << type;
     }
   };
 

--- a/flashlight/fl/test/tensor/af/ArrayFireTensorBaseTest.cpp
+++ b/flashlight/fl/test/tensor/af/ArrayFireTensorBaseTest.cpp
@@ -343,34 +343,37 @@ TEST(ArrayFireTensorBaseTest, median) {
 }
 
 TEST(ArrayFireTensorBaseTest, var) {
+  const bool bias = false;
+  af_var_bias biasMode = bias ? AF_VARIANCE_SAMPLE : AF_VARIANCE_POPULATION;
   auto a = fl::rand({3, 3});
-  ASSERT_EQ(fl::var(a).scalar<float>(), af::var<float>(toArray(a)));
+  ASSERT_EQ(fl::var(a).scalar<float>(), af::var<float>(toArray(a), biasMode));
   ASSERT_TRUE(allClose(
       toArray(fl::var(a, {0})),
-      detail::condenseIndices(af::var(toArray(a), /* biased = */ false, 0))));
+      detail::condenseIndices(af::var(toArray(a), /* mode = */ biasMode, 0))));
   ASSERT_TRUE(allClose(
       toArray(fl::var(a, {1})),
-      detail::condenseIndices(af::var(toArray(a), /* biased = */ false, 1))));
+      detail::condenseIndices(af::var(toArray(a), /* mode = */ biasMode, 1))));
   // Make sure multidimension matches computing for all
   ASSERT_FLOAT_EQ(
-      toArray(fl::var(a)).scalar<float>(), af::var<float>(toArray(a)));
+      toArray(fl::var(a)).scalar<float>(),
+      af::var<float>(toArray(a), biasMode));
   ASSERT_FLOAT_EQ(
       toArray(fl::var(a, {0, 1}, /* biased = */ true)).scalar<float>(),
-      af::var<float>(toArray(a), /* biased = */ true));
+      af::var<float>(toArray(a), /* mode = */ AF_VARIANCE_SAMPLE));
 }
 
 TEST(ArrayFireTensorBaseTest, std) {
   auto a = fl::rand({3, 3});
   ASSERT_TRUE(allClose(
       toArray(fl::std(a, {0}, /* keepDims = */ true)),
-      af::stdev(toArray(a), 0)));
+      af::stdev(toArray(a), AF_VARIANCE_POPULATION, 0)));
   ASSERT_TRUE(allClose(
       toArray(fl::std(a, {1}, /* keepDims = */ true)),
-      af::stdev(toArray(a), 1)));
+      af::stdev(toArray(a), AF_VARIANCE_POPULATION, 1)));
   // Make sure multidimension matches computing for all
   ASSERT_FLOAT_EQ(
       toArray(fl::std(a, {0, 1})).scalar<float>(),
-      std::sqrt(af::var<float>(toArray(a))));
+      std::sqrt(af::var<float>(toArray(a), AF_VARIANCE_POPULATION)));
 }
 
 TEST(ArrayFireTensorBaseTest, norm) {

--- a/flashlight/fl/test/tensor/af/MemoryFrameworkTest.cpp
+++ b/flashlight/fl/test/tensor/af/MemoryFrameworkTest.cpp
@@ -311,7 +311,7 @@ TEST(MemoryFramework, AdapterInstallerDeviceInterfaceTest) {
       EXPECT_CALL(*mockMemoryManager, alloc(/* user lock */ true, 1, _, 1))
           .Times(Exactly(1));
       size_t aSize = 8;
-      void* a = af::alloc(aSize, af::dtype::f32);
+      void* a = af::allocV2(aSize * af::getSizeOf(af::dtype::f32));
       // Allocated memory should properly appear in our internal data structures
       // given correct passage of state
       EXPECT_EQ(memoryManager->lockedPtrToSizeMap.size(), 1);
@@ -354,7 +354,7 @@ TEST(MemoryFramework, AdapterInstallerDeviceInterfaceTest) {
       // unlock with user-locked memory (since we used af::alloc)
       EXPECT_CALL(*mockMemoryManager, unlock(a, /* user lock */ true))
           .Times(Exactly(1));
-      af::free(a);
+      af::freeV2(a);
       // Internal data structures should be updated accordingly to reflect
       // removal of a buffer
       EXPECT_EQ(memoryManager->totalBytes, aSize * sizeof(float) + b.bytes());
@@ -404,9 +404,10 @@ TEST(MemoryFramework, AdapterInstallerDeviceInterfaceTest) {
     EXPECT_CALL(*mockMemoryManager, unlock(_, _)).Times(Exactly(0));
     dim_t cDim = 4;
     size_t pSize = 8;
-    auto c = af::randu({cDim, cDim});
-    void* p = af::alloc(pSize, af::dtype::f32);
-    af::free(p);
+    const af::dtype type = af::dtype::f32;
+    auto c = af::randu({cDim, cDim}, type);
+    void* p = af::allocV2(pSize * af::getSizeOf(type));
+    af::freeV2(p);
   }
   // The custom memory is destroyed; check that the log stream, which is flushed
   // on destruction, contains the correct output
@@ -433,9 +434,10 @@ TEST(MemoryFramework, AdapterInstallerDeviceInterfaceTest) {
   // been destroyed and its function pointers and closures invalidated
   dim_t cDim = 4;
   size_t pSize = 8;
-  auto c = af::randu({cDim, cDim});
-  void* p = af::alloc(pSize, af::dtype::f32);
-  af::free(p);
+  const af::dtype type = af::dtype::f32;
+  auto c = af::randu({cDim, cDim}, type);
+  void* p = af::allocV2(pSize * af::getSizeOf(type));
+  af::freeV2(p);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
See title. `af::var` and `af::stdev` without a mode has been deprecated for some time. Remove usages throughout.

Test plan: local build, CI

<!-- readthedocs-preview fl start -->
----
:books: Documentation preview :books:: https://fl--1143.org.readthedocs.build/en/1143/

<!-- readthedocs-preview fl end -->