### PR TITLE
Fix mamba install in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -279,7 +279,7 @@ commands:
                 command: |
                   sudo apt update
                   DEBIAN_FRONTEND=noninteractive sudo apt upgrade # needed for curl not to break
-                  curl micro.mamba.pm/install.sh | bash
+                  curl -L micro.mamba.pm/install.sh | bash
                   echo 'export MAMBA_EXE="$HOME/.local/bin/micromamba"' >> $BASH_ENV
                   echo 'export MAMBA_ROOT_PREFIX="$HOME/micromamba"' >> $BASH_ENV
                   echo '__mamba_setup="$($HOME/.local/bin/micromamba shell hook --shell bash --prefix ~/micromamba 2> /dev/null)"' >> $BASH_ENV


### PR DESCRIPTION
Summary: install fails because of a new redirect -- use `curl -L` everywhere as suggested

Test plan: CI

<!-- readthedocs-preview fl start -->
----
:books: Documentation preview :books:: https://fl--1148.org.readthedocs.build/en/1148/

<!-- readthedocs-preview fl end -->