### PR TITLE
Convert directory fbcode/deeplearning to use the Ruff Formatter

### DIFF
--- a/flashlight/app/objdet/scripts/eval_coco.py
+++ b/flashlight/app/objdet/scripts/eval_coco.py
@@ -92,7 +92,6 @@ def main(directory, coco_data):
     files = glob.glob(glob_path)
     assert len(files) > 0
     for f in files:
-
         image_sizes = af.read_array(f, key="imageSizes").to_ndarray()
         image_sizes = np.transpose(image_sizes, (1, 0))
         image_ids = af.read_array(f, key="imageIds").to_ndarray()


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/FBGEMM/pull/3242

Converts the directory specified to use the Ruff formatter in pyfmt

ruff_dog

If this diff causes merge conflicts when rebasing, please run
`hg status -n -0 --change . -I '**/*.{py,pyi}' | xargs -0 arc pyfmt`
on your diff, and amend any changes before rebasing onto latest.
That should help reduce or eliminate any merge conflicts.

allow-large-files
bypass-github-export-checks

Differential Revision: D63766623


