### PR TITLE
Fix fl_dependent_option with value definition

### DIFF
--- a/cmake/InternalUtils.cmake
+++ b/cmake/InternalUtils.cmake
@@ -139,7 +139,7 @@ function(fl_dependent_option)
   set(_frce ${fl_dependent_option_FRCE})
 
   foreach(_dep IN ITEMS ${_deps})
-    if(NOT "${${_dep}}" AND "${_option}" AND "${${_option}}")
+    if(NOT "${${_dep}}" AND DEFINED ${_option} AND "${${_option}}")
       message(FATAL_ERROR "${_dep} Required to build ${_option}")
     endif()
   endforeach()


### PR DESCRIPTION
See title. New versions of CMake seem to have broke this behavior in some corner case.


Test plan:

Local test with improperly specified (i.e. incomplete) specification of required pkgs to build a particular app

> cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DFL_USE_ONEDNN=OFF -DFL_USE_ARRAYFIRE=ON -DFL_ARRAYFIRE_USE_CUDA=OFF -DFL_BUILD_APP_ASR=ON   -DArrayFire_DIR=/checkpoint/jacobkahn/usr/share/ArrayFire/cmake -DFL_ARRAYFIRE_USE_CPU=ON -DFL_BUILD_PKG_RUNTIME=ON -DFL_BUILD_PKG_SPEECH=ON