### PR TITLE
Fix C++17 compilation errors

### DIFF
--- a/flashlight/fl/runtime/DeviceManager.cpp
+++ b/flashlight/fl/runtime/DeviceManager.cpp
@@ -58,7 +58,7 @@ DeviceManager& DeviceManager::getInstance() {
 }
 
 bool DeviceManager::isDeviceTypeAvailable(const DeviceType type) const {
-  return deviceTypeToInfo_.contains(type);
+  return deviceTypeToInfo_.find(type) != deviceTypeToInfo_.end();
 }
 
 unsigned DeviceManager::getDeviceCount(const DeviceType type) const {
@@ -89,7 +89,7 @@ std::vector<const Device*> DeviceManager::getDevicesOfType(
 Device& DeviceManager::getDevice(const DeviceType type, int id) const {
   enforceDeviceTypeAvailable("[DeviceManager::getActiveDevice]", type);
   auto& idToDevice = deviceTypeToInfo_.at(type);
-  if (!idToDevice.contains(id)) {
+  if (idToDevice.find(id) == idToDevice.end()) {
     throw std::runtime_error(
       "[DeviceManager::getDevice] unknown device id");
   }


### PR DESCRIPTION
**Original Issue**: https://github.com/flashlight/flashlight/issues/1183
The documentation's README.md requires:
> - A C++ compiler with good C++17 support (e.g. gcc/g++ >= 7)

But I'm getting C++20 compatibility errors:
```
...tmp/flashlight/flashlight/fl/runtime/DeviceManager.cpp: In member function ‘bool fl::DeviceManager::isDeviceTypeAvailable(fl::DeviceType) const’:
...tmp/flashlight/flashlight/fl/runtime/DeviceManager.cpp:61:28: error: ‘const class std::unordered_map<fl::DeviceType, std::unordered_map<int, const std::unique_ptr<fl::Device> > >’ has no member named ‘contains’
   61 |   return deviceTypeToInfo_.contains(type);
      |                            ^~~~~~~~
```

closes #1183

### Summary
Replace C++20 `contains()` with old-school iterator comparison to comply with C++17 std.

### Test Plan (required)
Compile with `g++-11 --std=c++17`. This pull request fixes the compilation process.


<!-- readthedocs-preview fl start -->
----
📚 Documentation preview 📚: https://fl--1184.org.readthedocs.build/en/1184/

<!-- readthedocs-preview fl end -->