### PR TITLE
1. Added plugin support for windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,11 @@ else()
       "Plugin functionality likely won't work.")
   endif()
 endif()
-set(FL_BUILD_PLUGIN ${COMPILER_SUPPORTS_RDYNAMIC})
+if (WIN32 OR MSVC)
+  set(FL_BUILD_PLUGIN ON)
+else()
+  set(FL_BUILD_PLUGIN ${COMPILER_SUPPORTS_RDYNAMIC})
+endif()
 
 # ]------ The library target for the Flashlight core
 add_library(flashlight)

--- a/cmake/FindNCCL.cmake
+++ b/cmake/FindNCCL.cmake
@@ -37,9 +37,11 @@ find_library(NCCL_LIBRARIES
   ${NCCL_LIB_DIR}
   ${NCCL_ROOT_DIR}
   ${NCCL_ROOT_DIR}/lib
+  ${NCCL_ROOT_DIR}/lib/x64
   ${NCCL_ROOT_DIR}/lib/x86_64-linux-gnu
   ${NCCL_ROOT_DIR}/lib64
   ${CUDA_TOOLKIT_ROOT_DIR}/lib
+  ${CUDA_TOOLKIT_ROOT_DIR}/lib/x64
   ${CUDA_TOOLKIT_ROOT_DIR}/lib64)
 
 include(FindPackageHandleStandardArgs)

--- a/flashlight/fl/common/CMakeLists.txt
+++ b/flashlight/fl/common/CMakeLists.txt
@@ -13,7 +13,9 @@ target_sources(
 )
 
 if (${FL_BUILD_PLUGIN})
-  target_sources(flashlight PRIVATE ${CMAKE_CURRENT_LIST_DIR}/Plugin.cpp)
+  target_sources(flashlight PRIVATE 
+    ${CMAKE_CURRENT_LIST_DIR}/Plugin.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/WinUtility.cpp)
 else()
   message(WARNING "Compiler doesn't support -rdynamic - not building Plugin")
 endif()

--- a/flashlight/fl/common/Plugin.cpp
+++ b/flashlight/fl/common/Plugin.cpp
@@ -7,26 +7,52 @@
 
 #include "flashlight/fl/common/Plugin.h"
 
-#include <dlfcn.h>
 #include <sstream>
 #include <stdexcept>
+
+#ifdef _WIN32
+  #include <windows.h>
+  #include "flashlight/fl/common/WinUtility.h"
+  #define PLUGIN_HANDLE HMODULE
+#else
+  #include <dlfcn.h>
+  #define PLUGIN_HANDLE void*
+#endif
 
 namespace fl {
 
 Plugin::Plugin(const std::string& name) : name_(name) {
+#ifdef _WIN32
+  auto wideName = detail::utf8ToWide(name);
+  handle_ = (void*)LoadLibraryW(wideName.c_str());
+  if (!handle_) {
+    auto err = detail::getWindowsErrorString();
+    throw std::runtime_error("unable to load library <" + name + ">: " + err);
+  }
+#else
   dlerror(); // clear errors
   handle_ = dlopen(name.c_str(), RTLD_LAZY);
   if (!handle_) {
-    std::string err = dlerror();
+    auto err = dlerror();
     throw std::runtime_error("unable to load library <" + name + ">: " + err);
   }
+#endif
 }
 
 void* Plugin::getRawSymbol(const std::string& symbol) {
+#ifdef _WIN32
+  auto addr = (void*)GetProcAddress((HMODULE)handle_, symbol.c_str());
+#else
   dlerror(); // clear errors
   auto addr = dlsym(handle_, symbol.c_str());
+#endif
+
   if (!addr) {
-    std::string err = dlerror();
+#ifdef _WIN32
+    auto err = detail::getWindowsErrorString();
+#else
+    auto err = dlerror();
+#endif
     std::stringstream msg;
     msg << "unable to resolve symbol <" << symbol << ">";
     msg << " in library <" << name_ << ">";
@@ -38,7 +64,11 @@ void* Plugin::getRawSymbol(const std::string& symbol) {
 
 Plugin::~Plugin() {
   if (handle_) {
+#ifdef _WIN32
+    FreeLibrary((HMODULE)handle_);
+#else
     dlclose(handle_);
+#endif
   }
 }
 

--- a/flashlight/fl/common/WinUtility.cpp
+++ b/flashlight/fl/common/WinUtility.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "flashlight/fl/common/WinUtility.h"
+
+#ifdef _WIN32
+
+#include <windows.h>
+#include <stdexcept>
+
+namespace fl {
+namespace detail {
+
+std::wstring utf8ToWide(const std::string& utf8) {
+  if (utf8.empty()) {
+    return std::wstring();
+  }
+
+  int wideSize = MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), -1, nullptr, 0);
+  if (wideSize == 0) {
+    throw std::runtime_error("Failed to convert UTF-8 to wide string");
+  }
+
+  std::wstring wide(wideSize - 1, 0);
+  MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), -1, &wide[0], wideSize);
+  return wide;
+}
+
+std::string getWindowsErrorString() {
+  DWORD error = GetLastError();
+  if (error == 0) {
+    return "No error";
+  }
+
+  LPWSTR messageBuffer = nullptr;
+  FormatMessageW(
+      FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
+          FORMAT_MESSAGE_IGNORE_INSERTS,
+      nullptr,
+      error,
+      MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+      (LPWSTR)&messageBuffer,
+      0,
+      nullptr);
+
+  std::string result;
+  if (messageBuffer) {
+    int utf8Size = WideCharToMultiByte(CP_UTF8, 0, messageBuffer, -1, nullptr,
+                                       0, nullptr, nullptr);
+    if (utf8Size > 0) {
+      result.resize(utf8Size - 1);
+      WideCharToMultiByte(CP_UTF8, 0, messageBuffer, -1, &result[0], utf8Size,
+                          nullptr, nullptr);
+    }
+    LocalFree(messageBuffer);
+  } else {
+    result = "Unknown error";
+  }
+  return result;
+}
+
+} // namespace detail
+} // namespace fl
+
+#endif // _WIN32

--- a/flashlight/fl/common/WinUtility.h
+++ b/flashlight/fl/common/WinUtility.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+
+#ifdef _WIN32
+
+namespace fl {
+namespace detail {
+
+/**
+ * Convert a UTF-8 string to a UTF-16LE wide string for Windows APIs
+ * @param[in] utf8 UTF-8 encoded string
+ * @return Wide string (UTF-16LE)
+ * @throws std::runtime_error if conversion fails
+ */
+std::wstring utf8ToWide(const std::string& utf8);
+
+/**
+ * Get a human-readable error message from the last Windows error code
+ * @return Error message as UTF-8 string
+ */
+std::string getWindowsErrorString();
+
+} // namespace detail
+} // namespace fl
+
+#endif // _WIN32


### PR DESCRIPTION
Added Windows Plugin support, also prepared for upcoming NCCL windows support which is [targeted for 2026 Q1](https://github.com/NVIDIA/nccl/issues/1995)

I bumped the c++ version to c++ 20 to solve `closes #[1183]` and `closes #[1187]`

also solves part of:
- #803 
- #1175 
- #629 

### Summary
[Explain the details for this change and the problem that the pull request solves]

### Test Plan (required)
compile with:
- arrayfire cuda (as only backend)
- without NCCL


<!-- readthedocs-preview fl start -->
----
📚 Documentation preview 📚: https://fl--1188.org.readthedocs.build/en/1188/

<!-- readthedocs-preview fl end -->